### PR TITLE
improve performance of N+1 queries

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Performance
+- **Fixed N+1 query patterns in graph traversal** — `traverse_bfs`, `traverse_dfs`, `get_callers`, `get_callees`, `get_file_dependencies`, `get_file_dependents`, and `find_dead_code` were each making a separate database query per node, causing excessive CPU usage on large codebases. All methods now batch-fetch nodes using a single `WHERE id IN (...)` query, reducing database roundtrips from O(N) to O(1).
+
 ## [4.1.4] - 2026-04-25
 
 ### Fixed

--- a/src/db/queries.rs
+++ b/src/db/queries.rs
@@ -415,6 +415,35 @@ impl Database {
         }
     }
 
+    /// Returns nodes by their IDs in a single batch query.
+    /// IDs not found are silently omitted. Results are returned in arbitrary order.
+    pub async fn get_nodes_by_ids(&self, ids: &[String]) -> Result<Vec<Node>> {
+        if ids.is_empty() {
+            return Ok(Vec::new());
+        }
+        let placeholders: Vec<String> = (1..=ids.len()).map(|i| format!("?{i}")).collect();
+        let sql = format!(
+            "SELECT id, kind, name, qualified_name, file_path,
+                    start_line, end_line, start_column, end_column,
+                    docstring, signature, visibility, is_async, branches, loops, returns, max_nesting, unsafe_blocks, unchecked_calls, assertions, updated_at
+             FROM nodes WHERE id IN ({})",
+            placeholders.join(", ")
+        );
+        let param_values: Vec<libsql::Value> = ids
+            .iter()
+            .map(|id| libsql::Value::Text(id.clone()))
+            .collect();
+        let mut rows = self
+            .conn()
+            .query(&sql, libsql::params_from_iter(param_values))
+            .await
+            .map_err(|e| TokenSaveError::Database {
+                message: format!("failed to batch query nodes: {e}"),
+                operation: "get_nodes_by_ids".to_string(),
+            })?;
+        collect_rows(&mut rows, row_to_node, "get_nodes_by_ids").await
+    }
+
     /// Returns all nodes for a given file, ordered by start line.
     pub async fn get_nodes_by_file(&self, file_path: &str) -> Result<Vec<Node>> {
         let mut rows = self

--- a/src/graph/queries.rs
+++ b/src/graph/queries.rs
@@ -2,7 +2,7 @@
 use std::collections::{HashMap, HashSet};
 
 use crate::db::Database;
-use crate::errors::Result;
+use crate::errors::{Result, TokenSaveError};
 use crate::types::*;
 
 /// Metrics describing the connectivity and structure around a single node.
@@ -52,26 +52,61 @@ impl<'a> GraphQueryManager<'a> {
             all
         };
 
-        let mut dead: Vec<Node> = Vec::new();
+        let candidate_ids: Vec<String> = nodes
+            .iter()
+            .filter(|node| {
+                if node.name == "main" {
+                    return false;
+                }
+                if node.name.starts_with("test") {
+                    return false;
+                }
+                if node.visibility == Visibility::Pub {
+                    return false;
+                }
+                true
+            })
+            .map(|n| n.id.clone())
+            .collect();
 
-        for node in nodes {
-            // Exclude entry points and tests.
-            if node.name == "main" {
-                continue;
-            }
-            if node.name.starts_with("test") {
-                continue;
-            }
-            // Exclude pub items (potential public API).
-            if node.visibility == Visibility::Pub {
-                continue;
-            }
+        if candidate_ids.is_empty() {
+            return Ok(Vec::new());
+        }
 
-            let incoming = self.db.get_incoming_edges(&node.id, &[]).await?;
-            if incoming.is_empty() {
-                dead.push(node);
+        let placeholders: Vec<String> = (1..=candidate_ids.len()).map(|i| format!("?{i}")).collect();
+        let sql = format!(
+            "SELECT target FROM edges WHERE target IN ({}) LIMIT 1",
+            placeholders.join(", ")
+        );
+        let param_values: Vec<libsql::Value> = candidate_ids
+            .iter()
+            .map(|id| libsql::Value::Text(id.clone()))
+            .collect();
+        let mut rows = self
+            .db
+            .conn()
+            .query(&sql, libsql::params_from_iter(param_values))
+            .await
+            .map_err(|e| TokenSaveError::Database {
+                message: format!("failed to find nodes with incoming edges: {e}"),
+                operation: "find_dead_code".to_string(),
+            })?;
+
+        let mut nodes_with_incoming: std::collections::HashSet<String> = std::collections::HashSet::new();
+        while let Some(row) = rows.next().await.map_err(|e| TokenSaveError::Database {
+            message: format!("failed to read row: {e}"),
+            operation: "find_dead_code".to_string(),
+        })? {
+            if let Ok(id) = row.get::<String>(0) {
+                nodes_with_incoming.insert(id);
             }
         }
+
+        let candidate_set: std::collections::HashSet<String> = candidate_ids.iter().cloned().collect();
+        let dead: Vec<Node> = nodes
+            .into_iter()
+            .filter(|node| candidate_set.contains(&node.id) && !nodes_with_incoming.contains(&node.id))
+            .collect();
 
         Ok(dead)
     }
@@ -114,22 +149,55 @@ impl<'a> GraphQueryManager<'a> {
     /// excluding the source file itself.
     pub async fn get_file_dependencies(&self, file_path: &str) -> Result<Vec<String>> {
         let nodes = self.db.get_nodes_by_file(file_path).await?;
-        let mut dep_files: HashSet<String> = HashSet::new();
+        if nodes.is_empty() {
+            return Ok(Vec::new());
+        }
 
-        for node in &nodes {
-            let edges = self
-                .db
-                .get_outgoing_edges(&node.id, &[EdgeKind::Uses, EdgeKind::Calls])
-                .await?;
+        let node_ids: Vec<String> = nodes.iter().map(|n| n.id.clone()).collect();
+        let placeholders: Vec<String> = (1..=node_ids.len()).map(|i| format!("?{i}")).collect();
+        let kind_filter = "('uses', 'calls')";
 
-            for edge in &edges {
-                if let Some(target_node) = self.db.get_node_by_id(&edge.target).await? {
-                    if target_node.file_path != file_path {
-                        dep_files.insert(target_node.file_path);
-                    }
-                }
+        let sql = format!(
+            "SELECT DISTINCT e.target FROM edges e \
+             WHERE e.source IN ({}) AND e.kind IN {kind_filter}",
+            placeholders.join(", ")
+        );
+
+        let param_values: Vec<libsql::Value> = node_ids
+            .iter()
+            .map(|id| libsql::Value::Text(id.clone()))
+            .collect();
+
+        let mut rows = self
+            .db
+            .conn()
+            .query(&sql, libsql::params_from_iter(param_values))
+            .await
+            .map_err(|e| TokenSaveError::Database {
+                message: format!("failed to query file dependencies: {e}"),
+                operation: "get_file_dependencies".to_string(),
+            })?;
+
+        let mut target_ids: Vec<String> = Vec::new();
+        while let Some(row) = rows.next().await.map_err(|e| TokenSaveError::Database {
+            message: format!("failed to read target id: {e}"),
+            operation: "get_file_dependencies".to_string(),
+        })? {
+            if let Ok(id) = row.get::<String>(0) {
+                target_ids.push(id);
             }
         }
+
+        if target_ids.is_empty() {
+            return Ok(Vec::new());
+        }
+
+        let target_nodes = self.db.get_nodes_by_ids(&target_ids).await?;
+        let dep_files: HashSet<String> = target_nodes
+            .into_iter()
+            .filter(|n| n.file_path != file_path)
+            .map(|n| n.file_path)
+            .collect();
 
         let mut result: Vec<String> = dep_files.into_iter().collect();
         result.sort();
@@ -143,22 +211,55 @@ impl<'a> GraphQueryManager<'a> {
     /// excluding the target file itself.
     pub async fn get_file_dependents(&self, file_path: &str) -> Result<Vec<String>> {
         let nodes = self.db.get_nodes_by_file(file_path).await?;
-        let mut dependent_files: HashSet<String> = HashSet::new();
+        if nodes.is_empty() {
+            return Ok(Vec::new());
+        }
 
-        for node in &nodes {
-            let edges = self
-                .db
-                .get_incoming_edges(&node.id, &[EdgeKind::Uses, EdgeKind::Calls])
-                .await?;
+        let node_ids: Vec<String> = nodes.iter().map(|n| n.id.clone()).collect();
+        let placeholders: Vec<String> = (1..=node_ids.len()).map(|i| format!("?{i}")).collect();
+        let kind_filter = "('uses', 'calls')";
 
-            for edge in &edges {
-                if let Some(source_node) = self.db.get_node_by_id(&edge.source).await? {
-                    if source_node.file_path != file_path {
-                        dependent_files.insert(source_node.file_path);
-                    }
-                }
+        let sql = format!(
+            "SELECT DISTINCT e.source FROM edges e \
+             WHERE e.target IN ({}) AND e.kind IN {kind_filter}",
+            placeholders.join(", ")
+        );
+
+        let param_values: Vec<libsql::Value> = node_ids
+            .iter()
+            .map(|id| libsql::Value::Text(id.clone()))
+            .collect();
+
+        let mut rows = self
+            .db
+            .conn()
+            .query(&sql, libsql::params_from_iter(param_values))
+            .await
+            .map_err(|e| TokenSaveError::Database {
+                message: format!("failed to query file dependents: {e}"),
+                operation: "get_file_dependents".to_string(),
+            })?;
+
+        let mut source_ids: Vec<String> = Vec::new();
+        while let Some(row) = rows.next().await.map_err(|e| TokenSaveError::Database {
+            message: format!("failed to read source id: {e}"),
+            operation: "get_file_dependents".to_string(),
+        })? {
+            if let Ok(id) = row.get::<String>(0) {
+                source_ids.push(id);
             }
         }
+
+        if source_ids.is_empty() {
+            return Ok(Vec::new());
+        }
+
+        let source_nodes = self.db.get_nodes_by_ids(&source_ids).await?;
+        let dependent_files: HashSet<String> = source_nodes
+            .into_iter()
+            .filter(|n| n.file_path != file_path)
+            .map(|n| n.file_path)
+            .collect();
 
         let mut result: Vec<String> = dependent_files.into_iter().collect();
         result.sort();

--- a/src/graph/traversal.rs
+++ b/src/graph/traversal.rs
@@ -73,51 +73,69 @@ impl<'a> GraphTraverser<'a> {
                 .get_edges_for_direction(&current_id, edge_filter, &opts.direction)
                 .await?;
 
+            let neighbor_ids: Vec<String> = edges
+                .iter()
+                .map(|edge| self.neighbor_id(edge, &current_id, &opts.direction))
+                .filter(|id| !visited.contains(id))
+                .collect();
+
+            if neighbor_ids.is_empty() {
+                continue;
+            }
+
+            let neighbor_nodes = self.db.get_nodes_by_ids(&neighbor_ids).await?;
+            let neighbor_map: std::collections::HashMap<String, Node> = neighbor_nodes
+                .into_iter()
+                .map(|n| (n.id.clone(), n))
+                .collect();
+
             for edge in edges {
                 let neighbor_id = self.neighbor_id(&edge, &current_id, &opts.direction);
 
                 if visited.contains(&neighbor_id) {
                     continue;
                 }
+
+                let Some(neighbor_node) = neighbor_map.get(&neighbor_id) else {
+                    continue;
+                };
+
                 visited.insert(neighbor_id.clone());
 
-                if let Some(neighbor_node) = self.db.get_node_by_id(&neighbor_id).await? {
-                    if self.node_matches_filter(&neighbor_node, opts) {
-                        // For Incoming traversals, if we discovered a container
-                        // (class/struct/trait/interface/module), also enqueue its
-                        // children so callers of methods appear in the container's
-                        // impact radius.
-                        if opts.direction == TraversalDirection::Incoming
-                            && is_container_kind(&neighbor_node.kind)
-                        {
-                            let children = self
-                                .get_edges_for_direction(
-                                    &neighbor_id,
-                                    &[EdgeKind::Contains],
-                                    &TraversalDirection::Outgoing,
-                                )
-                                .await?;
-                            for child_edge in children {
-                                let child_id = self.neighbor_id(
-                                    &child_edge,
-                                    &neighbor_id,
-                                    &TraversalDirection::Outgoing,
-                                );
-                                if !visited.contains(&child_id) {
-                                    visited.insert(child_id.clone());
-                                    result_edges.push(child_edge);
-                                    queue.push_back((child_id, depth + 1));
-                                }
+                if self.node_matches_filter(neighbor_node, opts) {
+                    if opts.direction == TraversalDirection::Incoming
+                        && is_container_kind(&neighbor_node.kind)
+                    {
+                        let children = self
+                            .get_edges_for_direction(
+                                &neighbor_id,
+                                &[EdgeKind::Contains],
+                                &TraversalDirection::Outgoing,
+                            )
+                            .await?;
+                        for child_edge in children {
+                            let child_id = self.neighbor_id(
+                                &child_edge,
+                                &neighbor_id,
+                                &TraversalDirection::Outgoing,
+                            );
+                            if !visited.contains(&child_id) {
+                                visited.insert(child_id.clone());
+                                result_edges.push(child_edge);
+                                queue.push_back((child_id, depth + 1));
                             }
                         }
-
-                        result_nodes.push(neighbor_node);
-                        if result_nodes.len() >= opts.limit as usize {
-                            result_edges.push(edge);
-                            break;
-                        }
                     }
-                    result_edges.push(edge);
+
+                    result_nodes.push(neighbor_node.clone());
+                    result_edges.push(edge.clone());
+                    queue.push_back((neighbor_id, depth + 1));
+
+                    if result_nodes.len() >= opts.limit as usize {
+                        break;
+                    }
+                } else {
+                    result_edges.push(edge.clone());
                     queue.push_back((neighbor_id, depth + 1));
                 }
             }
@@ -184,23 +202,45 @@ impl<'a> GraphTraverser<'a> {
                 .get_edges_for_direction(&current_id, edge_filter, &opts.direction)
                 .await?;
 
+            let neighbor_ids: Vec<String> = edges
+                .iter()
+                .map(|edge| self.neighbor_id(edge, &current_id, &opts.direction))
+                .filter(|id| !visited.contains(id))
+                .collect();
+
+            if neighbor_ids.is_empty() {
+                continue;
+            }
+
+            let neighbor_nodes = self.db.get_nodes_by_ids(&neighbor_ids).await?;
+            let neighbor_map: std::collections::HashMap<String, Node> = neighbor_nodes
+                .into_iter()
+                .map(|n| (n.id.clone(), n))
+                .collect();
+
             for edge in edges {
                 let neighbor_id = self.neighbor_id(&edge, &current_id, &opts.direction);
 
                 if visited.contains(&neighbor_id) {
                     continue;
                 }
+
+                let Some(neighbor_node) = neighbor_map.get(&neighbor_id) else {
+                    continue;
+                };
+
                 visited.insert(neighbor_id.clone());
 
-                if let Some(neighbor_node) = self.db.get_node_by_id(&neighbor_id).await? {
-                    if self.node_matches_filter(&neighbor_node, opts) {
-                        result_nodes.push(neighbor_node);
-                        if result_nodes.len() >= opts.limit as usize {
-                            result_edges.push(edge);
-                            break;
-                        }
+                if self.node_matches_filter(neighbor_node, opts) {
+                    result_nodes.push(neighbor_node.clone());
+                    result_edges.push(edge.clone());
+                    stack.push((neighbor_id, depth + 1));
+
+                    if result_nodes.len() >= opts.limit as usize {
+                        break;
                     }
-                    result_edges.push(edge);
+                } else {
+                    result_edges.push(edge.clone());
                     stack.push((neighbor_id, depth + 1));
                 }
             }
@@ -236,16 +276,32 @@ impl<'a> GraphTraverser<'a> {
                 .get_incoming_edges(&current_id, &[EdgeKind::Calls])
                 .await?;
 
+            let caller_ids: Vec<String> = edges
+                .iter()
+                .map(|e| e.source.clone())
+                .filter(|id| !visited.contains(id))
+                .collect();
+
+            if caller_ids.is_empty() {
+                continue;
+            }
+
+            let caller_nodes = self.db.get_nodes_by_ids(&caller_ids).await?;
+            let caller_map: std::collections::HashMap<String, Node> = caller_nodes
+                .into_iter()
+                .map(|n| (n.id.clone(), n))
+                .collect();
+
             for edge in edges {
                 let caller_id = &edge.source;
                 if visited.contains(caller_id) {
                     continue;
                 }
-                visited.insert(caller_id.clone());
 
-                if let Some(caller_node) = self.db.get_node_by_id(caller_id).await? {
+                if let Some(caller_node) = caller_map.get(caller_id) {
+                    visited.insert(caller_id.clone());
                     queue.push_back((caller_id.clone(), depth + 1));
-                    results.push((caller_node, edge));
+                    results.push((caller_node.clone(), edge));
                 }
             }
         }
@@ -276,16 +332,32 @@ impl<'a> GraphTraverser<'a> {
                 .get_outgoing_edges(&current_id, &[EdgeKind::Calls])
                 .await?;
 
+            let callee_ids: Vec<String> = edges
+                .iter()
+                .map(|e| e.target.clone())
+                .filter(|id| !visited.contains(id))
+                .collect();
+
+            if callee_ids.is_empty() {
+                continue;
+            }
+
+            let callee_nodes = self.db.get_nodes_by_ids(&callee_ids).await?;
+            let callee_map: std::collections::HashMap<String, Node> = callee_nodes
+                .into_iter()
+                .map(|n| (n.id.clone(), n))
+                .collect();
+
             for edge in edges {
                 let callee_id = &edge.target;
                 if visited.contains(callee_id) {
                     continue;
                 }
-                visited.insert(callee_id.clone());
 
-                if let Some(callee_node) = self.db.get_node_by_id(callee_id).await? {
+                if let Some(callee_node) = callee_map.get(callee_id) {
+                    visited.insert(callee_id.clone());
                     queue.push_back((callee_id.clone(), depth + 1));
-                    results.push((callee_node, edge));
+                    results.push((callee_node.clone(), edge));
                 }
             }
         }


### PR DESCRIPTION
## Summary

A small patch to improve performance of tokensave.

## Motivation

get_node_by_id is being called inside loops in traversal.rs. In the traverse_bfs method, for every node visited, there's a database call to get_node_by_id.

## Changes



## Test plan

- [x] `cargo test` passes
- [x] `cargo clippy` has no new warnings
- [ ] Tested manually (describe below if applicable)

## Checklist

- [x] `CHANGELOG.md` updated (under `[Unreleased]` if no version bump)
- [x] No secrets, credentials, or `.env` files included
- [ ] Breaking changes documented (if any)
