### PR TITLE
Fix upgrade flow messaging for Homebrew installs

### DIFF
--- a/src/cloud.rs
+++ b/src/cloud.rs
@@ -232,9 +232,10 @@ pub fn detect_install_method() -> InstallMethod {
 }
 
 /// Returns the upgrade command string.
-///
-/// Always suggests `tokensave upgrade` which handles all install methods
-/// and channels automatically.
-pub fn upgrade_command(_method: &InstallMethod) -> &'static str {
-    "tokensave upgrade"
+pub fn upgrade_command(method: &InstallMethod) -> &'static str {
+    match method {
+        InstallMethod::Cargo | InstallMethod::Unknown => "tokensave upgrade",
+        InstallMethod::Brew => "brew upgrade tokensave",
+        InstallMethod::Scoop => "scoop update tokensave",
+    }
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -562,9 +562,11 @@ async fn run(cli: Cli) -> tokensave::errors::Result<()> {
                 if tokensave::cloud::is_newer_version(current_version, &latest)
                     && now - config.last_version_warning_at >= 900
                 {
+                    let upgrade_cmd =
+                        tokensave::cloud::upgrade_command(&tokensave::cloud::detect_install_method());
                     eprintln!(
-                        "\n\x1b[33mUpdate available: v{} → v{}\x1b[0m\n  Run: \x1b[1mtokensave upgrade\x1b[0m",
-                        current_version, latest
+                        "\n\x1b[33mUpdate available: v{} → v{}\x1b[0m\n  Run: \x1b[1m{}\x1b[0m",
+                        current_version, latest, upgrade_cmd
                     );
                     config.last_version_warning_at = now;
                     config.save();
@@ -1803,10 +1805,13 @@ fn check_for_update(
         tokensave::cloud::is_newer_minor_version(current_version, &latest)
     };
 
-    if dominated && (skip_suppression || now - config.last_version_warning_at >= 900) {
+    if dominated && (skip_suppression || now - config.last_version_warning_at >= 900)
+    {
+        let upgrade_cmd =
+            tokensave::cloud::upgrade_command(&tokensave::cloud::detect_install_method());
         eprintln!(
-            "\n\x1b[33mUpdate available: v{} → v{}\x1b[0m\n  Run: \x1b[1mtokensave upgrade\x1b[0m",
-            current_version, latest
+            "\n\x1b[33mUpdate available: v{} → v{}\x1b[0m\n  Run: \x1b[1m{}\x1b[0m",
+            current_version, latest, upgrade_cmd
         );
         if !skip_suppression {
             config.last_version_warning_at = now;

--- a/src/mcp/server.rs
+++ b/src/mcp/server.rs
@@ -190,9 +190,11 @@ impl McpServer {
                 if checked_at.elapsed() < VERSION_CHECK_INTERVAL {
                     let latest = cache.latest.as_deref()?;
                     return if crate::cloud::is_newer_minor_version(current, latest) {
+                        let upgrade_cmd =
+                            crate::cloud::upgrade_command(&crate::cloud::detect_install_method());
                         Some(format!(
                             "⚠️ tokensave v{current} is installed, but v{latest} is available. \
-                             Run `tokensave upgrade` to update."
+                             Run `{upgrade_cmd}` to update."
                         ))
                     } else {
                         None
@@ -215,9 +217,11 @@ impl McpServer {
 
         let latest = latest?;
         if crate::cloud::is_newer_minor_version(current, &latest) {
+            let upgrade_cmd =
+                crate::cloud::upgrade_command(&crate::cloud::detect_install_method());
             Some(format!(
                 "⚠️ tokensave v{current} is installed, but v{latest} is available. \
-                 Run `tokensave upgrade` to update."
+                 Run `{upgrade_cmd}` to update."
             ))
         } else {
             None

--- a/src/upgrade.rs
+++ b/src/upgrade.rs
@@ -296,8 +296,23 @@ pub fn run_upgrade() -> Result<String> {
     let current = env!("CARGO_PKG_VERSION");
     let is_beta = cloud::is_beta();
     let channel = if is_beta { "beta" } else { "stable" };
+    let install_method = cloud::detect_install_method();
 
     eprintln!("Current version: v{current} ({channel} channel)");
+
+    match install_method {
+        cloud::InstallMethod::Brew | cloud::InstallMethod::Scoop => {
+            let upgrade_cmd = cloud::upgrade_command(&install_method);
+            return Err(TokenSaveError::Config {
+                message: format!(
+                    "self-update is not supported for this installation method.\n  \
+                     Upgrade with: {upgrade_cmd}"
+                ),
+            });
+        }
+        cloud::InstallMethod::Cargo | cloud::InstallMethod::Unknown => {}
+    }
+
     eprintln!("Checking for updates...");
 
     let latest = cloud::fetch_latest_version().ok_or_else(|| TokenSaveError::Config {
@@ -373,7 +388,8 @@ pub fn switch_channel(target_channel: &str) -> Result<String> {
 
     if target_is_beta == current_is_beta {
         eprintln!("Already on the {current_channel} channel (v{current}).");
-        eprintln!("Run `tokensave upgrade` to check for updates within this channel.");
+        let upgrade_cmd = cloud::upgrade_command(&cloud::detect_install_method());
+        eprintln!("Run `{upgrade_cmd}` to check for updates within this channel.");
         return Ok(current.to_string());
     }
 

--- a/tests/cloud_test.rs
+++ b/tests/cloud_test.rs
@@ -156,16 +156,12 @@ fn is_beta_returns_bool() {
 }
 
 #[test]
-fn upgrade_command_always_suggests_tokensave_upgrade() {
+fn upgrade_command_matches_install_method() {
     use tokensave::cloud::{upgrade_command, InstallMethod};
-    for method in &[
-        InstallMethod::Cargo,
-        InstallMethod::Brew,
-        InstallMethod::Scoop,
-        InstallMethod::Unknown,
-    ] {
-        assert_eq!(upgrade_command(method), "tokensave upgrade");
-    }
+    assert_eq!(upgrade_command(&InstallMethod::Cargo), "tokensave upgrade");
+    assert_eq!(upgrade_command(&InstallMethod::Brew), "brew upgrade tokensave");
+    assert_eq!(upgrade_command(&InstallMethod::Scoop), "scoop update tokensave");
+    assert_eq!(upgrade_command(&InstallMethod::Unknown), "tokensave upgrade");
 }
 
 #[test]


### PR DESCRIPTION
## Context
- `tokensave upgrade` was run from a Homebrew-installed binary on macOS
- the CLI detected an available update and attempted a self-replace of the running executable
- that path fails for package-manager installs and surfaced as `binary replacement failed: No such file or directory (os error 2)`
- the update messaging was also misleading because it always suggested `tokensave upgrade`, even when the install method required a package-manager command instead

## Summary
- make `upgrade_command()` return an install-method specific update instruction instead of always suggesting `tokensave upgrade`
- make `tokensave upgrade` exit early for Homebrew and Scoop installs with the correct package-manager command instead of attempting self-replacement
- use the install-method specific update instruction in CLI/MCP update notices and adjust the cloud test

## Testing
- cargo test --test cloud_test upgrade_command_matches_install_method
- cargo test --test cloud_test detect_install_method_no_panic
