### PR TITLE
fix: resolve current branch in git worktrees via gix + symbolic-ref fallback

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+- **Branch detection in git worktrees** — `current_branch()` read `.git/HEAD` directly as a plain file, which fails in git worktrees where `.git` is a pointer file (not a directory). This caused the MCP server to always fall back to the default branch database, returning stale or wrong results in worktree environments. Fixed with a two-tier approach: first try `gix::open()` which handles worktrees natively, then fall back to `git symbolic-ref -q HEAD` via subprocess. The subprocess fallback is needed because tokensave's minimal `gix` feature set (`revision`, `blob-diff`, `sha1`) excludes worktree support, so `gix` itself cannot resolve HEAD in worktrees.
+
 ## [4.0.3] - 2026-04-16
 
 ### Fixed

--- a/src/branch.rs
+++ b/src/branch.rs
@@ -4,17 +4,40 @@ use std::path::Path;
 
 use crate::branch_meta::BranchMeta;
 
-/// Resolves the current branch name using `gix`, which correctly handles
-/// git worktrees (where `.git` is a file, not a directory).
+/// Resolves the current branch name using `gix`. Falls back to
+/// `git symbolic-ref HEAD` for worktrees when gix cannot resolve HEAD
+/// (e.g. with minimal feature flags that exclude worktree support).
 ///
 /// Returns `None` for detached HEAD or if the repository cannot be opened.
 pub fn current_branch(project_root: &Path) -> Option<String> {
+    if let Some(branch) = current_branch_gix(project_root) {
+        return Some(branch);
+    }
+    current_branch_git(project_root)
+}
+
+fn current_branch_gix(project_root: &Path) -> Option<String> {
     let repo = gix::open(project_root).ok()?;
     let head = repo.head().ok()?;
     let name = head.name().as_bstr();
     let name_str = std::str::from_utf8(name).ok()?;
     name_str
         .strip_prefix("refs/heads/")
+        .map(|s| s.to_string())
+}
+
+fn current_branch_git(project_root: &Path) -> Option<String> {
+    let output = std::process::Command::new("git")
+        .args(["symbolic-ref", "-q", "HEAD"])
+        .current_dir(project_root)
+        .output()
+        .ok()?;
+    if !output.status.success() {
+        return None;
+    }
+    let name = std::str::from_utf8(&output.stdout).ok()?;
+    name.strip_prefix("refs/heads/")
+        .and_then(|s| s.strip_suffix('\n'))
         .map(|s| s.to_string())
 }
 

--- a/src/branch.rs
+++ b/src/branch.rs
@@ -4,15 +4,18 @@ use std::path::Path;
 
 use crate::branch_meta::BranchMeta;
 
-/// Reads `.git/HEAD` and resolves the current branch name.
+/// Resolves the current branch name using `gix`, which correctly handles
+/// git worktrees (where `.git` is a file, not a directory).
 ///
-/// Returns `None` for detached HEAD or if `.git/HEAD` cannot be read.
+/// Returns `None` for detached HEAD or if the repository cannot be opened.
 pub fn current_branch(project_root: &Path) -> Option<String> {
-    let head_path = project_root.join(".git/HEAD");
-    let content = std::fs::read_to_string(head_path).ok()?;
-    let trimmed = content.trim();
-    let branch = trimmed.strip_prefix("ref: refs/heads/")?;
-    Some(branch.to_string())
+    let repo = gix::open(project_root).ok()?;
+    let head = repo.head().ok()?;
+    let name = head.name().as_bstr();
+    let name_str = std::str::from_utf8(name).ok()?;
+    name_str
+        .strip_prefix("refs/heads/")
+        .map(|s| s.to_string())
 }
 
 /// Auto-detects the default branch (main or master).

--- a/src/config.rs
+++ b/src/config.rs
@@ -62,8 +62,28 @@ impl Default for TokenSaveConfig {
     }
 }
 
-/// Returns the path to the `.tokensave` directory within the given project root.
+/// Returns the path to the `.tokensave` directory.
+///
+/// When running inside a git worktree, resolves to the **main repo's**
+/// `.tokensave` directory so that all worktrees share the same database,
+/// branch metadata, and configuration.
 pub fn get_tokensave_dir(project_root: &Path) -> PathBuf {
+    let git_marker = project_root.join(".git");
+    if git_marker.is_file() {
+        // Worktree: .git is a file containing "gitdir: <path>"
+        if let Ok(content) = fs::read_to_string(&git_marker) {
+            for line in content.lines() {
+                if let Some(gitdir) = line.strip_prefix("gitdir: ") {
+                    // gitdir = "/path/main/.git/worktrees/<name>"
+                    // Walk up 2 levels → "/path/main/.git" → parent → repo root
+                    let path = PathBuf::from(gitdir.trim());
+                    if let Some(repo_root) = path.parent().and_then(|p| p.parent()).and_then(|p| p.parent()) {
+                        return repo_root.join(TOKENSAVE_DIR);
+                    }
+                }
+            }
+        }
+    }
     project_root.join(TOKENSAVE_DIR)
 }
 

--- a/src/config.rs
+++ b/src/config.rs
@@ -62,28 +62,8 @@ impl Default for TokenSaveConfig {
     }
 }
 
-/// Returns the path to the `.tokensave` directory.
-///
-/// When running inside a git worktree, resolves to the **main repo's**
-/// `.tokensave` directory so that all worktrees share the same database,
-/// branch metadata, and configuration.
+/// Returns the path to the `.tokensave` directory within the given project root.
 pub fn get_tokensave_dir(project_root: &Path) -> PathBuf {
-    let git_marker = project_root.join(".git");
-    if git_marker.is_file() {
-        // Worktree: .git is a file containing "gitdir: <path>"
-        if let Ok(content) = fs::read_to_string(&git_marker) {
-            for line in content.lines() {
-                if let Some(gitdir) = line.strip_prefix("gitdir: ") {
-                    // gitdir = "/path/main/.git/worktrees/<name>"
-                    // Walk up 2 levels → "/path/main/.git" → parent → repo root
-                    let path = PathBuf::from(gitdir.trim());
-                    if let Some(repo_root) = path.parent().and_then(|p| p.parent()).and_then(|p| p.parent()) {
-                        return repo_root.join(TOKENSAVE_DIR);
-                    }
-                }
-            }
-        }
-    }
     project_root.join(TOKENSAVE_DIR)
 }
 


### PR DESCRIPTION
## Summary

  - `current_branch()` now uses `gix::open()` first (handles worktrees natively), with subprocess
   fallback to `git symbolic-ref -q HEAD`
  - Fixes branch detection when working inside `git worktree add` checkouts


## Motivation

  In git worktrees, `.git` is a pointer file, not a directory. The previous implementation read
  `.git/HEAD` directly as a plain file, which fails. This caused the MCP server to treat every
  worktree as a detached HEAD, always falling back to the default branch database and eventually
  crashing, requiring a manual restart.

  The `gix` crate with tokensave's minimal feature set (`revision`, `blob-diff`, `sha1`) cannot
  resolve HEAD in worktrees either. The subprocess fallback bridges this gap.

  Complements #24 — both fixes touch different functions in `branch.rs` and should be merged
  together for complete worktree support.

## Changes

  - `src/branch.rs`: replaced file-read `current_branch()` with two-tier `current_branch_gix()` +
   `current_branch_git()`
  - `CHANGELOG.md`: added fix description under `[Unreleased]`
  - Merged `origin/master` (includes v4.0.3 release)

## Test plan

- [x] cargo check --no-default-features --features lite compiles
- [x] `cargo clippy` has no new warnings
- [x] Tested manually (describe below if applicable)


## Checklist

- [x] `CHANGELOG.md` updated (under `[Unreleased]` if no version bump)
- [x] No secrets, credentials, or `.env` files included
- [x] Breaking changes documented (if any)

Closes #27 
