### PR TITLE
feat: follow symlinked source directories during indexing

### DIFF
--- a/src/tokensave.rs
+++ b/src/tokensave.rs
@@ -880,6 +880,7 @@ impl TokenSave {
                 // causing the ignore-aware walker to skip everything. Fall
                 // back to plain walkdir if source files clearly exist.
                 let has_source = WalkDir::new(&self.project_root)
+                    .follow_links(true)
                     .max_depth(2)
                     .into_iter()
                     .filter_map(|e| e.ok())
@@ -905,7 +906,7 @@ impl TokenSave {
     fn scan_files_walkdir(&self, supported_exts: &[&str]) -> Result<Vec<String>> {
         let mut files = Vec::new();
         for entry in WalkDir::new(&self.project_root)
-            .follow_links(false)
+            .follow_links(true)
             .into_iter()
             .filter_entry(|e| {
                 if e.depth() == 0 {
@@ -934,7 +935,7 @@ impl TokenSave {
     fn scan_files_with_gitignore(&self, supported_exts: &[&str]) -> Result<Vec<String>> {
         let mut files = Vec::new();
         let walker = ignore::WalkBuilder::new(&self.project_root)
-            .follow_links(false)
+            .follow_links(true)
             .hidden(true) // skip hidden files/dirs
             .git_ignore(true)
             .git_global(true)

--- a/tests/integration_test.rs
+++ b/tests/integration_test.rs
@@ -1,5 +1,8 @@
 use std::fs;
+#[cfg(unix)]
+use std::os::unix::fs::symlink;
 use tempfile::TempDir;
+use tokensave::config::{load_config, save_config};
 use tokensave::tokensave::TokenSave;
 use tokensave::types::EdgeKind;
 
@@ -367,6 +370,67 @@ pub fn create_user(name: &str, email: &str) -> String {
     // Search for function from services
     let results = cg.search("create_user", 10).await.unwrap();
     assert!(!results.is_empty(), "should find 'create_user' function");
+}
+
+#[cfg(unix)]
+#[tokio::test]
+async fn test_index_follows_symlinked_directories() {
+    let dir = TempDir::new().unwrap();
+    let project = dir.path();
+    let external = TempDir::new().unwrap();
+
+    fs::create_dir_all(external.path()).unwrap();
+    fs::write(
+        external.path().join("lib.rs"),
+        "pub fn through_symlink() {}\n",
+    )
+    .unwrap();
+    symlink(external.path(), project.join("src")).unwrap();
+
+    let cg = TokenSave::init(project).await.unwrap();
+    let result = cg.index_all().await.unwrap();
+
+    assert_eq!(result.file_count, 1, "should index the file behind the symlink");
+
+    let files = cg.get_all_files().await.unwrap();
+    let paths: Vec<&str> = files.iter().map(|f| f.path.as_str()).collect();
+    assert!(paths.contains(&"src/lib.rs"));
+
+    let results = cg.search("through_symlink", 10).await.unwrap();
+    assert!(!results.is_empty(), "should extract symbols from symlinked source");
+}
+
+#[cfg(unix)]
+#[tokio::test]
+async fn test_gitignore_scan_follows_symlinked_directories() {
+    let dir = TempDir::new().unwrap();
+    let project = dir.path();
+    let external = TempDir::new().unwrap();
+
+    fs::create_dir_all(external.path()).unwrap();
+    fs::write(
+        external.path().join("lib.rs"),
+        "pub fn through_gitignore_symlink() {}\n",
+    )
+    .unwrap();
+    symlink(external.path(), project.join("src")).unwrap();
+
+    TokenSave::init(project).await.unwrap();
+
+    let mut config = load_config(project).unwrap();
+    config.git_ignore = true;
+    save_config(project, &config).unwrap();
+
+    let cg = TokenSave::open(project).await.unwrap();
+    let result = cg.index_all().await.unwrap();
+
+    assert_eq!(result.file_count, 1, "gitignore-aware scan should follow symlinks");
+
+    let results = cg.search("through_gitignore_symlink", 10).await.unwrap();
+    assert!(
+        !results.is_empty(),
+        "should extract symbols through symlink with gitignore-aware walker"
+    );
 }
 
 // ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

- follow symlinked directories during file discovery in both the plain `walkdir` path and the `.gitignore`-aware `ignore::WalkBuilder` path
- update the fallback source probe to use the same symlink-following behavior
- add Unix integration tests covering indexing through a symlinked source directory with and without `git_ignore` enabled

## Problem

Right now `tokensave` skips directory symlinks while scanning files because both walkers are configured with `follow_links(false)`. That means projects that expose source code through symlinked paths are only partially indexed or not indexed at all, even when the symlinked tree is part of the intended project layout.

## Implementation

This changes the file discovery paths in `TokenSave::scan_files()` to follow symlinks consistently:

- `scan_files_walkdir()` now uses `WalkDir::follow_links(true)`
- `scan_files_with_gitignore()` now uses `ignore::WalkBuilder::follow_links(true)`
- the fallback `has_source` probe also follows symlinks, so the fallback decision matches the actual scan behavior

## Testing

- `cargo test test_index_follows_symlinked_directories --test integration_test`
- `cargo test test_gitignore_scan_follows_symlinked_directories --test integration_test`
- `cargo test test_multiple_files_cross_reference --test integration_test`
