### PR TITLE
Fix: prevent nested tokio runtime panic on Windows daemon

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,11 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Fixed
+- **Windows daemon nested runtime panic** — `tokensave daemon` panicked on Windows because `daemon-kit` runs the closure inline (no fork), creating a nested tokio runtime. Now uses `block_in_place` + `Handle::current()` on Windows while keeping `Runtime::new()` on Unix where the forked child genuinely has no runtime.
+
 ## [4.0.2] - 2026-04-14
 
 ### Added

--- a/src/daemon.rs
+++ b/src/daemon.rs
@@ -461,10 +461,7 @@ pub async fn run(foreground: bool) -> Result<bool> {
         // the upgrade exit code internally via std::process::exit.
         daemon
             .start(false, move || {
-                let rt = tokio::runtime::Runtime::new().map_err(|e| {
-                    daemon_kit::DaemonError::Daemonize(format!("failed to create runtime: {e}"))
-                })?;
-                rt.block_on(async {
+                let future = async {
                     match run_loop(debounce).await {
                         Ok(true) => {
                             // Upgrade detected — exit non-zero for service manager restart.
@@ -473,7 +470,23 @@ pub async fn run(foreground: bool) -> Result<bool> {
                         Ok(false) => Ok(()),
                         Err(e) => Err(daemon_kit::DaemonError::Daemonize(e.to_string())),
                     }
-                })
+                };
+                // On Unix, daemon-kit forks — the child has no tokio runtime,
+                // so we must create one. On Windows, the closure runs inline in
+                // the existing #[tokio::main] runtime, so we use block_in_place.
+                #[cfg(windows)]
+                {
+                    tokio::task::block_in_place(|| {
+                        tokio::runtime::Handle::current().block_on(future)
+                    })
+                }
+                #[cfg(not(windows))]
+                {
+                    let rt = tokio::runtime::Runtime::new().map_err(|e| {
+                        daemon_kit::DaemonError::Daemonize(format!("failed to create runtime: {e}"))
+                    })?;
+                    rt.block_on(future)
+                }
             })
             .map_err(|e| TokenSaveError::Config {
                 message: format!("daemon error: {e}"),


### PR DESCRIPTION
## Summary

- tokensave daemon panicked on Windows because daemon-kit runs the closure inline (no fork), so Runtime::new().block_on() nested inside the existing #[tokio::main] runtime
- Use tokio::task::block_in_place + Handle::current().block_on() on Windows; keep Runtime::new() on Unix where the forked child genuinely has no runtime

-

## Test plan

- [x] `cargo build --no-default-features --features lite` compiles on Windows                                                                                                                                                                                                                                 
- [x] `tokensave daemon` starts without panic on Windows (previously panicked with nested runtime error)
- [ ] `cargo test` — blocked by pre-existing linker issue on this machine (stale `tokensave-large-treesitters` rlib with unresolved `tree_sitter_dockerfile`), unrelated to this change
- [ ] Verify `tokensave daemon` still works on Unix/macOS (CI or maintainer)

## Checklist

- [x] `CHANGELOG.md` updated (under `[Unreleased]` if no version bump)
- [x] No secrets, credentials, or `.env` files included
- [x] Breaking changes documented (if any)

Closes #22