### PR TITLE
Fix/symbolic ref default branch

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+- **Default branch detection wrote `"HEAD"` instead of actual branch name** — `detect_default_branch()` used `reference.name()` on the `refs/remotes/origin/HEAD` symbolic ref, which returns the ref's own name. Now resolves through `reference.follow()` to get the target (e.g. `refs/remotes/origin/master`), then strips the prefix correctly.
+
 ## [4.0.3] - 2026-04-16
 
 ### Fixed

--- a/src/branch.rs
+++ b/src/branch.rs
@@ -23,10 +23,12 @@ pub fn current_branch(project_root: &Path) -> Option<String> {
 pub fn detect_default_branch(project_root: &Path) -> Option<String> {
     let repo = gix::open(project_root).ok()?;
 
-    // Try symbolic-ref first
+    // Try symbolic-ref first (refs/remotes/origin/HEAD -> refs/remotes/origin/<branch>)
     if let Ok(reference) = repo.find_reference("refs/remotes/origin/HEAD") {
-        if let Some(name) = reference.name().as_bstr().to_string().strip_prefix("refs/remotes/origin/") {
-            return Some(name.to_string());
+        if let Some(Ok(target)) = reference.follow() {
+            if let Some(name) = target.name().as_bstr().to_string().strip_prefix("refs/remotes/origin/") {
+                return Some(name.to_string());
+            }
         }
     }
 


### PR DESCRIPTION
## Summary

- Fix `detect_default_branch()` resolving `refs/remotes/origin/HEAD` symbolic ref to the literal string `"HEAD"` instead of the actual branch name (e.g. `"master"`).

## Motivation

When `refs/remotes/origin/HEAD` exists as a symbolic reference, `reference.name()` returns the ref's own name. Stripping the `refs/remotes/origin/` prefix yields `"HEAD"`, which gets written as `default_branch` in `.tokensave/branch-meta.json`. This corrupts all branch operations (add, remove, gc, MCP tools) that rely on `meta.default_branch`.

Closes #(issue_number)

## Changes

- `src/branch.rs`: use `reference.follow()` to resolve the symbolic ref target before extracting the branch name, instead of using `reference.name()` directly.

## Test plan

- [x] `cargo check --no-default-features --features lite` compiles
- [ ] Verify `branch-meta.json` writes correct default branch name (e.g. `"master"`) after `tokensave sync` in a repo with `refs/remotes/origin/HEAD`
- [ ] Verify fallback to heuristic (`main`/`master`) still works when no `origin/HEAD` ref exists

## Checklist

- [x] `CHANGELOG.md` updated (under `[Unreleased]` if no version bump)
- [x] No secrets, credentials, or `.env` files included
- [x] Breaking changes documented (if any)


Closes #25