### PR TITLE
fix: use correct Claude Code hook JSON schema for PreToolUse

### DIFF
--- a/src/hooks.rs
+++ b/src/hooks.rs
@@ -12,7 +12,10 @@
 /// Claude to use tokensave MCP tools instead.
 pub fn hook_pre_tool_use() {
     let tool_input = std::env::var("TOOL_INPUT").unwrap_or_default();
-    println!("{}", evaluate_hook_decision(&tool_input));
+    let decision = evaluate_hook_decision(&tool_input);
+    if !decision.is_empty() {
+        println!("{}", decision);
+    }
 }
 
 /// Pure decision logic for the PreToolUse hook.
@@ -21,13 +24,16 @@ pub fn hook_pre_tool_use() {
 /// string to print to stdout.
 pub fn evaluate_hook_decision(tool_input: &str) -> String {
     let block_msg = serde_json::json!({
-        "decision": "block",
-        "reason": "STOP: Use tokensave MCP tools (tokensave_context, tokensave_search, \
-                   tokensave_callees, tokensave_callers, tokensave_impact, tokensave_files, \
-                   tokensave_affected) instead of agents for code research. Tokensave is \
-                   faster and more precise for symbol relationships, call paths, and code \
-                   structure. Only use agents for code exploration if you have already tried \
-                   tokensave and it cannot answer the question."
+        "hookSpecificOutput": {
+            "hookEventName": "PreToolUse",
+            "permissionDecision": "deny",
+            "permissionDecisionReason": "STOP: Use tokensave MCP tools (tokensave_context, tokensave_search, \
+                       tokensave_callees, tokensave_callers, tokensave_impact, tokensave_files, \
+                       tokensave_affected) instead of agents for code research. Tokensave is \
+                       faster and more precise for symbol relationships, call paths, and code \
+                       structure. Only use agents for code exploration if you have already tried \
+                       tokensave and it cannot answer the question."
+        }
     });
 
     let parsed: serde_json::Value =
@@ -52,7 +58,8 @@ pub fn evaluate_hook_decision(tool_input: &str) -> String {
         }
     }
 
-    r#"{"decision": "allow"}"#.to_string()
+    // Empty string = no output → Claude Code implicitly allows the tool call
+    String::new()
 }
 
 /// `UserPromptSubmit` hook handler: resets the per-session local counter.

--- a/tests/hooks_test.rs
+++ b/tests/hooks_test.rs
@@ -1,124 +1,142 @@
 use tokensave::hooks::evaluate_hook_decision;
 
-fn parse_decision(json: &str) -> String {
+fn is_blocked(json: &str) -> bool {
     let v: serde_json::Value = serde_json::from_str(json).unwrap();
-    v["decision"].as_str().unwrap().to_string()
+    v["hookSpecificOutput"]["permissionDecision"].as_str() == Some("deny")
+}
+
+fn get_block_reason(json: &str) -> String {
+    let v: serde_json::Value = serde_json::from_str(json).unwrap();
+    v["hookSpecificOutput"]["permissionDecisionReason"]
+        .as_str()
+        .unwrap_or("")
+        .to_string()
 }
 
 #[test]
 fn test_blocks_explore_agent() {
     let input = r#"{"subagent_type": "Explore", "prompt": "find files"}"#;
     let result = evaluate_hook_decision(input);
-    assert_eq!(parse_decision(&result), "block");
+    assert!(is_blocked(&result));
 }
 
 #[test]
 fn test_allows_non_explore_agent() {
     let input = r#"{"subagent_type": "general-purpose", "prompt": "write a function"}"#;
     let result = evaluate_hook_decision(input);
-    assert_eq!(parse_decision(&result), "allow");
+    assert!(result.is_empty(), "allow should produce no output");
 }
 
 #[test]
 fn test_blocks_exploration_prompt_explore() {
     let input = r#"{"prompt": "Explore the codebase and find all API endpoints"}"#;
     let result = evaluate_hook_decision(input);
-    assert_eq!(parse_decision(&result), "block");
+    assert!(is_blocked(&result));
 }
 
 #[test]
 fn test_blocks_codebase_structure_prompt() {
     let input = r#"{"prompt": "Understand the codebase structure"}"#;
     let result = evaluate_hook_decision(input);
-    assert_eq!(parse_decision(&result), "block");
+    assert!(is_blocked(&result));
 }
 
 #[test]
 fn test_blocks_call_graph_prompt() {
     let input = r#"{"prompt": "Show me the call graph for this function"}"#;
     let result = evaluate_hook_decision(input);
-    assert_eq!(parse_decision(&result), "block");
+    assert!(is_blocked(&result));
 }
 
 #[test]
 fn test_blocks_who_calls_prompt() {
     let input = r#"{"prompt": "who calls the process_data function?"}"#;
     let result = evaluate_hook_decision(input);
-    assert_eq!(parse_decision(&result), "block");
+    assert!(is_blocked(&result));
 }
 
 #[test]
 fn test_blocks_callers_of_prompt() {
     let input = r#"{"prompt": "find callers of handle_request"}"#;
     let result = evaluate_hook_decision(input);
-    assert_eq!(parse_decision(&result), "block");
+    assert!(is_blocked(&result));
 }
 
 #[test]
 fn test_blocks_callees_of_prompt() {
     let input = r#"{"prompt": "what are the callees of main?"}"#;
     let result = evaluate_hook_decision(input);
-    assert_eq!(parse_decision(&result), "block");
+    assert!(is_blocked(&result));
 }
 
 #[test]
 fn test_blocks_symbol_lookup_prompt() {
     let input = r#"{"prompt": "do a symbol lookup for TokenSave"}"#;
     let result = evaluate_hook_decision(input);
-    assert_eq!(parse_decision(&result), "block");
+    assert!(is_blocked(&result));
 }
 
 #[test]
 fn test_blocks_read_every_prompt() {
     let input = r#"{"prompt": "read every file in src/"}"#;
     let result = evaluate_hook_decision(input);
-    assert_eq!(parse_decision(&result), "block");
+    assert!(is_blocked(&result));
 }
 
 #[test]
 fn test_blocks_entire_codebase_prompt() {
     let input = r#"{"prompt": "scan the entire codebase for patterns"}"#;
     let result = evaluate_hook_decision(input);
-    assert_eq!(parse_decision(&result), "block");
+    assert!(is_blocked(&result));
 }
 
 #[test]
 fn test_allows_normal_prompt() {
     let input = r#"{"prompt": "write a unit test for the parse function"}"#;
     let result = evaluate_hook_decision(input);
-    assert_eq!(parse_decision(&result), "allow");
+    assert!(result.is_empty(), "allow should produce no output");
 }
 
 #[test]
 fn test_allows_empty_input() {
     let result = evaluate_hook_decision("");
-    assert_eq!(parse_decision(&result), "allow");
+    assert!(result.is_empty(), "allow should produce no output");
 }
 
 #[test]
 fn test_allows_invalid_json() {
     let result = evaluate_hook_decision("not json at all");
-    assert_eq!(parse_decision(&result), "allow");
+    assert!(result.is_empty(), "allow should produce no output");
 }
 
 #[test]
 fn test_allows_no_prompt_no_subagent() {
     let input = r#"{"foo": "bar"}"#;
     let result = evaluate_hook_decision(input);
-    assert_eq!(parse_decision(&result), "allow");
+    assert!(result.is_empty(), "allow should produce no output");
 }
 
 #[test]
 fn test_case_insensitive_blocking() {
     let input = r#"{"prompt": "EXPLORE the Codebase Architecture"}"#;
     let result = evaluate_hook_decision(input);
-    assert_eq!(parse_decision(&result), "block");
+    assert!(is_blocked(&result));
 }
 
 #[test]
 fn test_block_response_has_reason() {
     let input = r#"{"subagent_type": "Explore"}"#;
     let result = evaluate_hook_decision(input);
+    let reason = get_block_reason(&result);
+    assert!(reason.contains("tokensave MCP tools"));
+}
+
+#[test]
+fn test_block_response_uses_correct_hook_schema() {
+    let input = r#"{"subagent_type": "Explore"}"#;
+    let result = evaluate_hook_decision(input);
     let v: serde_json::Value = serde_json::from_str(&result).unwrap();
-    assert!(v["reason"].as_str().unwrap().contains("tokensave MCP tools"));
+    assert_eq!(v["hookSpecificOutput"]["hookEventName"].as_str(), Some("PreToolUse"));
+    assert_eq!(v["hookSpecificOutput"]["permissionDecision"].as_str(), Some("deny"));
+    assert!(v["hookSpecificOutput"]["permissionDecisionReason"].as_str().is_some());
 }


### PR DESCRIPTION
## Problem

The `PreToolUse` hook in `src/hooks.rs` emits JSON that does not conform to Claude Code's hook output schema.

**Current output (wrong):**
```json
// allow
{"decision": "allow"}

// block
{"decision": "block", "reason": "..."}
```

**Claude Code expected schema:**
```json
// block
{
  "hookSpecificOutput": {
    "hookEventName": "PreToolUse",
    "permissionDecision": "deny",
    "permissionDecisionReason": "..."
  }
}

// allow → no output (exit 0 with empty stdout)
```

This causes a validation warning on **every** `Agent` tool call:

```
PreToolUse:Agent hook error
Hook JSON output validation failed — (root): Invalid input
```

The warning is non-fatal (the tool call proceeds), but it's noisy and confusing. The block path (`{"decision": "block"}`) also fails silently — Claude Code doesn't recognize the deny decision, so Explore agents are not actually blocked by the hook.

## Root cause

The hook was written against an undocumented/assumed schema. The actual Claude Code hook output schema requires responses to be wrapped in a `hookSpecificOutput` envelope with `hookEventName`, `permissionDecision`, and `permissionDecisionReason` fields. For allow decisions, the simplest approach is no output at all (exit 0).

Reference: Claude Code hooks documentation — PreToolUse hook output schema.

## Fix

- **Block**: emit `{"hookSpecificOutput": {"hookEventName": "PreToolUse", "permissionDecision": "deny", "permissionDecisionReason": "..."}}`
- **Allow**: emit nothing (empty stdout, exit 0) — Claude Code implicitly allows
- **`hook_pre_tool_use()`**: skip `println!` when the decision string is empty
- **Tests**: all 18 tests updated to match new schema + 1 new test verifying the block response structure

## Testing

```
cargo test --test hooks_test
# 18 passed (1 suite)
```