### PR TITLE
fix: prevent nested tokio runtime panic on Windows monitor

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+- **Windows monitor nested runtime panic** — `tokensave monitor` cost cache refresh panicked on Windows because `refresh_cost_cache` created a new tokio runtime inside the existing `#[tokio::main]` runtime. Now uses `block_in_place` + `Handle::current()` on Windows while keeping a single-threaded runtime on Unix, matching the daemon.rs pattern from #23.
+
 ## [4.0.3] - 2026-04-16
 
 ### Fixed

--- a/src/monitor.rs
+++ b/src/monitor.rs
@@ -373,15 +373,7 @@ impl CostCache {
 /// Refresh cost data from the global DB. Best-effort, non-blocking.
 /// Uses a tokio runtime because GlobalDb is async.
 fn refresh_cost_cache(cache: &mut CostCache) {
-    // Build a single-threaded runtime for the async DB call.
-    // This runs ~2 fast SQL queries, well under 10ms.
-    let Ok(rt) = tokio::runtime::Builder::new_current_thread()
-        .enable_all()
-        .build()
-    else {
-        return;
-    };
-    rt.block_on(async {
+    let future = async {
         let Some(gdb) = crate::global_db::GlobalDb::open().await else {
             return;
         };
@@ -413,7 +405,27 @@ fn refresh_cost_cache(cache: &mut CostCache) {
             cache.top_model = model.clone();
             cache.top_model_cost = *cost;
         }
-    });
+    };
+    // On Windows the monitor TUI runs inside #[tokio::main], so creating
+    // a new runtime would panic. Use block_in_place + existing handle.
+    #[cfg(windows)]
+    {
+        tokio::task::block_in_place(|| {
+            tokio::runtime::Handle::current().block_on(future)
+        })
+    }
+    // On Unix the function may be called outside any tokio runtime,
+    // so create a single-threaded one.
+    #[cfg(not(windows))]
+    {
+        let Ok(rt) = tokio::runtime::Builder::new_current_thread()
+            .enable_all()
+            .build()
+        else {
+            return;
+        };
+        rt.block_on(future)
+    }
     cache.last_refresh = std::time::Instant::now();
 }
 


### PR DESCRIPTION
refresh_cost_cache created a new tokio runtime inside #[tokio::main], panicking on Windows. Uses block_in_place + Handle::current() on Windows, single-threaded runtime on Unix — same pattern as daemon.rs (#23).

## Summary

   - Same root cause as #22: `tokensave monitor` panicked on Windows because
   `refresh_cost_cache` called `Runtime::new_current_thread().block_on()` inside the existing
   `#[tokio::main]` runtime (the `Commands::Monitor` match arm in `main.rs` runs within the
   async main)
   - Use `tokio::task::block_in_place` + `Handle::current().block_on()` on Windows; keep
   `Builder::new_current_thread()` on Unix — same pattern applied to `daemon.rs` in #23

## Motivation

tokensave monitor panic.

## Changes

  - src/monitor.rs: refresh_cost_cache now uses #[cfg(windows)] / #[cfg(not(windows))] dispatch —
   block_in_place + Handle::current() on Windows, single-threaded runtime on Unix

## Test plan

   - [x] `cargo build --no-default-features --features lite` compiles on Windows
   - [x] `tokensave monitor` starts without panic on Windows (previously panicked with nested
   runtime error on cost cache refresh)
   - [ ] `cargo test` — blocked by pre-existing linker issue on this machine (stale
   `tokensave-large-treesitters` rlib with unresolved `tree_sitter_dockerfile`), unrelated to
   this change
   - [ ] Verify `tokensave monitor` still works on Unix/macOS (CI or maintainer)

## Checklist

   - [x] `CHANGELOG.md` updated (under `[Unreleased]` if no version bump)
   - [x] No secrets, credentials, or `.env` files included
   - [x] Breaking changes documented (if any)