### PR TITLE
Edit primitives for faster code modification

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Performance
 - **Fixed N+1 query patterns in graph traversal** — `traverse_bfs`, `traverse_dfs`, `get_callers`, `get_callees`, `get_file_dependencies`, `get_file_dependents`, and `find_dead_code` were each making a separate database query per node, causing excessive CPU usage on large codebases. All methods now batch-fetch nodes using a single `WHERE id IN (...)` query, reducing database roundtrips from O(N) to O(1).
 
+### Fixed
+
+- **Fixed** _dead_code for large codebase.
+
 ## [4.1.4] - 2026-04-25
 
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+- **Edit primitives for code modification** — four new MCP tools enable Claude&friends to edit files without regex or shell quoting hazards:
+  - `tokensave_str_replace` — replaces a unique `old_str` with `new_str`; fails if 0 or >1 matches, protecting against multi-edit bugs
+  - `tokensave_multi_str_replace` — applies N `(old, new)` replacements atomically; all-or-nothing transaction
+  - `tokensave_insert_at` — inserts content before or after a unique anchor string or line number
+  - `tokensave_ast_grep_rewrite` — structural code rewrite via ast-grep CLI (`--rewrite` mode)
+- **Auto re-indexing** — all edit tools automatically re-index the modified file in the code graph after writing, so the graph stays in sync without manual steps
+
 ### Performance
 - **Fixed N+1 query patterns in graph traversal** — `traverse_bfs`, `traverse_dfs`, `get_callers`, `get_callees`, `get_file_dependencies`, `get_file_dependents`, and `find_dead_code` were each making a separate database query per node, causing excessive CPU usage on large codebases. All methods now batch-fetch nodes using a single `WHERE id IN (...)` query, reducing database roundtrips from O(N) to O(1).
 

--- a/src/accounting/classifier.rs
+++ b/src/accounting/classifier.rs
@@ -69,7 +69,7 @@ impl TaskCategory {
 
 /// Classify a turn based on tool names and Bash command content.
 ///
-/// `tool_names`: names of all tool_use blocks in the turn (e.g. "Edit", "Bash").
+/// `tool_names`: names of all `tool_use` blocks in the turn (e.g. "Edit", "Bash").
 /// `bash_commands`: content of Bash tool inputs (the `command` field).
 pub fn classify(tool_names: &[&str], bash_commands: &[&str]) -> TaskCategory {
     if tool_names.is_empty() {

--- a/src/accounting/metrics.rs
+++ b/src/accounting/metrics.rs
@@ -81,11 +81,10 @@ pub fn parse_range(range: &str) -> u64 {
     let now = now_epoch();
     match range {
         "today" => today_start_epoch(now),
-        "7d" => now.saturating_sub(7 * 86400),
         "30d" => now.saturating_sub(30 * 86400),
         "month" => month_start_epoch(now),
         "all" => 0,
-        _ => now.saturating_sub(7 * 86400), // default to 7d
+        _ => now.saturating_sub(7 * 86400),
     }
 }
 

--- a/src/accounting/parser.rs
+++ b/src/accounting/parser.rs
@@ -107,11 +107,11 @@ fn parse_line(line: &str, project_hash: &str, session_id: &str) -> Option<CostTu
     let output_tokens = usage.get("output_tokens")?.as_u64().unwrap_or(0);
     let cache_write_tokens = usage
         .get("cache_creation_input_tokens")
-        .and_then(|v| v.as_u64())
+        .and_then(serde_json::Value::as_u64)
         .unwrap_or(0);
     let cache_read_tokens = usage
         .get("cache_read_input_tokens")
-        .and_then(|v| v.as_u64())
+        .and_then(serde_json::Value::as_u64)
         .unwrap_or(0);
 
     // Parse timestamp from the outer object (ISO 8601)
@@ -142,8 +142,14 @@ fn parse_line(line: &str, project_hash: &str, session_id: &str) -> Option<CostTu
     }
 
     // Classify
-    let tool_refs: Vec<&str> = tool_names_vec.iter().map(|s| s.as_str()).collect();
-    let bash_refs: Vec<&str> = bash_commands.iter().map(|s| s.as_str()).collect();
+    let tool_refs: Vec<&str> = tool_names_vec
+        .iter()
+        .map(std::string::String::as_str)
+        .collect();
+    let bash_refs: Vec<&str> = bash_commands
+        .iter()
+        .map(std::string::String::as_str)
+        .collect();
     let category = classifier::classify(&tool_refs, &bash_refs);
 
     // Compute cost
@@ -228,16 +234,14 @@ pub async fn ingest(gdb: &GlobalDb) -> IngestStats {
         let path_str = file_path.to_string_lossy().to_string();
 
         // Check file mtime
-        let meta = match fs::metadata(file_path) {
-            Ok(m) => m,
-            Err(_) => continue,
+        let Ok(meta) = fs::metadata(file_path) else {
+            continue;
         };
         let mtime = meta
             .modified()
             .ok()
             .and_then(|t| t.duration_since(std::time::UNIX_EPOCH).ok())
-            .map(|d| d.as_secs())
-            .unwrap_or(0);
+            .map_or(0, |d| d.as_secs());
 
         // Check if we've already parsed this file up to this mtime
         let (prev_offset, prev_mtime) = gdb.get_parse_offset(&path_str).await.unwrap_or((0, 0));
@@ -259,9 +263,8 @@ pub async fn ingest(gdb: &GlobalDb) -> IngestStats {
 
         let (project_hash, session_id) = extract_path_parts(file_path);
 
-        let f = match fs::File::open(file_path) {
-            Ok(f) => f,
-            Err(_) => continue,
+        let Ok(f) = fs::File::open(file_path) else {
+            continue;
         };
         let mut reader = BufReader::new(f);
 
@@ -276,7 +279,7 @@ pub async fn ingest(gdb: &GlobalDb) -> IngestStats {
         loop {
             line.clear();
             match reader.read_line(&mut line) {
-                Ok(0) => break,
+                Ok(0) | Err(_) => break,
                 Ok(n) => {
                     current_offset += n as u64;
                     let trimmed = line.trim();
@@ -293,7 +296,6 @@ pub async fn ingest(gdb: &GlobalDb) -> IngestStats {
                         }
                     }
                 }
-                Err(_) => break,
             }
         }
 

--- a/src/accounting/pricing.rs
+++ b/src/accounting/pricing.rs
@@ -3,16 +3,16 @@
 //! Pricing lifecycle:
 //! 1. **Cached file** at `~/.tokensave/pricing.json` -- checked first.
 //! 2. **Embedded fallback** baked into the binary -- used when no cache exists.
-//! 3. **Remote refresh** from LiteLLM's public pricing JSON -- fetched at most
+//! 3. **Remote refresh** from `LiteLLM`'s public pricing JSON -- fetched at most
 //!    once every 24 hours, stored to the cache file.
 //!
-//! All prices are per million tokens (MTok).
+//! All prices are per million tokens (`MTok`).
 
 use std::collections::HashMap;
 use std::path::PathBuf;
 use std::time::Duration;
 
-/// LiteLLM pricing data URL. Public, no authentication required.
+/// `LiteLLM` pricing data URL. Public, no authentication required.
 /// See: <https://github.com/BerriAI/litellm>
 const LITELLM_PRICING_URL: &str =
     "https://raw.githubusercontent.com/BerriAI/litellm/main/model_prices_and_context_window.json";
@@ -100,9 +100,9 @@ fn embedded_table() -> HashMap<String, ModelPricing> {
     m
 }
 
-/// Parse LiteLLM's JSON format into our pricing table.
+/// Parse `LiteLLM`'s JSON format into our pricing table.
 ///
-/// LiteLLM uses per-token costs (e.g. `3e-06` for $3/MTok). We filter to
+/// `LiteLLM` uses per-token costs (e.g. `3e-06` for $3/MTok). We filter to
 /// Claude models only and convert to per-MTok.
 fn parse_litellm_json(json: &str) -> Option<HashMap<String, ModelPricing>> {
     let parsed: serde_json::Value = serde_json::from_str(json).ok()?;
@@ -126,19 +126,19 @@ fn parse_litellm_json(json: &str) -> Option<HashMap<String, ModelPricing>> {
 
         let input = entry
             .get("input_cost_per_token")
-            .and_then(|v| v.as_f64())
+            .and_then(serde_json::Value::as_f64)
             .unwrap_or(0.0);
         let output = entry
             .get("output_cost_per_token")
-            .and_then(|v| v.as_f64())
+            .and_then(serde_json::Value::as_f64)
             .unwrap_or(0.0);
         let cache_write = entry
             .get("cache_creation_input_token_cost")
-            .and_then(|v| v.as_f64())
+            .and_then(serde_json::Value::as_f64)
             .unwrap_or(0.0);
         let cache_read = entry
             .get("cache_read_input_token_cost")
-            .and_then(|v| v.as_f64())
+            .and_then(serde_json::Value::as_f64)
             .unwrap_or(0.0);
 
         // Skip entries with no pricing data
@@ -230,20 +230,18 @@ pub fn cost_of_turn(
         + (cache_read_tokens as f64 / mtok) * p.cache_read_per_mtok
 }
 
-/// Fetch fresh pricing from LiteLLM and save to the cache file.
+/// Fetch fresh pricing from `LiteLLM` and save to the cache file.
 ///
 /// Returns `true` if the cache was updated, `false` on any failure.
 /// Best-effort: never blocks longer than `FETCH_TIMEOUT`, failures
 /// are silently ignored.
 pub fn refresh_pricing() -> bool {
     let agent = crate::cloud::agent_with_timeout(FETCH_TIMEOUT);
-    let mut resp = match agent.get(LITELLM_PRICING_URL).call() {
-        Ok(r) => r,
-        Err(_) => return false,
+    let Ok(mut resp) = agent.get(LITELLM_PRICING_URL).call() else {
+        return false;
     };
-    let body: String = match resp.body_mut().read_to_string() {
-        Ok(s) => s,
-        Err(_) => return false,
+    let Ok(body) = resp.body_mut().read_to_string() else {
+        return false;
     };
 
     // Validate that it parses before writing
@@ -262,7 +260,7 @@ pub fn refresh_pricing() -> bool {
 }
 
 /// Refresh pricing if the cache is stale (older than 24 hours).
-/// Uses `last_pricing_fetch_at` in UserConfig for TTL tracking.
+/// Uses `last_pricing_fetch_at` in `UserConfig` for TTL tracking.
 pub fn refresh_if_stale() {
     let mut config = crate::user_config::UserConfig::load();
     let now = std::time::SystemTime::now()

--- a/src/agents/antigravity.rs
+++ b/src/agents/antigravity.rs
@@ -134,7 +134,7 @@ fn uninstall_mcp_server(mcp_path: &Path) {
 
     let is_empty = settings.as_object().is_some_and(|o| {
         o.iter()
-            .all(|(k, v)| k == "mcpServers" && v.as_object().is_some_and(|m| m.is_empty()))
+            .all(|(k, v)| k == "mcpServers" && v.as_object().is_some_and(serde_json::Map::is_empty))
     });
 
     if is_empty {

--- a/src/agents/claude.rs
+++ b/src/agents/claude.rs
@@ -194,16 +194,14 @@ fn install_single_hook(
 
     let has_hook = hooks_arr.iter().any(|h| {
         let hooks_list = h.get("hooks").and_then(|a| a.as_array());
-        hooks_list
-            .map(|arr| {
-                arr.iter().any(|entry| {
-                    entry
-                        .get("command")
-                        .and_then(|c| c.as_str())
-                        .is_some_and(|c| c.contains("tokensave"))
-                })
+        hooks_list.is_some_and(|arr| {
+            arr.iter().any(|entry| {
+                entry
+                    .get("command")
+                    .and_then(|c| c.as_str())
+                    .is_some_and(|c| c.contains("tokensave"))
             })
-            .unwrap_or(false)
+        })
     });
 
     if !has_hook {
@@ -230,7 +228,7 @@ fn install_permissions(settings: &mut serde_json::Value, tool_permissions: &[Str
         .as_array()
         .map(|arr| {
             arr.iter()
-                .filter_map(|v| v.as_str().map(|s| s.to_string()))
+                .filter_map(|v| v.as_str().map(std::string::ToString::to_string))
                 .collect()
         })
         .unwrap_or_default();
@@ -392,7 +390,7 @@ fn clean_local_settings_file(project_path: &Path, local_settings_path: &Path) {
         return;
     }
 
-    let is_empty = local_val.as_object().is_some_and(|obj| obj.is_empty());
+    let is_empty = local_val.as_object().is_some_and(serde_json::Map::is_empty);
     if is_empty {
         if std::fs::remove_file(local_settings_path).is_ok() {
             eprintln!(
@@ -441,7 +439,9 @@ fn uninstall_mcp_server(claude_json_path: &Path) {
     if servers.is_empty() {
         claude_json.as_object_mut().map(|o| o.remove("mcpServers"));
     }
-    let is_empty = claude_json.as_object().is_some_and(|o| o.is_empty());
+    let is_empty = claude_json
+        .as_object()
+        .is_some_and(serde_json::Map::is_empty);
     if is_empty {
         std::fs::remove_file(claude_json_path).ok();
         eprintln!(
@@ -518,7 +518,7 @@ fn uninstall_single_hook(settings: &mut serde_json::Value, event: &str) -> bool 
         .filter(|h| {
             !h.get("hooks")
                 .and_then(|a| a.as_array())
-                .map(|arr| {
+                .is_some_and(|arr| {
                     arr.iter().any(|entry| {
                         entry
                             .get("command")
@@ -526,10 +526,13 @@ fn uninstall_single_hook(settings: &mut serde_json::Value, event: &str) -> bool 
                             .is_some_and(|c| c.contains("tokensave"))
                     })
                 })
-                .unwrap_or(false)
         })
         .collect();
-    if filtered.len() >= settings["hooks"][event].as_array().map_or(0, |a| a.len()) {
+    if filtered.len()
+        >= settings["hooks"][event]
+            .as_array()
+            .map_or(0, std::vec::Vec::len)
+    {
         return false;
     }
     if filtered.is_empty() {
@@ -561,7 +564,7 @@ fn uninstall_permissions(settings: &mut serde_json::Value) -> bool {
     if filtered.len()
         >= settings["permissions"]["allow"]
             .as_array()
-            .map_or(0, |a| a.len())
+            .map_or(0, std::vec::Vec::len)
     {
         return false;
     }
@@ -781,7 +784,7 @@ fn doctor_check_single_hook(dc: &mut DoctorCounters, settings: &serde_json::Valu
                 .and_then(|a| a.first())
                 .and_then(|c| c["command"].as_str())
                 .filter(|c| c.contains("tokensave"))
-                .map(|s| s.to_string())
+                .map(String::from)
         })
     });
     let Some(ref hook_cmd) = hook_cmd_str else {
@@ -819,7 +822,7 @@ fn doctor_fix_hooks(dc: &mut DoctorCounters, settings_path: &Path, settings: &se
     let bin = extract_tokensave_bin_from_hooks(settings).or_else(|| {
         std::env::current_exe()
             .ok()
-            .and_then(|p| p.to_str().map(|s| s.to_string()))
+            .and_then(|p| p.to_str().map(String::from))
     });
     let Some(bin) = bin else {
         return;
@@ -840,7 +843,7 @@ fn doctor_fix_hooks(dc: &mut DoctorCounters, settings_path: &Path, settings: &se
                     .and_then(|a| a.first())
                     .and_then(|c| c["command"].as_str())
                     .filter(|c| c.contains("tokensave"))
-                    .map(|s| s.to_string())
+                    .map(String::from)
             })
         });
 
@@ -882,7 +885,7 @@ fn doctor_check_permissions(dc: &mut DoctorCounters, settings: &serde_json::Valu
     let expected = expected_tool_perms();
     let missing: Vec<&String> = expected
         .iter()
-        .filter(|p| !installed.iter().any(|i| *i == p.as_str()))
+        .filter(|p| !installed.contains(&p.as_str()))
         .collect();
 
     if missing.is_empty() {
@@ -1030,7 +1033,7 @@ fn doctor_clean_local_settings(
         return false;
     }
 
-    let is_empty = local_val.as_object().is_some_and(|obj| obj.is_empty());
+    let is_empty = local_val.as_object().is_some_and(serde_json::Map::is_empty);
     if is_empty {
         if std::fs::remove_file(local_settings_path).is_ok() {
             dc.warn(&format!(
@@ -1061,11 +1064,11 @@ fn clean_orphaned_local_mcp_keys(local_val: &mut serde_json::Value) {
     let no_local_servers = local_val
         .get("enabledMcpjsonServers")
         .and_then(|v| v.as_array())
-        .is_some_and(|a| a.is_empty())
+        .is_some_and(std::vec::Vec::is_empty)
         && local_val
             .get("mcpServers")
             .and_then(|v| v.as_object())
-            .is_none_or(|o| o.is_empty());
+            .is_none_or(serde_json::Map::is_empty);
     if no_local_servers {
         local_val
             .as_object_mut()
@@ -1121,13 +1124,12 @@ fn warn_missing_permissions(settings: &serde_json::Value) {
     let expected = expected_tool_perms();
     let missing_count = expected
         .iter()
-        .filter(|p| !installed.iter().any(|i| *i == p.as_str()))
+        .filter(|p| !installed.contains(&p.as_str()))
         .count();
 
     if missing_count > 0 {
         eprintln!(
-            "\x1b[33mwarning: {} new tokensave tool(s) not yet permitted. Run `tokensave install` to update.\x1b[0m",
-            missing_count
+            "\x1b[33mwarning: {missing_count} new tokensave tool(s) not yet permitted. Run `tokensave install` to update.\x1b[0m"
         );
     }
 }

--- a/src/agents/claude.rs
+++ b/src/agents/claude.rs
@@ -886,10 +886,7 @@ fn doctor_check_permissions(dc: &mut DoctorCounters, settings: &serde_json::Valu
         .collect();
 
     if missing.is_empty() {
-        dc.pass(&format!(
-            "All {} tool permissions granted",
-            expected.len()
-        ));
+        dc.pass(&format!("All {} tool permissions granted", expected.len()));
     } else {
         dc.fail(&format!(
             "{} tool permission(s) missing — run `tokensave install`",

--- a/src/agents/claude.rs
+++ b/src/agents/claude.rs
@@ -13,8 +13,8 @@ use serde_json::json;
 use crate::errors::{Result, TokenSaveError};
 
 use super::{
-    backup_config_file, load_json_file_strict, safe_write_json_file, write_json_file,
-    AgentIntegration, DoctorCounters, HealthcheckContext, InstallContext, EXPECTED_TOOL_PERMS,
+    backup_config_file, expected_tool_perms, load_json_file_strict, safe_write_json_file,
+    write_json_file, AgentIntegration, DoctorCounters, HealthcheckContext, InstallContext,
 };
 
 /// Claude Code agent.
@@ -41,7 +41,7 @@ impl AgentIntegration for ClaudeIntegration {
         let mut settings = load_json_file_strict(&settings_path)?;
         install_migrate_old_mcp(&mut settings, &settings_path);
         install_hook(&mut settings, &ctx.tokensave_bin);
-        install_permissions(&mut settings, ctx.tool_permissions);
+        install_permissions(&mut settings, &ctx.tool_permissions);
         write_json_file(&settings_path, &settings)?;
 
         install_claude_md_rules(&claude_md_path)?;
@@ -225,7 +225,7 @@ fn install_single_hook(
 }
 
 /// Add MCP tool permissions (idempotent).
-fn install_permissions(settings: &mut serde_json::Value, tool_permissions: &[&str]) {
+fn install_permissions(settings: &mut serde_json::Value, tool_permissions: &[String]) {
     let existing: Vec<String> = settings["permissions"]["allow"]
         .as_array()
         .map(|arr| {
@@ -236,8 +236,8 @@ fn install_permissions(settings: &mut serde_json::Value, tool_permissions: &[&st
         .unwrap_or_default();
     let mut allow: Vec<String> = existing;
     for tool in tool_permissions {
-        if !allow.iter().any(|e| e == *tool) {
-            allow.push(tool.to_string());
+        if !allow.iter().any(|e| e == tool) {
+            allow.push(tool.clone());
         }
     }
     allow.sort();
@@ -879,15 +879,16 @@ fn doctor_check_permissions(dc: &mut DoctorCounters, settings: &serde_json::Valu
         .map(|arr| arr.iter().filter_map(|v| v.as_str()).collect())
         .unwrap_or_default();
 
-    let missing: Vec<&&str> = EXPECTED_TOOL_PERMS
+    let expected = expected_tool_perms();
+    let missing: Vec<&String> = expected
         .iter()
-        .filter(|p| !installed.contains(p))
+        .filter(|p| !installed.iter().any(|i| *i == p.as_str()))
         .collect();
 
     if missing.is_empty() {
         dc.pass(&format!(
             "All {} tool permissions granted",
-            EXPECTED_TOOL_PERMS.len()
+            expected.len()
         ));
     } else {
         dc.fail(&format!(
@@ -895,13 +896,13 @@ fn doctor_check_permissions(dc: &mut DoctorCounters, settings: &serde_json::Valu
             missing.len()
         ));
         for perm in &missing {
-            dc.info(&format!("missing: {}", perm));
+            dc.info(&format!("missing: {perm}"));
         }
     }
 
     let stale: Vec<&&str> = installed
         .iter()
-        .filter(|p| p.starts_with("mcp__tokensave__") && !EXPECTED_TOOL_PERMS.contains(p))
+        .filter(|p| p.starts_with("mcp__tokensave__") && !expected.contains(&p.to_string()))
         .collect();
     if !stale.is_empty() {
         dc.warn(&format!(
@@ -1120,9 +1121,10 @@ fn warn_missing_permissions(settings: &serde_json::Value) {
         .map(|arr| arr.iter().filter_map(|v| v.as_str()).collect())
         .unwrap_or_default();
 
-    let missing_count = EXPECTED_TOOL_PERMS
+    let expected = expected_tool_perms();
+    let missing_count = expected
         .iter()
-        .filter(|p| !installed.contains(p))
+        .filter(|p| !installed.iter().any(|i| *i == p.as_str()))
         .count();
 
     if missing_count > 0 {

--- a/src/agents/cline.rs
+++ b/src/agents/cline.rs
@@ -102,7 +102,7 @@ impl AgentIntegration for ClineIntegration {
 // Uninstall helpers
 // ---------------------------------------------------------------------------
 
-/// Remove MCP server entry from Cline's cline_mcp_settings.json.
+/// Remove MCP server entry from Cline's `cline_mcp_settings.json`.
 fn uninstall_mcp_server(settings_path: &Path) {
     if !settings_path.exists() {
         eprintln!("  {} not found, skipping", settings_path.display());
@@ -137,7 +137,7 @@ fn uninstall_mcp_server(settings_path: &Path) {
 
     let is_empty = settings.as_object().is_some_and(|o| {
         o.iter()
-            .all(|(k, v)| k == "mcpServers" && v.as_object().is_some_and(|m| m.is_empty()))
+            .all(|(k, v)| k == "mcpServers" && v.as_object().is_some_and(serde_json::Map::is_empty))
     });
 
     if is_empty {
@@ -160,7 +160,7 @@ fn uninstall_mcp_server(settings_path: &Path) {
 // Healthcheck helpers
 // ---------------------------------------------------------------------------
 
-/// Check Cline's cline_mcp_settings.json has tokensave MCP server registered.
+/// Check Cline's `cline_mcp_settings.json` has tokensave MCP server registered.
 fn doctor_check_settings(dc: &mut DoctorCounters, home: &Path) {
     let settings_path = cline_ext_dir(home).join("settings/cline_mcp_settings.json");
 

--- a/src/agents/codex.rs
+++ b/src/agents/codex.rs
@@ -11,8 +11,8 @@ use std::path::Path;
 use crate::errors::{Result, TokenSaveError};
 
 use super::{
-    load_toml_file, write_toml_file, AgentIntegration, DoctorCounters, HealthcheckContext,
-    InstallContext, TOOL_NAMES,
+    load_toml_file, tool_names, write_toml_file, AgentIntegration, DoctorCounters,
+    HealthcheckContext, InstallContext,
 };
 
 /// OpenAI Codex CLI agent.
@@ -118,7 +118,7 @@ fn install_mcp_server(config_path: &Path, tokensave_bin: &str) -> Result<()> {
 
     // Auto-approve all tokensave tools so Codex doesn't prompt for each one
     let mut tools_table = toml::map::Map::new();
-    for tool_name in TOOL_NAMES {
+    for tool_name in tool_names() {
         let mut tool_config = toml::map::Map::new();
         tool_config.insert(
             "approval_mode".to_string(),
@@ -315,16 +315,14 @@ fn doctor_check_config(dc: &mut DoctorCounters, config_path: &Path) {
             .count()
     });
 
-    if auto_count >= TOOL_NAMES.len() {
-        dc.pass(&format!(
-            "All {} tools set to auto-approve",
-            TOOL_NAMES.len()
-        ));
+    let tools = tool_names();
+    let tools_len = tools.len();
+    if auto_count >= tools_len {
+        dc.pass(&format!("All {} tools set to auto-approve", tools_len));
     } else if auto_count > 0 {
         dc.warn(&format!(
             "{}/{} tools auto-approved — run `tokensave install --agent codex` to update",
-            auto_count,
-            TOOL_NAMES.len()
+            auto_count, tools_len
         ));
     } else {
         dc.warn("No tools auto-approved — Codex will prompt for each tool call");

--- a/src/agents/codex.rs
+++ b/src/agents/codex.rs
@@ -1,5 +1,5 @@
 // Rust guideline compliant 2025-10-17
-//! OpenAI Codex CLI agent integration.
+//! `OpenAI` Codex CLI agent integration.
 //!
 //! Handles registration of the tokensave MCP server in Codex's config
 //! file (`~/.codex/config.toml`), per-tool auto-approval settings,
@@ -15,7 +15,7 @@ use super::{
     HealthcheckContext, InstallContext,
 };
 
-/// OpenAI Codex CLI agent.
+/// `OpenAI` Codex CLI agent.
 pub struct CodexIntegration;
 
 impl AgentIntegration for CodexIntegration {
@@ -124,7 +124,7 @@ fn install_mcp_server(config_path: &Path, tokensave_bin: &str) -> Result<()> {
             "approval_mode".to_string(),
             toml::Value::String("auto".to_string()),
         );
-        tools_table.insert(tool_name.to_string(), toml::Value::Table(tool_config));
+        tools_table.insert(tool_name.clone(), toml::Value::Table(tool_config));
     }
     server_table.insert("tools".to_string(), toml::Value::Table(tools_table));
 
@@ -244,8 +244,7 @@ fn uninstall_prompt_rules(agents_md: &Path) {
     let after_marker = start + marker.len();
     let end = contents[after_marker..]
         .find("\n## ")
-        .map(|pos| after_marker + pos)
-        .unwrap_or(contents.len());
+        .map_or(contents.len(), |pos| after_marker + pos);
     let mut new_contents = String::new();
     new_contents.push_str(contents[..start].trim_end());
     let remainder = &contents[end..];
@@ -318,11 +317,10 @@ fn doctor_check_config(dc: &mut DoctorCounters, config_path: &Path) {
     let tools = tool_names();
     let tools_len = tools.len();
     if auto_count >= tools_len {
-        dc.pass(&format!("All {} tools set to auto-approve", tools_len));
+        dc.pass(&format!("All {tools_len} tools set to auto-approve"));
     } else if auto_count > 0 {
         dc.warn(&format!(
-            "{}/{} tools auto-approved — run `tokensave install --agent codex` to update",
-            auto_count, tools_len
+            "{auto_count}/{tools_len} tools auto-approved — run `tokensave install --agent codex` to update"
         ));
     } else {
         dc.warn("No tools auto-approved — Codex will prompt for each tool call");

--- a/src/agents/copilot.rs
+++ b/src/agents/copilot.rs
@@ -190,7 +190,7 @@ fn uninstall_vscode_mcp_server(settings_path: &Path) {
         let servers_empty = mcp
             .get("servers")
             .and_then(|v| v.as_object())
-            .is_some_and(|o| o.is_empty());
+            .is_some_and(serde_json::Map::is_empty);
         if servers_empty {
             mcp.as_object_mut().map(|o| o.remove("servers"));
         }
@@ -199,7 +199,7 @@ fn uninstall_vscode_mcp_server(settings_path: &Path) {
         let mcp_empty = settings
             .get("mcp")
             .and_then(|v| v.as_object())
-            .is_some_and(|o| o.is_empty());
+            .is_some_and(serde_json::Map::is_empty);
         if mcp_empty {
             settings.as_object_mut().map(|o| o.remove("mcp"));
         }
@@ -241,7 +241,7 @@ fn uninstall_cli_mcp_server(settings_path: &Path) {
     if servers.is_empty() {
         settings.as_object_mut().map(|o| o.remove("mcpServers"));
     }
-    let is_empty = settings.as_object().is_some_and(|o| o.is_empty());
+    let is_empty = settings.as_object().is_some_and(serde_json::Map::is_empty);
     if is_empty {
         std::fs::remove_file(settings_path).ok();
         eprintln!(

--- a/src/agents/cursor.rs
+++ b/src/agents/cursor.rs
@@ -131,7 +131,7 @@ fn uninstall_mcp_server(mcp_path: &Path) {
 
     let is_empty = settings.as_object().is_some_and(|o| {
         o.iter()
-            .all(|(k, v)| k == "mcpServers" && v.as_object().is_some_and(|m| m.is_empty()))
+            .all(|(k, v)| k == "mcpServers" && v.as_object().is_some_and(serde_json::Map::is_empty))
     });
 
     if is_empty {

--- a/src/agents/gemini.rs
+++ b/src/agents/gemini.rs
@@ -190,7 +190,7 @@ fn uninstall_mcp_server(settings_path: &Path) {
     if servers.is_empty() {
         settings.as_object_mut().map(|o| o.remove("mcpServers"));
     }
-    let is_empty = settings.as_object().is_some_and(|o| o.is_empty());
+    let is_empty = settings.as_object().is_some_and(serde_json::Map::is_empty);
     if is_empty {
         std::fs::remove_file(settings_path).ok();
         eprintln!(
@@ -226,8 +226,7 @@ fn uninstall_prompt_rules(gemini_md: &Path) {
     let after_marker = start + marker.len();
     let end = contents[after_marker..]
         .find("\n## ")
-        .map(|pos| after_marker + pos)
-        .unwrap_or(contents.len());
+        .map_or(contents.len(), |pos| after_marker + pos);
     let mut new_contents = String::new();
     new_contents.push_str(contents[..start].trim_end());
     let remainder = &contents[end..];
@@ -295,7 +294,7 @@ fn doctor_check_settings(dc: &mut DoctorCounters, home: &Path) {
     // Check trust flag
     let is_trusted = server
         .get("trust")
-        .and_then(|v| v.as_bool())
+        .and_then(serde_json::Value::as_bool)
         .unwrap_or(false);
     if is_trusted {
         dc.pass("MCP server has trust: true (tools auto-approved)");

--- a/src/agents/mod.rs
+++ b/src/agents/mod.rs
@@ -1188,7 +1188,10 @@ mod git_hook_tests {
 }
 
 pub fn tool_names() -> Vec<String> {
-    get_tool_definitions().iter().map(|t| t.name.clone()).collect()
+    get_tool_definitions()
+        .iter()
+        .map(|t| t.name.clone())
+        .collect()
 }
 
 pub fn expected_tool_perms() -> Vec<String> {

--- a/src/agents/mod.rs
+++ b/src/agents/mod.rs
@@ -1,5 +1,5 @@
 // Rust guideline compliant 2025-10-17
-//! Agent integration layer for CLI tools (Claude Code, OpenCode, Codex, etc.).
+//! Agent integration layer for CLI tools (Claude Code, `OpenCode`, Codex, etc.).
 //!
 //! Each supported agent implements the [`AgentIntegration`] trait which provides
 //! `install`, `uninstall`, and `healthcheck` operations. The MCP server
@@ -185,7 +185,7 @@ impl DoctorCounters {
 // ---------------------------------------------------------------------------
 
 /// Load a JSON file, returning an empty object on missing/invalid.
-/// Use this for **read-only** paths (healthcheck, has_tokensave, etc.).
+/// Use this for **read-only** paths (healthcheck, `has_tokensave`, etc.).
 /// For install/edit paths, use [`load_json_file_strict`] instead.
 pub fn load_json_file(path: &Path) -> serde_json::Value {
     if path.exists() {
@@ -560,9 +560,8 @@ fn remove_trailing_commas(input: &str) -> String {
 /// Use this for **read-only** paths. For install/edit paths, use
 /// [`load_jsonc_file_strict`] instead.
 pub fn load_jsonc_file(path: &Path) -> serde_json::Value {
-    let contents = match std::fs::read_to_string(path) {
-        Ok(s) => s,
-        Err(_) => return serde_json::json!({}),
+    let Ok(contents) = std::fs::read_to_string(path) else {
+        return serde_json::json!({});
     };
     parse_jsonc(&contents)
 }

--- a/src/agents/mod.rs
+++ b/src/agents/mod.rs
@@ -23,6 +23,7 @@ use std::path::{Path, PathBuf};
 
 use crate::errors::Result;
 use crate::errors::TokenSaveError;
+use crate::mcp::tools::get_tool_definitions;
 
 pub use antigravity::AntigravityIntegration;
 pub use claude::ClaudeIntegration;
@@ -75,7 +76,7 @@ pub trait AgentIntegration {
 pub struct InstallContext {
     pub home: PathBuf,
     pub tokensave_bin: String,
-    pub tool_permissions: &'static [&'static str],
+    pub tool_permissions: Vec<String>,
 }
 
 /// Context passed to [`AgentIntegration::healthcheck`].
@@ -1186,67 +1187,16 @@ mod git_hook_tests {
     }
 }
 
-/// Bare MCP tool names (without any agent-specific prefix).
-pub const TOOL_NAMES: &[&str] = &[
-    "tokensave_affected",
-    "tokensave_callees",
-    "tokensave_callers",
-    "tokensave_changelog",
-    "tokensave_circular",
-    "tokensave_complexity",
-    "tokensave_context",
-    "tokensave_coupling",
-    "tokensave_dead_code",
-    "tokensave_diff_context",
-    "tokensave_distribution",
-    "tokensave_doc_coverage",
-    "tokensave_files",
-    "tokensave_god_class",
-    "tokensave_hotspots",
-    "tokensave_impact",
-    "tokensave_inheritance_depth",
-    "tokensave_largest",
-    "tokensave_module_api",
-    "tokensave_node",
-    "tokensave_rank",
-    "tokensave_recursion",
-    "tokensave_rename_preview",
-    "tokensave_search",
-    "tokensave_similar",
-    "tokensave_status",
-    "tokensave_unused_imports",
-];
+pub fn tool_names() -> Vec<String> {
+    get_tool_definitions().iter().map(|t| t.name.clone()).collect()
+}
 
-/// Expected MCP tool permissions for the current version (Claude Code format).
-pub const EXPECTED_TOOL_PERMS: &[&str] = &[
-    "mcp__tokensave__tokensave_affected",
-    "mcp__tokensave__tokensave_callees",
-    "mcp__tokensave__tokensave_callers",
-    "mcp__tokensave__tokensave_changelog",
-    "mcp__tokensave__tokensave_circular",
-    "mcp__tokensave__tokensave_complexity",
-    "mcp__tokensave__tokensave_context",
-    "mcp__tokensave__tokensave_coupling",
-    "mcp__tokensave__tokensave_dead_code",
-    "mcp__tokensave__tokensave_diff_context",
-    "mcp__tokensave__tokensave_distribution",
-    "mcp__tokensave__tokensave_doc_coverage",
-    "mcp__tokensave__tokensave_files",
-    "mcp__tokensave__tokensave_god_class",
-    "mcp__tokensave__tokensave_hotspots",
-    "mcp__tokensave__tokensave_impact",
-    "mcp__tokensave__tokensave_inheritance_depth",
-    "mcp__tokensave__tokensave_largest",
-    "mcp__tokensave__tokensave_module_api",
-    "mcp__tokensave__tokensave_node",
-    "mcp__tokensave__tokensave_rank",
-    "mcp__tokensave__tokensave_recursion",
-    "mcp__tokensave__tokensave_rename_preview",
-    "mcp__tokensave__tokensave_search",
-    "mcp__tokensave__tokensave_similar",
-    "mcp__tokensave__tokensave_status",
-    "mcp__tokensave__tokensave_unused_imports",
-];
+pub fn expected_tool_perms() -> Vec<String> {
+    get_tool_definitions()
+        .iter()
+        .map(|t| format!("mcp__tokensave__{}", t.name))
+        .collect()
+}
 
 #[cfg(test)]
 #[allow(clippy::unwrap_used, clippy::expect_used)]

--- a/src/agents/opencode.rs
+++ b/src/agents/opencode.rs
@@ -1,9 +1,9 @@
 // Rust guideline compliant 2025-10-17
-//! OpenCode agent integration.
+//! `OpenCode` agent integration.
 //!
-//! Handles registration of the tokensave MCP server in OpenCode's config
+//! Handles registration of the tokensave MCP server in `OpenCode`'s config
 //! file (`$HOME/.config/opencode/opencode.json` or `$XDG_CONFIG_HOME/opencode/opencode.json`),
-//! and prompt rules via `OPENCODE.md`. OpenCode has no hook system or
+//! and prompt rules via `OPENCODE.md`. `OpenCode` has no hook system or
 //! declarative tool permissions — it uses interactive runtime approval.
 
 use std::io::Write;
@@ -18,7 +18,7 @@ use super::{
     AgentIntegration, DoctorCounters, HealthcheckContext, InstallContext,
 };
 
-/// OpenCode agent.
+/// `OpenCode` agent.
 pub struct OpenCodeIntegration;
 
 impl AgentIntegration for OpenCodeIntegration {
@@ -222,7 +222,7 @@ fn uninstall_mcp_server(config_path: &Path) {
     if mcp.is_empty() {
         config.as_object_mut().map(|o| o.remove("mcp"));
     }
-    let is_empty = config.as_object().is_some_and(|o| o.is_empty());
+    let is_empty = config.as_object().is_some_and(serde_json::Map::is_empty);
     if is_empty {
         std::fs::remove_file(config_path).ok();
         eprintln!(
@@ -258,8 +258,7 @@ fn uninstall_prompt_rules(prompt_path: &Path) {
     let after_marker = start + marker.len();
     let end = contents[after_marker..]
         .find("\n## ")
-        .map(|pos| after_marker + pos)
-        .unwrap_or(contents.len());
+        .map_or(contents.len(), |pos| after_marker + pos);
     let mut new_contents = String::new();
     new_contents.push_str(contents[..start].trim_end());
     let remainder = &contents[end..];

--- a/src/agents/roo_code.rs
+++ b/src/agents/roo_code.rs
@@ -102,7 +102,7 @@ impl AgentIntegration for RooCodeIntegration {
 // Uninstall helpers
 // ---------------------------------------------------------------------------
 
-/// Remove MCP server entry from Roo Code's cline_mcp_settings.json.
+/// Remove MCP server entry from Roo Code's `cline_mcp_settings.json`.
 fn uninstall_mcp_server(settings_path: &Path) {
     if !settings_path.exists() {
         eprintln!("  {} not found, skipping", settings_path.display());
@@ -137,7 +137,7 @@ fn uninstall_mcp_server(settings_path: &Path) {
 
     let is_empty = settings.as_object().is_some_and(|o| {
         o.iter()
-            .all(|(k, v)| k == "mcpServers" && v.as_object().is_some_and(|m| m.is_empty()))
+            .all(|(k, v)| k == "mcpServers" && v.as_object().is_some_and(serde_json::Map::is_empty))
     });
 
     if is_empty {
@@ -160,7 +160,7 @@ fn uninstall_mcp_server(settings_path: &Path) {
 // Healthcheck helpers
 // ---------------------------------------------------------------------------
 
-/// Check Roo Code's cline_mcp_settings.json has tokensave MCP server registered.
+/// Check Roo Code's `cline_mcp_settings.json` has tokensave MCP server registered.
 fn doctor_check_settings(dc: &mut DoctorCounters, home: &Path) {
     let settings_path = roo_ext_dir(home).join("settings/cline_mcp_settings.json");
 

--- a/src/agents/zed.rs
+++ b/src/agents/zed.rs
@@ -139,7 +139,7 @@ fn uninstall_context_server(settings_path: &Path) {
     let cs_empty = settings
         .get("context_servers")
         .and_then(|v| v.as_object())
-        .is_some_and(|o| o.is_empty());
+        .is_some_and(serde_json::Map::is_empty);
     if cs_empty {
         settings
             .as_object_mut()

--- a/src/branch.rs
+++ b/src/branch.rs
@@ -21,7 +21,9 @@ fn current_branch_gix(project_root: &Path) -> Option<String> {
     let head = repo.head().ok()?;
     let name = head.name().as_bstr();
     let name_str = std::str::from_utf8(name).ok()?;
-    name_str.strip_prefix("refs/heads/").map(|s| s.to_string())
+    name_str
+        .strip_prefix("refs/heads/")
+        .map(std::string::ToString::to_string)
 }
 
 fn current_branch_git(project_root: &Path) -> Option<String> {
@@ -36,7 +38,7 @@ fn current_branch_git(project_root: &Path) -> Option<String> {
     let name = std::str::from_utf8(&output.stdout).ok()?;
     name.strip_prefix("refs/heads/")
         .and_then(|s| s.strip_suffix('\n'))
-        .map(|s| s.to_string())
+        .map(std::string::ToString::to_string)
 }
 
 /// Auto-detects the default branch (main or master).

--- a/src/cloud.rs
+++ b/src/cloud.rs
@@ -79,13 +79,11 @@ struct CountriesResponse {
 /// Returns a list of emoji flags, or an empty vec on failure.
 pub fn fetch_country_flags() -> Vec<String> {
     let agent = agent_with_timeout(Duration::from_millis(500));
-    let mut resp = match agent.get(&format!("{WORKER_URL}/countries")).call() {
-        Ok(r) => r,
-        Err(_) => return Vec::new(),
+    let Ok(mut resp) = agent.get(&format!("{WORKER_URL}/countries")).call() else {
+        return Vec::new();
     };
-    let parsed: CountriesResponse = match resp.body_mut().read_json() {
-        Ok(r) => r,
-        Err(_) => return Vec::new(),
+    let Ok(parsed): Result<CountriesResponse, _> = resp.body_mut().read_json() else {
+        return Vec::new();
     };
     parsed.flags
 }
@@ -177,7 +175,6 @@ pub fn is_newer_version(current: &str, latest: &str) -> bool {
             }
             // Same base version, same channel
             match (cpre, lpre) {
-                (None, None) => false,
                 (Some(a), Some(b)) => b > a,
                 _ => false,
             }

--- a/src/config.rs
+++ b/src/config.rs
@@ -10,10 +10,10 @@ use crate::errors::{Result, TokenSaveError};
 /// Name of the configuration file stored inside the `.tokensave` directory.
 pub const CONFIG_FILENAME: &str = "config.json";
 
-/// Name of the hidden directory used to store TokenSave metadata.
+/// Name of the hidden directory used to store `TokenSave` metadata.
 pub const TOKENSAVE_DIR: &str = ".tokensave";
 
-/// Configuration for a TokenSave project.
+/// Configuration for a `TokenSave` project.
 ///
 /// Controls which files are indexed, size limits, and feature toggles.
 /// Language inclusion is derived automatically from the installed
@@ -124,7 +124,7 @@ pub fn save_config(project_root: &Path, config: &TokenSaveConfig) -> Result<()> 
     let tmp_path = config_path.with_extension("tmp");
 
     let json = serde_json::to_string_pretty(config).map_err(|e| TokenSaveError::Config {
-        message: format!("failed to serialize config: {}", e),
+        message: format!("failed to serialize config: {e}"),
     })?;
 
     fs::write(&tmp_path, &json).map_err(|e| TokenSaveError::Config {
@@ -225,7 +225,7 @@ pub fn resolve_path(path: Option<String>) -> PathBuf {
 /// Walks from `start` upward looking for a `.tokensave/tokensave.db`.
 ///
 /// Returns the first ancestor directory (inclusive) that contains an
-/// initialised TokenSave project, or `None` if the filesystem root is
+/// initialised `TokenSave` project, or `None` if the filesystem root is
 /// reached without finding one.
 pub fn discover_project_root(start: &Path) -> Option<PathBuf> {
     let mut dir = start.to_path_buf();
@@ -240,18 +240,17 @@ pub fn discover_project_root(start: &Path) -> Option<PathBuf> {
 }
 
 /// Like [`resolve_path`], but when `path` is `None` it walks up from `cwd`
-/// to find the nearest initialised TokenSave project before falling back to
+/// to find the nearest initialised `TokenSave` project before falling back to
 /// `cwd` itself.
 ///
 /// Used by `serve`, `sync`, and `status`. NOT used by `init` (which must
 /// create a fresh project at the target directory).
 pub fn resolve_path_with_discovery(path: Option<String>) -> PathBuf {
-    match path {
-        Some(p) => PathBuf::from(p),
-        None => {
-            let cwd = std::env::current_dir().unwrap_or_else(|_| PathBuf::from("."));
-            discover_project_root(&cwd).unwrap_or(cwd)
-        }
+    if let Some(p) = path {
+        PathBuf::from(p)
+    } else {
+        let cwd = std::env::current_dir().unwrap_or_else(|_| PathBuf::from("."));
+        discover_project_root(&cwd).unwrap_or(cwd)
     }
 }
 

--- a/src/context/builder.rs
+++ b/src/context/builder.rs
@@ -43,9 +43,9 @@ impl<'a> ContextBuilder<'a> {
 
         // Step 4: extract code blocks from source files
         let code_blocks = if options.include_code {
-            let blocks = self.extract_code_blocks(&entry_points, options).await?;
+            let blocks = self.extract_code_blocks(&entry_points, options)?;
             if options.merge_adjacent {
-                self.merge_adjacent_blocks(blocks).await
+                self.merge_adjacent_blocks(blocks)
             } else {
                 blocks
             }
@@ -54,10 +54,10 @@ impl<'a> ContextBuilder<'a> {
         };
 
         // Collect unique related files
-        let related_files = self.collect_related_files(&subgraph);
+        let related_files = Self::collect_related_files(&subgraph);
 
         // Build summary
-        let summary = self.build_summary(query, &entry_points, &subgraph);
+        let summary = Self::build_summary(query, &entry_points, &subgraph);
 
         let seen_node_ids: Vec<String> = entry_points.iter().map(|n| n.id.clone()).collect();
 
@@ -89,7 +89,7 @@ impl<'a> ContextBuilder<'a> {
     /// Reads the source file and extracts the code for a node.
     ///
     /// Returns `None` if the file cannot be read or the line range is invalid.
-    pub async fn get_code(&self, node: &Node) -> Result<Option<String>> {
+    pub fn get_code(&self, node: &Node) -> Result<Option<String>> {
         debug_assert!(
             !node.file_path.is_empty(),
             "get_code called with empty file_path"
@@ -104,9 +104,8 @@ impl<'a> ContextBuilder<'a> {
                 return Ok(None);
             }
         }
-        let content = match fs::read_to_string(&file_path) {
-            Ok(c) => c,
-            Err(_) => return Ok(None),
+        let Ok(content) = fs::read_to_string(&file_path) else {
+            return Ok(None);
         };
 
         let lines: Vec<&str> = content.lines().collect();
@@ -165,7 +164,8 @@ impl<'a> ContextBuilder<'a> {
         // --- FTS search: full query ---
         let search_results = self.db.search_nodes(query, options.search_limit).await?;
         for sr in search_results {
-            if self.score_passes(sr.score, options.min_score) && seen_ids.insert(sr.node.id.clone())
+            if Self::score_passes(sr.score, options.min_score)
+                && seen_ids.insert(sr.node.id.clone())
             {
                 candidates.push(sr);
             }
@@ -178,7 +178,7 @@ impl<'a> ContextBuilder<'a> {
             }
             let results = self.db.search_nodes(symbol, options.search_limit).await?;
             for sr in results {
-                if self.score_passes(sr.score, options.min_score)
+                if Self::score_passes(sr.score, options.min_score)
                     && seen_ids.insert(sr.node.id.clone())
                 {
                     candidates.push(sr);
@@ -194,7 +194,7 @@ impl<'a> ContextBuilder<'a> {
             }
             let results = self.db.search_nodes(stem, options.search_limit).await?;
             for sr in results {
-                if self.score_passes(sr.score, options.min_score)
+                if Self::score_passes(sr.score, options.min_score)
                     && seen_ids.insert(sr.node.id.clone())
                 {
                     candidates.push(sr);
@@ -209,7 +209,7 @@ impl<'a> ContextBuilder<'a> {
             }
             let results = self.db.search_nodes(keyword, options.search_limit).await?;
             for sr in results {
-                if self.score_passes(sr.score, options.min_score)
+                if Self::score_passes(sr.score, options.min_score)
                     && seen_ids.insert(sr.node.id.clone())
                 {
                     candidates.push(sr);
@@ -261,7 +261,7 @@ impl<'a> ContextBuilder<'a> {
         // --- Co-occurrence boost for multi-term queries ---
         let query_terms: Vec<String> = query
             .split_whitespace()
-            .map(|w| w.to_lowercase())
+            .map(str::to_lowercase)
             .filter(|w| w.len() >= 3)
             .collect();
         if query_terms.len() >= 2 {
@@ -362,7 +362,7 @@ impl<'a> ContextBuilder<'a> {
     }
 
     /// Extracts code blocks for the entry-point nodes.
-    async fn extract_code_blocks(
+    fn extract_code_blocks(
         &self,
         entry_points: &[Node],
         options: &BuildContextOptions,
@@ -382,7 +382,7 @@ impl<'a> ContextBuilder<'a> {
                 break;
             }
 
-            if let Some(code) = self.get_code(node).await? {
+            if let Some(code) = self.get_code(node)? {
                 let truncated = if code.len() > options.max_code_block_size {
                     let mut end = options.max_code_block_size;
                     // Ensure we land on a valid UTF-8 boundary
@@ -413,7 +413,7 @@ impl<'a> ContextBuilder<'a> {
 
     /// Merges code blocks from the same file that are adjacent or overlapping.
     /// Two blocks are "adjacent" if the gap between them is <= 5 lines.
-    async fn merge_adjacent_blocks(&self, blocks: Vec<CodeBlock>) -> Vec<CodeBlock> {
+    fn merge_adjacent_blocks(&self, blocks: Vec<CodeBlock>) -> Vec<CodeBlock> {
         if blocks.len() <= 1 {
             return blocks;
         }
@@ -460,7 +460,7 @@ impl<'a> ContextBuilder<'a> {
                         assertions: 0,
                         updated_at: 0,
                     };
-                    if let Ok(Some(code)) = self.get_code(&merged_node).await {
+                    if let Ok(Some(code)) = self.get_code(&merged_node) {
                         current.content = code;
                         current.end_line = new_end;
                     } else {
@@ -487,12 +487,12 @@ impl<'a> ContextBuilder<'a> {
     /// threshold. We accept any result whose score is positive (i.e. the FTS
     /// engine considered it a match) unless the caller explicitly set a
     /// non-default threshold above 0.
-    fn score_passes(&self, score: f64, min_score: f64) -> bool {
+    fn score_passes(score: f64, min_score: f64) -> bool {
         score > 0.0 && score >= min_score
     }
 
     /// Collects unique file paths from all nodes in the subgraph.
-    fn collect_related_files(&self, subgraph: &Subgraph) -> Vec<String> {
+    fn collect_related_files(subgraph: &Subgraph) -> Vec<String> {
         let mut seen: HashSet<String> = HashSet::new();
         let mut files: Vec<String> = Vec::new();
 
@@ -506,7 +506,7 @@ impl<'a> ContextBuilder<'a> {
     }
 
     /// Builds a human-readable summary string.
-    fn build_summary(&self, query: &str, entry_points: &[Node], subgraph: &Subgraph) -> String {
+    fn build_summary(query: &str, entry_points: &[Node], subgraph: &Subgraph) -> String {
         let ep_count = entry_points.len();
         let node_count = subgraph.nodes.len();
         let edge_count = subgraph.edges.len();
@@ -525,8 +525,8 @@ impl<'a> ContextBuilder<'a> {
 ///
 /// Recognizes the following patterns:
 /// - CamelCase words (e.g. `UserService`, `processRequest`)
-/// - snake_case words (e.g. `process_request`, `user_service`)
-/// - SCREAMING_SNAKE_CASE words (e.g. `MAX_RETRIES`)
+/// - `snake_case` words (e.g. `process_request`, `user_service`)
+/// - `SCREAMING_SNAKE_CASE` words (e.g. `MAX_RETRIES`)
 /// - Qualified paths with `::` separators (e.g. `crate::types::Node` yields `Node`)
 ///
 /// Common English stop words are filtered out.
@@ -725,7 +725,7 @@ fn classify_token(
 
 /// Split a compound name into individual words.
 ///
-/// Handles camelCase, PascalCase, and snake_case:
+/// Handles camelCase, `PascalCase`, and `snake_case`:
 /// - `getUserName` → `["get", "User", "Name"]`
 /// - `process_request` → `["process", "request"]`
 /// - `MAX_RETRIES` → `["MAX", "RETRIES"]`

--- a/src/context/formatter.rs
+++ b/src/context/formatter.rs
@@ -1,4 +1,5 @@
 use std::collections::HashMap;
+use std::fmt::Write as _;
 
 use crate::types::TaskContext;
 
@@ -18,7 +19,7 @@ pub fn format_context_as_markdown(context: &TaskContext) -> String {
     let mut out = String::new();
 
     out.push_str("## Code Context\n");
-    out.push_str(&format!("**Query:** {}\n\n", context.query));
+    let _ = write!(out, "**Query:** {}\n\n", context.query);
 
     // Entry Points
     out.push_str("### Entry Points\n");
@@ -26,15 +27,16 @@ pub fn format_context_as_markdown(context: &TaskContext) -> String {
         out.push_str("_No entry points found._\n\n");
     } else {
         for node in &context.entry_points {
-            out.push_str(&format!(
-                "- **{}** ({}) - {}:{}\n",
+            let _ = writeln!(
+                out,
+                "- **{}** ({}) - {}:{}",
                 node.name,
                 node.kind.as_str(),
                 node.file_path,
                 node.start_line,
-            ));
+            );
             if let Some(ref sig) = node.signature {
-                out.push_str(&format!("  `{}`\n", sig));
+                let _ = writeln!(out, "  `{sig}`");
             }
         }
         out.push('\n');
@@ -61,9 +63,9 @@ pub fn format_context_as_markdown(context: &TaskContext) -> String {
             let symbols = by_file.get(*file).unwrap_or(&Vec::new()).clone();
             let formatted: Vec<String> = symbols
                 .iter()
-                .map(|(name, line)| format!("{}:{}", name, line))
+                .map(|(name, line)| format!("{name}:{line}"))
                 .collect();
-            out.push_str(&format!("- {}: {}\n", file, formatted.join(", ")));
+            let _ = writeln!(out, "- {}: {}", file, formatted.join(", "));
         }
         out.push('\n');
     }
@@ -81,16 +83,16 @@ pub fn format_context_as_markdown(context: &TaskContext) -> String {
                     .entry_points
                     .iter()
                     .find(|n| &n.id == node_id)
-                    .map(|n| n.name.clone())
-                    .unwrap_or_else(|| node_id.clone())
+                    .map_or_else(|| node_id.clone(), |n| n.name.clone())
             } else {
                 "unknown".to_string()
             };
 
-            out.push_str(&format!(
-                "#### {} ({}:{})\n",
+            let _ = writeln!(
+                out,
+                "#### {} ({}:{})",
                 label, block.file_path, block.start_line,
-            ));
+            );
             out.push_str("```rust\n");
             out.push_str(&block.content);
             if !block.content.ends_with('\n') {

--- a/src/context/ranking.rs
+++ b/src/context/ranking.rs
@@ -3,17 +3,32 @@ use crate::types::{NodeKind, SearchResult, Visibility};
 /// Boost factor based on node kind.
 pub fn kind_boost(kind: &NodeKind) -> f64 {
     match kind {
-        NodeKind::Function | NodeKind::Method | NodeKind::StructMethod => 2.0,
-        NodeKind::Constructor | NodeKind::AbstractMethod | NodeKind::Procedure => 2.0,
+        NodeKind::Function
+        | NodeKind::Method
+        | NodeKind::StructMethod
+        | NodeKind::Constructor
+        | NodeKind::AbstractMethod
+        | NodeKind::Procedure => 2.0,
         NodeKind::ArrowFunction => 1.8,
 
-        NodeKind::Struct | NodeKind::Class | NodeKind::Enum | NodeKind::Trait => 1.5,
-        NodeKind::Interface | NodeKind::InterfaceType => 1.5,
-        NodeKind::DataClass | NodeKind::SealedClass | NodeKind::CaseClass => 1.5,
-        NodeKind::Record | NodeKind::Union => 1.5,
+        NodeKind::Struct
+        | NodeKind::Class
+        | NodeKind::Enum
+        | NodeKind::Trait
+        | NodeKind::Interface
+        | NodeKind::InterfaceType
+        | NodeKind::DataClass
+        | NodeKind::SealedClass
+        | NodeKind::CaseClass
+        | NodeKind::Record
+        | NodeKind::Union => 1.5,
 
-        NodeKind::Module | NodeKind::Impl | NodeKind::Namespace => 1.2,
-        NodeKind::ScalaObject | NodeKind::CompanionObject | NodeKind::KotlinObject => 1.2,
+        NodeKind::Module
+        | NodeKind::Impl
+        | NodeKind::Namespace
+        | NodeKind::ScalaObject
+        | NodeKind::CompanionObject
+        | NodeKind::KotlinObject => 1.2,
 
         NodeKind::Field | NodeKind::Property | NodeKind::ValField | NodeKind::VarField => 0.5,
         NodeKind::EnumVariant => 0.3,
@@ -54,10 +69,10 @@ pub fn path_boost(file_path: &str) -> f64 {
 }
 
 /// Applies a log-scale connectivity boost based on incoming call counts.
-/// `call_counts` maps node_id → incoming "calls" edge count.
-pub fn apply_connectivity_boost(
+/// `call_counts` maps `node_id` → incoming "calls" edge count.
+pub fn apply_connectivity_boost<S: std::hash::BuildHasher>(
     candidates: &mut [SearchResult],
-    call_counts: &std::collections::HashMap<String, u64>,
+    call_counts: &std::collections::HashMap<String, u64, S>,
 ) {
     for candidate in candidates.iter_mut() {
         let count = call_counts.get(&candidate.node.id).copied().unwrap_or(0);

--- a/src/daemon.rs
+++ b/src/daemon.rs
@@ -447,11 +447,15 @@ fn daemon_log(msg: &str) {
 /// Returns `true` if the daemon exited due to an upgrade (binary changed on
 /// disk). The caller should exit with a non-zero code so the service manager
 /// restarts with the new version.
-pub async fn run(foreground: bool) -> Result<bool> {
+pub async fn run(foreground: bool, debounce_override: Option<String>) -> Result<bool> {
     let daemon = build_daemon()?;
 
     let config = crate::user_config::UserConfig::load();
-    let debounce = parse_duration(&config.daemon_debounce).unwrap_or(Duration::from_secs(15));
+    let debounce = if let Some(ref override_str) = debounce_override {
+        parse_duration(override_str).unwrap_or(Duration::from_secs(2))
+    } else {
+        parse_duration(&config.daemon_debounce).unwrap_or(Duration::from_secs(2))
+    };
 
     if foreground {
         // Already inside a tokio runtime — call run_loop directly.

--- a/src/daemon.rs
+++ b/src/daemon.rs
@@ -2,6 +2,7 @@
 //! changes and runs incremental syncs automatically.
 
 use std::collections::{HashMap, HashSet};
+use std::io::{Read, Write};
 use std::path::{Path, PathBuf};
 use std::time::Duration;
 
@@ -37,8 +38,6 @@ pub fn query_daemon_info() -> Option<DaemonInfo> {
     )
     .ok()?;
     stream.set_read_timeout(Some(Duration::from_secs(2))).ok()?;
-
-    use std::io::{Read, Write};
     stream.write_all(b"GET /status HTTP/1.0\r\n\r\n").ok()?;
     let mut buf = String::new();
     stream.read_to_string(&mut buf).ok()?;
@@ -176,7 +175,7 @@ async fn run_loop(debounce: Duration) -> Result<bool> {
         watchers.len(),
     ));
 
-    let mut discovery_interval = time::interval(Duration::from_secs(60));
+    let mut discovery_interval = time::interval(Duration::from_mins(1));
     discovery_interval.tick().await; // consume first immediate tick
 
     // Set up ctrl-c handler
@@ -193,7 +192,7 @@ async fn run_loop(debounce: Duration) -> Result<bool> {
         let next_deadline = dirty.values().copied().min();
         let sleep_dur = match next_deadline {
             Some(deadline) => deadline.saturating_duration_since(Instant::now()),
-            None => Duration::from_secs(3600),
+            None => Duration::from_hours(1),
         };
 
         tokio::select! {
@@ -204,7 +203,7 @@ async fn run_loop(debounce: Duration) -> Result<bool> {
             Some(project_root) = rx.recv() => {
                 dirty.insert(project_root, Instant::now() + debounce);
             }
-            _ = tokio::time::sleep(sleep_dur), if next_deadline.is_some() => {
+            () = tokio::time::sleep(sleep_dur), if next_deadline.is_some() => {
                 let now = Instant::now();
                 let ready: Vec<PathBuf> = dirty
                     .iter()
@@ -267,6 +266,7 @@ fn start_status_api(
     start_time: std::time::SystemTime,
 ) -> tokio::task::JoinHandle<()> {
     tokio::spawn(async move {
+        use tokio::io::AsyncWriteExt;
         let listener = match tokio::net::TcpListener::bind("127.0.0.1:0").await {
             Ok(l) => l,
             Err(e) => {
@@ -294,7 +294,7 @@ fn start_status_api(
                 continue;
             };
             let count = project_count.load(std::sync::atomic::Ordering::Relaxed);
-            let uptime = start_time.elapsed().map(|d| d.as_secs()).unwrap_or(0);
+            let uptime = start_time.elapsed().map_or(0, |d| d.as_secs());
             let info = DaemonInfo {
                 version: env!("CARGO_PKG_VERSION").to_string(),
                 pid: std::process::id(),
@@ -307,7 +307,6 @@ fn start_status_api(
                 body.len(),
                 body,
             );
-            use tokio::io::AsyncWriteExt;
             let _ = stream.write_all(response.as_bytes()).await;
         }
     })
@@ -520,26 +519,23 @@ pub fn stop() -> Result<()> {
 
 /// Print daemon status and return exit code (0 = running, 1 = not running).
 pub fn status() -> i32 {
-    match running_daemon_pid() {
-        Some(pid) => {
-            if let Some(info) = query_daemon_info() {
-                eprintln!(
-                    "tokensave daemon v{} is running (PID: {}, uptime: {}, watching {} projects)",
-                    info.version,
-                    info.pid,
-                    format_uptime(info.uptime_secs),
-                    info.projects_watched,
-                );
-                check_daemon_version_mismatch(&info.version);
-            } else {
-                eprintln!("tokensave daemon is running (PID: {pid})");
-            }
-            0
+    if let Some(pid) = running_daemon_pid() {
+        if let Some(info) = query_daemon_info() {
+            eprintln!(
+                "tokensave daemon v{} is running (PID: {}, uptime: {}, watching {} projects)",
+                info.version,
+                info.pid,
+                format_uptime(info.uptime_secs),
+                info.projects_watched,
+            );
+            check_daemon_version_mismatch(&info.version);
+        } else {
+            eprintln!("tokensave daemon is running (PID: {pid})");
         }
-        None => {
-            eprintln!("tokensave daemon is not running");
-            1
-        }
+        0
+    } else {
+        eprintln!("tokensave daemon is not running");
+        1
     }
 }
 

--- a/src/db/connection.rs
+++ b/src/db/connection.rs
@@ -9,8 +9,8 @@ use super::migrations;
 
 /// Computes adaptive `(cache_size_kb, mmap_size)` based on the DB file size.
 ///
-/// - **cache_size**: 25% of DB size, clamped to \[2 MB, 64 MB\] (in KiB).
-/// - **mmap_size**: 2× DB size, clamped to \[0, 256 MB\].
+/// - **`cache_size`**: 25% of DB size, clamped to \[2 MB, 64 MB\] (in KiB).
+/// - **`mmap_size`**: 2× DB size, clamped to \[0, 256 MB\].
 ///
 /// This avoids the fixed 320 MB memory baseline for small/medium projects.
 pub(crate) fn adaptive_cache_sizes(db_file_size: u64) -> (u64, u64) {
@@ -27,7 +27,7 @@ pub(crate) fn adaptive_cache_sizes(db_file_size: u64) -> (u64, u64) {
     (cache_kb, mmap)
 }
 
-/// SQLite database backing the code graph, powered by libsql.
+/// `SQLite` database backing the code graph, powered by libsql.
 pub struct Database {
     conn: Connection,
     /// Kept alive so the underlying database is not dropped.
@@ -88,7 +88,7 @@ impl Database {
             operation: "open".to_string(),
         })?;
 
-        let file_size = std::fs::metadata(db_path).map(|m| m.len()).unwrap_or(0);
+        let file_size = std::fs::metadata(db_path).map_or(0, |m| m.len());
         Self::apply_pragmas(&conn, file_size).await?;
         let migrated = migrations::migrate(&conn).await?;
 
@@ -206,7 +206,7 @@ impl Database {
         Ok(())
     }
 
-    /// Applies performance-oriented SQLite pragmas.
+    /// Applies performance-oriented `SQLite` pragmas.
     ///
     /// `cache_size` and `mmap_size` are scaled to the on-disk DB size so
     /// small projects don't pay the 320 MB baseline of a large project.

--- a/src/db/migrations.rs
+++ b/src/db/migrations.rs
@@ -7,7 +7,7 @@
 //! cannot corrupt the schema.
 //!
 //! The current schema version is stored in `PRAGMA user_version`, which
-//! is an atomic integer built into SQLite. No extra table is needed.
+//! is an atomic integer built into `SQLite`. No extra table is needed.
 
 use libsql::Connection;
 
@@ -187,9 +187,7 @@ pub async fn migrate(conn: &Connection) -> Result<bool> {
     let current = get_version(conn).await?;
     debug_assert!(
         current <= LATEST_VERSION,
-        "database version {} is ahead of code version {}",
-        current,
-        LATEST_VERSION
+        "database version {current} is ahead of code version {LATEST_VERSION}"
     );
     if current >= LATEST_VERSION {
         return Ok(false);
@@ -423,7 +421,7 @@ async fn migrate_v2(conn: &Connection) -> Result<()> {
 // Migration V3: complexity metric columns on nodes
 // ---------------------------------------------------------------------------
 
-/// Adds branches, loops, returns, and max_nesting columns to the nodes table.
+/// Adds branches, loops, returns, and `max_nesting` columns to the nodes table.
 async fn migrate_v3(conn: &Connection) -> Result<()> {
     conn.execute_batch(
         "ALTER TABLE nodes ADD COLUMN branches INTEGER NOT NULL DEFAULT 0;
@@ -444,7 +442,7 @@ async fn migrate_v3(conn: &Connection) -> Result<()> {
 // Migration V4: unsafe_blocks, unchecked_calls, assertions columns on nodes
 // ---------------------------------------------------------------------------
 
-/// Adds unsafe_blocks, unchecked_calls, and assertions columns to the nodes table.
+/// Adds `unsafe_blocks`, `unchecked_calls`, and assertions columns to the nodes table.
 async fn migrate_v4(conn: &Connection) -> Result<()> {
     conn.execute_batch(
         "ALTER TABLE nodes ADD COLUMN unsafe_blocks INTEGER NOT NULL DEFAULT 0;
@@ -466,7 +464,7 @@ async fn migrate_v4(conn: &Connection) -> Result<()> {
 
 /// Removes duplicate edges accumulated by repeated reference resolution
 /// during incremental syncs, then adds a UNIQUE index to prevent future
-/// duplicates. See: https://github.com/…/issues/5
+/// duplicates. See: <https://github.com/…/issues/5>
 async fn migrate_v5(conn: &Connection) -> Result<()> {
     // Rebuild the edges table keeping only distinct rows. We use a temp
     // table + swap because DELETE with a self-join subquery can be very

--- a/src/db/queries.rs
+++ b/src/db/queries.rs
@@ -13,11 +13,11 @@ use crate::types::*;
 
 /// Maps a row from the `nodes` table to a `Node`.
 ///
-/// Expected column order: id(0), kind(1), name(2), qualified_name(3),
-/// file_path(4), start_line(5), end_line(6), start_column(7), end_column(8),
-/// docstring(9), signature(10), visibility(11), is_async(12),
-/// branches(13), loops(14), returns(15), max_nesting(16),
-/// unsafe_blocks(17), unchecked_calls(18), assertions(19), updated_at(20).
+/// Expected column order: id(0), kind(1), name(2), `qualified_name(3)`,
+/// `file_path(4)`, `start_line(5)`, `end_line(6)`, `start_column(7)`, `end_column(8)`,
+/// docstring(9), signature(10), visibility(11), `is_async(12)`,
+/// branches(13), loops(14), returns(15), `max_nesting(16)`,
+/// `unsafe_blocks(17)`, `unchecked_calls(18)`, assertions(19), `updated_at(20)`.
 fn row_to_node(row: &libsql::Row) -> std::result::Result<Node, libsql::Error> {
     let kind_str = get_string_lossy(row, 1)?;
     let vis_str = get_string_lossy(row, 11)?;
@@ -97,8 +97,8 @@ fn row_to_edge(row: &libsql::Row) -> std::result::Result<Edge, libsql::Error> {
 
 /// Maps a row from the `files` table to a `FileRecord`.
 ///
-/// Expected column order: path(0), content_hash(1), size(2), modified_at(3),
-/// indexed_at(4), node_count(5).
+/// Expected column order: path(0), `content_hash(1)`, size(2), `modified_at(3)`,
+/// `indexed_at(4)`, `node_count(5)`.
 fn row_to_file(row: &libsql::Row) -> std::result::Result<FileRecord, libsql::Error> {
     Ok(FileRecord {
         path: row.get::<String>(0)?,
@@ -112,8 +112,8 @@ fn row_to_file(row: &libsql::Row) -> std::result::Result<FileRecord, libsql::Err
 
 /// Maps a row from the `unresolved_refs` table to an `UnresolvedRef`.
 ///
-/// Expected column order: from_node_id(0), reference_name(1),
-/// reference_kind(2), line(3), col(4), file_path(5).
+/// Expected column order: `from_node_id(0)`, `reference_name(1)`,
+/// `reference_kind(2)`, line(3), col(4), `file_path(5)`.
 fn row_to_unresolved_ref(row: &libsql::Row) -> std::result::Result<UnresolvedRef, libsql::Error> {
     let kind_str = row.get::<String>(2)?;
 
@@ -149,21 +149,21 @@ impl Database {
                     node.name.as_str(),
                     node.qualified_name.as_str(),
                     node.file_path.as_str(),
-                    node.start_line as i64,
-                    node.end_line as i64,
-                    node.start_column as i64,
-                    node.end_column as i64,
-                    opt_str(&node.docstring),
-                    opt_str(&node.signature),
+                    i64::from(node.start_line),
+                    i64::from(node.end_line),
+                    i64::from(node.start_column),
+                    i64::from(node.end_column),
+                    opt_str(node.docstring.as_deref()),
+                    opt_str(node.signature.as_deref()),
                     node.visibility.as_str(),
-                    node.is_async as i64,
-                    node.branches as i64,
-                    node.loops as i64,
-                    node.returns as i64,
-                    node.max_nesting as i64,
-                    node.unsafe_blocks as i64,
-                    node.unchecked_calls as i64,
-                    node.assertions as i64,
+                    i64::from(node.is_async),
+                    i64::from(node.branches),
+                    i64::from(node.loops),
+                    i64::from(node.returns),
+                    i64::from(node.max_nesting),
+                    i64::from(node.unsafe_blocks),
+                    i64::from(node.unchecked_calls),
+                    i64::from(node.assertions),
                     node.updated_at as i64,
                 ],
             )
@@ -175,7 +175,7 @@ impl Database {
         Ok(())
     }
 
-    /// Inserts all nodes, edges, and file records in a single execute_batch call.
+    /// Inserts all nodes, edges, and file records in a single `execute_batch` call.
     /// This minimizes transaction overhead by combining everything into one SQL string.
     pub async fn insert_all(
         &self,
@@ -212,35 +212,35 @@ impl Database {
                 sql.push(',');
                 push_quoted(&mut sql, &node.file_path);
                 sql.push(',');
-                push_int(&mut sql, node.start_line as i64);
+                push_int(&mut sql, i64::from(node.start_line));
                 sql.push(',');
-                push_int(&mut sql, node.end_line as i64);
+                push_int(&mut sql, i64::from(node.end_line));
                 sql.push(',');
-                push_int(&mut sql, node.start_column as i64);
+                push_int(&mut sql, i64::from(node.start_column));
                 sql.push(',');
-                push_int(&mut sql, node.end_column as i64);
+                push_int(&mut sql, i64::from(node.end_column));
                 sql.push(',');
-                push_opt_quoted(&mut sql, &node.docstring);
+                push_opt_quoted(&mut sql, node.docstring.as_deref());
                 sql.push(',');
-                push_opt_quoted(&mut sql, &node.signature);
+                push_opt_quoted(&mut sql, node.signature.as_deref());
                 sql.push(',');
                 push_quoted(&mut sql, node.visibility.as_str());
                 sql.push(',');
-                push_int(&mut sql, node.is_async as i64);
+                push_int(&mut sql, i64::from(node.is_async));
                 sql.push(',');
-                push_int(&mut sql, node.branches as i64);
+                push_int(&mut sql, i64::from(node.branches));
                 sql.push(',');
-                push_int(&mut sql, node.loops as i64);
+                push_int(&mut sql, i64::from(node.loops));
                 sql.push(',');
-                push_int(&mut sql, node.returns as i64);
+                push_int(&mut sql, i64::from(node.returns));
                 sql.push(',');
-                push_int(&mut sql, node.max_nesting as i64);
+                push_int(&mut sql, i64::from(node.max_nesting));
                 sql.push(',');
-                push_int(&mut sql, node.unsafe_blocks as i64);
+                push_int(&mut sql, i64::from(node.unsafe_blocks));
                 sql.push(',');
-                push_int(&mut sql, node.unchecked_calls as i64);
+                push_int(&mut sql, i64::from(node.unchecked_calls));
                 sql.push(',');
-                push_int(&mut sql, node.assertions as i64);
+                push_int(&mut sql, i64::from(node.assertions));
                 sql.push(',');
                 push_int(&mut sql, node.updated_at as i64);
                 sql.push(')');
@@ -263,7 +263,7 @@ impl Database {
                 push_quoted(&mut sql, edge.kind.as_str());
                 sql.push(',');
                 match edge.line {
-                    Some(l) => push_int(&mut sql, l as i64),
+                    Some(l) => push_int(&mut sql, i64::from(l)),
                     None => sql.push_str("NULL"),
                 }
                 sql.push(')');
@@ -292,7 +292,7 @@ impl Database {
                 sql.push(',');
                 push_int(&mut sql, file.indexed_at);
                 sql.push(',');
-                push_int(&mut sql, file.node_count as i64);
+                push_int(&mut sql, i64::from(file.node_count));
                 sql.push(')');
             }
             sql.push_str(";\n");
@@ -348,21 +348,21 @@ impl Database {
                 node.name.as_str(),
                 node.qualified_name.as_str(),
                 node.file_path.as_str(),
-                node.start_line as i64,
-                node.end_line as i64,
-                node.start_column as i64,
-                node.end_column as i64,
-                opt_str(&node.docstring),
-                opt_str(&node.signature),
+                i64::from(node.start_line),
+                i64::from(node.end_line),
+                i64::from(node.start_column),
+                i64::from(node.end_column),
+                opt_str(node.docstring.as_deref()),
+                opt_str(node.signature.as_deref()),
                 node.visibility.as_str(),
-                node.is_async as i64,
-                node.branches as i64,
-                node.loops as i64,
-                node.returns as i64,
-                node.max_nesting as i64,
-                node.unsafe_blocks as i64,
-                node.unchecked_calls as i64,
-                node.assertions as i64,
+                i64::from(node.is_async),
+                i64::from(node.branches),
+                i64::from(node.loops),
+                i64::from(node.returns),
+                i64::from(node.max_nesting),
+                i64::from(node.unsafe_blocks),
+                i64::from(node.unchecked_calls),
+                i64::from(node.assertions),
                 node.updated_at as i64,
             ])
             .await
@@ -614,7 +614,7 @@ impl Database {
                     edge.source.as_str(),
                     edge.target.as_str(),
                     edge.kind.as_str(),
-                    edge.line.map(|l| l as i64)
+                    edge.line.map(i64::from)
                 ],
             )
             .await
@@ -653,7 +653,7 @@ impl Database {
                 edge.source.as_str(),
                 edge.target.as_str(),
                 edge.kind.as_str(),
-                edge.line.map(|l| l as i64),
+                edge.line.map(i64::from),
             ])
             .await
             .map_err(|e| TokenSaveError::Database {
@@ -868,7 +868,7 @@ impl Database {
         Ok(items)
     }
 
-    /// Returns nodes ranked by line span (end_line - start_line + 1), optionally
+    /// Returns nodes ranked by line span (`end_line` - `start_line` + 1), optionally
     /// filtered by node kind. Results are ordered by size descending.
     pub async fn get_largest_nodes(
         &self,
@@ -1005,7 +1005,7 @@ impl Database {
     /// Returns the maximum inheritance depth for classes/interfaces reachable
     /// via `extends` edges. Uses a recursive CTE to walk the hierarchy.
     ///
-    /// Each result is a (leaf_node, depth) pair where depth is the number of
+    /// Each result is a (`leaf_node`, depth) pair where depth is the number of
     /// `extends` hops from the leaf to the root of its hierarchy.
     pub async fn get_inheritance_depth(
         &self,
@@ -1072,7 +1072,7 @@ impl Database {
     /// Returns node kind counts grouped by file or directory prefix.
     ///
     /// If `path_prefix` is provided, only files under that path are included.
-    /// Results are grouped by (file_path, kind) and ordered by file then count.
+    /// Results are grouped by (`file_path`, kind) and ordered by file then count.
     pub async fn get_node_distribution(
         &self,
         path_prefix: Option<&str>,
@@ -1084,7 +1084,7 @@ impl Database {
                  WHERE file_path LIKE ?1
                  GROUP BY file_path, kind
                  ORDER BY file_path, cnt DESC",
-                vec![libsql::Value::Text(format!("{}%", prefix))],
+                vec![libsql::Value::Text(format!("{prefix}%"))],
             ),
             None => (
                 "SELECT file_path, kind, COUNT(*) AS cnt
@@ -1176,7 +1176,7 @@ impl Database {
 
     /// Returns functions/methods ranked by a composite complexity score.
     ///
-    /// Complexity = line_count + (call_fan_out * 3) + call_fan_in.
+    /// Complexity = `line_count` + (`call_fan_out` * 3) + `call_fan_in`.
     /// Line count reflects size, fan-out reflects cognitive load, fan-in
     /// reflects coupling. Results are ordered by score descending.
     pub async fn get_complexity_ranked(
@@ -1288,7 +1288,7 @@ impl Database {
                  LIMIT ?2"
                     .to_string(),
                 vec![
-                    libsql::Value::Text(format!("{}%", prefix)),
+                    libsql::Value::Text(format!("{prefix}%")),
                     libsql::Value::Integer(limit as i64),
                 ],
             ),
@@ -1450,7 +1450,7 @@ impl Database {
                 file.size as i64,
                 file.modified_at,
                 file.indexed_at,
-                file.node_count as i64,
+                i64::from(file.node_count),
             ])
             .await
             .map_err(|e| TokenSaveError::Database {
@@ -1482,7 +1482,7 @@ impl Database {
                     file.size as i64,
                     file.modified_at,
                     file.indexed_at,
-                    file.node_count as i64,
+                    i64::from(file.node_count),
                 ],
             )
             .await
@@ -1570,8 +1570,8 @@ impl Database {
                     uref.from_node_id.as_str(),
                     uref.reference_name.as_str(),
                     uref.reference_kind.as_str(),
-                    uref.line as i64,
-                    uref.column as i64,
+                    i64::from(uref.line),
+                    i64::from(uref.column),
                     uref.file_path.as_str(),
                 ],
             )
@@ -1610,8 +1610,8 @@ impl Database {
                 uref.from_node_id.as_str(),
                 uref.reference_name.as_str(),
                 uref.reference_kind.as_str(),
-                uref.line as i64,
-                uref.column as i64,
+                i64::from(uref.line),
+                i64::from(uref.column),
                 uref.file_path.as_str(),
             ])
             .await
@@ -1784,7 +1784,7 @@ impl Database {
         Ok(results)
     }
 
-    /// Returns a map of node_id → incoming "calls" edge count for the given IDs.
+    /// Returns a map of `node_id` → incoming "calls" edge count for the given IDs.
     /// IDs not found in any edge target are omitted from the result.
     pub async fn batch_incoming_call_counts(
         &self,
@@ -1864,7 +1864,7 @@ impl Database {
         collect_rows(&mut rows, row_to_node, "search_nodes_by_exact_name").await
     }
 
-    /// Returns `true` if the error indicates SQLite database corruption.
+    /// Returns `true` if the error indicates `SQLite` database corruption.
     pub fn is_corruption_error(e: &TokenSaveError) -> bool {
         match e {
             TokenSaveError::Database { message, .. } => {
@@ -2108,16 +2108,16 @@ impl Database {
     ///
     /// Batches queries in groups of 500 IDs to avoid SQL parameter limits.
     pub async fn get_internal_edges(&self, node_ids: &[String]) -> Result<Vec<Edge>> {
+        const BATCH_SIZE: usize = 500;
         if node_ids.is_empty() {
             return Ok(Vec::new());
         }
 
         // Build a set of IDs for filtering targets in memory, then query
         // edges from each batch of sources.
-        let id_set: std::collections::HashSet<&str> = node_ids.iter().map(|s| s.as_str()).collect();
+        let id_set: std::collections::HashSet<&str> =
+            node_ids.iter().map(std::string::String::as_str).collect();
         let mut all_edges = Vec::new();
-
-        const BATCH_SIZE: usize = 500;
         let mut offset = 0;
         while offset < node_ids.len() {
             let end = (offset + BATCH_SIZE).min(node_ids.len());
@@ -2169,9 +2169,9 @@ impl Database {
 // ---------------------------------------------------------------------------
 
 /// Converts `Option<String>` to a `libsql::Value` for use in params.
-fn opt_str(opt: &Option<String>) -> libsql::Value {
+fn opt_str(opt: Option<&str>) -> libsql::Value {
     match opt {
-        Some(s) => libsql::Value::Text(s.clone()),
+        Some(s) => libsql::Value::Text(s.to_string()),
         None => libsql::Value::Null,
     }
 }
@@ -2190,7 +2190,7 @@ fn push_quoted(buf: &mut String, s: &str) {
 }
 
 /// Appends a SQL-safe quoted string or NULL for Option<String>.
-fn push_opt_quoted(buf: &mut String, opt: &Option<String>) {
+fn push_opt_quoted(buf: &mut String, opt: Option<&str>) {
     match opt {
         Some(s) => push_quoted(buf, s),
         None => buf.push_str("NULL"),

--- a/src/display.rs
+++ b/src/display.rs
@@ -3,6 +3,8 @@
 //! All the formatting and layout logic for `tokensave status` output,
 //! extracted from main.rs to keep the CLI entry point focused on dispatch.
 
+use std::fmt::Write as _;
+
 use crate::types::GraphStats;
 
 /// Formats a token count as a compact string (e.g. "1.2M", "45.3k").
@@ -186,11 +188,11 @@ pub fn print_status_table(
 const MAX_CELL_WIDTH: usize = 32;
 
 /// Maximum number of country flags to display in the title row.
-/// Derived from MAX_CELL_WIDTH: available = 3*32 = 96, title ~16, gap 2 → 78 cols for flags.
+/// Derived from `MAX_CELL_WIDTH`: available = 3*32 = 96, title ~16, gap 2 → 78 cols for flags.
 /// Each flag = 3 cols (2 emoji + 1 space), first = 2 → fits 26; use 25 for margin.
 const MAX_DISPLAY_FLAGS: usize = 25;
 
-/// Compute cell width from the widest node-kind entry, capped at MAX_CELL_WIDTH.
+/// Compute cell width from the widest node-kind entry, capped at `MAX_CELL_WIDTH`.
 fn compute_cell_width(sorted_kinds: &[(&String, &u64)]) -> usize {
     let max_kind_len = sorted_kinds
         .iter()
@@ -303,13 +305,13 @@ fn print_sync_row(last_sync_at: u64, last_full_sync_at: u64, inner_width: usize)
     );
     let available = inner_width.saturating_sub(2);
     let pad = available.saturating_sub(sync_text.len());
-    println!("│ {}\x1b[2m{}\x1b[0m │", " ".repeat(pad), sync_text,);
+    println!("│ {}\x1b[2m{}\x1b[0m │", " ".repeat(pad), sync_text);
 }
 
 fn print_branch_row(info: &BranchInfo, inner_width: usize) {
     let mut text = format!("Branch: {}", info.branch);
     if let Some(ref parent) = info.parent {
-        text.push_str(&format!("  (from {parent})"));
+        let _ = write!(text, "  (from {parent})");
     }
     if info.is_fallback {
         text.push_str("  \x1b[33m[fallback]\x1b[0m");
@@ -339,7 +341,7 @@ fn print_cost_row(cost_info: &CostRow, inner_width: usize) {
     let text = parts.join("  ");
     let available = inner_width.saturating_sub(2);
     let pad = available.saturating_sub(text.len());
-    println!("│ {}\x1b[36m{}\x1b[0m │", " ".repeat(pad), text,);
+    println!("│ {}\x1b[36m{}\x1b[0m │", " ".repeat(pad), text);
 }
 
 /// Build the stats rows (files/nodes/edges, DB size, languages).

--- a/src/doctor.rs
+++ b/src/doctor.rs
@@ -73,7 +73,7 @@ pub async fn run_doctor(agent_filter: Option<&str>) {
 /// Check database health: report size and run VACUUM to reclaim space.
 async fn check_database(dc: &mut DoctorCounters, project_path: &Path) {
     let db_path = crate::config::get_tokensave_dir(project_path).join("tokensave.db");
-    let size_before = std::fs::metadata(&db_path).map(|m| m.len()).unwrap_or(0);
+    let size_before = std::fs::metadata(&db_path).map_or(0, |m| m.len());
 
     let ts = match TokenSave::open(project_path).await {
         Ok(ts) => ts,
@@ -88,9 +88,7 @@ async fn check_database(dc: &mut DoctorCounters, project_path: &Path) {
     eprintln!("    Compacting database (VACUUM)…");
     match ts.optimize().await {
         Ok(()) => {
-            let size_after = std::fs::metadata(&db_path)
-                .map(|m| m.len())
-                .unwrap_or(size_before);
+            let size_after = std::fs::metadata(&db_path).map_or(size_before, |m| m.len());
             if size_before > size_after {
                 let reclaimed = size_before - size_after;
                 dc.pass(&format!(

--- a/src/extraction/bash_extractor.rs
+++ b/src/extraction/bash_extractor.rs
@@ -19,7 +19,7 @@ struct ExtractionState {
     edges: Vec<Edge>,
     unresolved_refs: Vec<UnresolvedRef>,
     errors: Vec<String>,
-    /// Stack of (name, node_id) for building qualified names and parent edges.
+    /// Stack of (name, `node_id`) for building qualified names and parent edges.
     node_stack: Vec<(String, String)>,
     file_path: String,
     source: Vec<u8>,
@@ -158,12 +158,11 @@ impl BashExtractor {
 
     /// Extract a function definition.
     ///
-    /// Bash functions are always top-level (no classes), so they get NodeKind::Function.
+    /// Bash functions are always top-level (no classes), so they get `NodeKind::Function`.
     fn visit_function(state: &mut ExtractionState, node: TsNode<'_>) {
         let name = node
             .child_by_field_name("name")
-            .map(|n| state.node_text(n))
-            .unwrap_or_else(|| "<anonymous>".to_string());
+            .map_or_else(|| "<anonymous>".to_string(), |n| state.node_text(n));
 
         let kind = NodeKind::Function;
         let visibility = Visibility::Pub;
@@ -445,7 +444,7 @@ impl BashExtractor {
         None
     }
 
-    /// Build the final ExtractionResult from the accumulated state.
+    /// Build the final `ExtractionResult` from the accumulated state.
     fn build_result(state: ExtractionState, start: Instant) -> ExtractionResult {
         ExtractionResult {
             nodes: state.nodes,
@@ -462,7 +461,7 @@ impl crate::extraction::LanguageExtractor for BashExtractor {
         &["sh", "bash"]
     }
 
-    fn language_name(&self) -> &str {
+    fn language_name(&self) -> &'static str {
         "Bash"
     }
 

--- a/src/extraction/batch_extractor.rs
+++ b/src/extraction/batch_extractor.rs
@@ -19,7 +19,7 @@ struct ExtractionState {
     edges: Vec<Edge>,
     unresolved_refs: Vec<UnresolvedRef>,
     errors: Vec<String>,
-    /// Stack of (name, node_id) for building qualified names and parent edges.
+    /// Stack of (name, `node_id`) for building qualified names and parent edges.
     node_stack: Vec<(String, String)>,
     file_path: String,
     source: Vec<u8>,
@@ -142,12 +142,9 @@ impl BatchExtractor {
         let mut i: usize = 0;
 
         while i < child_count {
-            let child = match root.child(i as u32) {
-                Some(c) => c,
-                None => {
-                    i += 1;
-                    continue;
-                }
+            let Some(child) = root.child(i as u32) else {
+                i += 1;
+                continue;
             };
 
             match child.kind() {
@@ -168,9 +165,8 @@ impl BatchExtractor {
     /// In Batch, labels (:Name) serve as subroutine entry points.
     /// The body extends from the label to the next label or end of file.
     fn visit_label(state: &mut ExtractionState, root: TsNode<'_>, label_index: usize) {
-        let label_node = match root.child(label_index as u32) {
-            Some(n) => n,
-            None => return,
+        let Some(label_node) = root.child(label_index as u32) else {
+            return;
         };
 
         let label_text = state.node_text(label_node);
@@ -387,7 +383,7 @@ impl BatchExtractor {
         }
     }
 
-    /// Recursively find call_stmt nodes and create unresolved Calls references.
+    /// Recursively find `call_stmt` nodes and create unresolved Calls references.
     fn extract_call_sites_recursive(
         state: &mut ExtractionState,
         node: TsNode<'_>,
@@ -441,7 +437,7 @@ impl BatchExtractor {
         None
     }
 
-    /// Build the final ExtractionResult from the accumulated state.
+    /// Build the final `ExtractionResult` from the accumulated state.
     fn build_result(state: ExtractionState, start: Instant) -> ExtractionResult {
         ExtractionResult {
             nodes: state.nodes,
@@ -458,7 +454,7 @@ impl crate::extraction::LanguageExtractor for BatchExtractor {
         &["bat", "cmd"]
     }
 
-    fn language_name(&self) -> &str {
+    fn language_name(&self) -> &'static str {
         "Batch"
     }
 

--- a/src/extraction/c_extractor.rs
+++ b/src/extraction/c_extractor.rs
@@ -20,7 +20,7 @@ struct ExtractionState {
     edges: Vec<Edge>,
     unresolved_refs: Vec<UnresolvedRef>,
     errors: Vec<String>,
-    /// Stack of (name, node_id) for building qualified names and parent edges.
+    /// Stack of (name, `node_id`) for building qualified names and parent edges.
     node_stack: Vec<(String, String)>,
     file_path: String,
     source: Vec<u8>,
@@ -179,7 +179,7 @@ impl CExtractor {
 
         let name =
             Self::extract_function_name(state, node).unwrap_or_else(|| "<anonymous>".to_string());
-        let signature = Self::extract_function_signature(state, node);
+        let signature = Some(Self::extract_function_signature(state, node));
         let docstring = Self::extract_docstring(state, node);
         let start_line = node.start_position().row as u32;
         let end_line = node.end_position().row as u32;
@@ -230,7 +230,7 @@ impl CExtractor {
         }
     }
 
-    /// Extract the function name from a function_definition or declaration node.
+    /// Extract the function name from a `function_definition` or declaration node.
     /// The name is typically inside a `function_declarator` -> `identifier`.
     fn extract_function_name(state: &ExtractionState, node: TsNode<'_>) -> Option<String> {
         // Look for function_declarator which contains the name
@@ -251,14 +251,13 @@ impl CExtractor {
     }
 
     /// Extract the function signature (everything except the body).
-    fn extract_function_signature(state: &ExtractionState, node: TsNode<'_>) -> Option<String> {
+    fn extract_function_signature(state: &ExtractionState, node: TsNode<'_>) -> String {
         let text = state.node_text(node);
         if let Some(brace_pos) = text.find('{') {
-            Some(text[..brace_pos].trim().to_string())
+            text[..brace_pos].trim().to_string()
         } else {
             // For declarations without a body (prototypes), use the full text without semicolon
-            let trimmed = text.trim().trim_end_matches(';').trim().to_string();
-            Some(trimmed)
+            text.trim().trim_end_matches(';').trim().to_string()
         }
     }
 
@@ -440,7 +439,7 @@ impl CExtractor {
     // type_definition (typedef)
     // -------------------------------------------------------
 
-    /// Visit a type_definition node (typedef).
+    /// Visit a `type_definition` node (typedef).
     fn visit_type_definition(state: &mut ExtractionState, node: TsNode<'_>) {
         // Check for typedef struct { ... } Name;
         if let Some(struct_spec) = Self::find_child_by_kind(node, "struct_specifier") {
@@ -532,8 +531,7 @@ impl CExtractor {
         // Also create a Struct node if it has a body
         if Self::find_child_by_kind(struct_spec, "field_declaration_list").is_some() {
             let struct_name = Self::find_child_by_kind(struct_spec, "type_identifier")
-                .map(|n| state.node_text(n))
-                .unwrap_or_else(|| typedef_name.clone());
+                .map_or_else(|| typedef_name.clone(), |n| state.node_text(n));
 
             Self::create_struct_node(state, &struct_name, struct_spec, docstring);
         }
@@ -600,8 +598,7 @@ impl CExtractor {
         // Also create a Union node if it has a body
         if Self::find_child_by_kind(union_spec, "field_declaration_list").is_some() {
             let union_name = Self::find_child_by_kind(union_spec, "type_identifier")
-                .map(|n| state.node_text(n))
-                .unwrap_or_else(|| typedef_name.clone());
+                .map_or_else(|| typedef_name.clone(), |n| state.node_text(n));
 
             Self::create_union_node(state, &union_name, union_spec, docstring);
         }
@@ -668,8 +665,7 @@ impl CExtractor {
         // Also create an Enum node if it has a body
         if Self::find_child_by_kind(enum_spec, "enumerator_list").is_some() {
             let enum_name = Self::find_child_by_kind(enum_spec, "type_identifier")
-                .map(|n| state.node_text(n))
-                .unwrap_or_else(|| typedef_name.clone());
+                .map_or_else(|| typedef_name.clone(), |n| state.node_text(n));
 
             Self::create_enum_node(state, &enum_name, enum_spec, docstring);
         }
@@ -800,8 +796,8 @@ impl CExtractor {
         }
     }
 
-    /// Find the typedef name, which is usually the last type_identifier child of the
-    /// type_definition node.
+    /// Find the typedef name, which is usually the last `type_identifier` child of the
+    /// `type_definition` node.
     fn find_typedef_name(state: &ExtractionState, node: TsNode<'_>) -> Option<String> {
         // The typedef name is typically the last type_identifier direct child
         let mut last_type_id = None;
@@ -831,8 +827,7 @@ impl CExtractor {
             return;
         }
         let name = Self::find_child_by_kind(node, "type_identifier")
-            .map(|n| state.node_text(n))
-            .unwrap_or_else(|| "<anonymous>".to_string());
+            .map_or_else(|| "<anonymous>".to_string(), |n| state.node_text(n));
 
         // Skip anonymous structs that are not inside a typedef
         if name == "<anonymous>" {
@@ -849,8 +844,7 @@ impl CExtractor {
             return;
         }
         let name = Self::find_child_by_kind(node, "type_identifier")
-            .map(|n| state.node_text(n))
-            .unwrap_or_else(|| "<anonymous>".to_string());
+            .map_or_else(|| "<anonymous>".to_string(), |n| state.node_text(n));
 
         if name == "<anonymous>" {
             return;
@@ -866,8 +860,7 @@ impl CExtractor {
             return;
         }
         let name = Self::find_child_by_kind(node, "type_identifier")
-            .map(|n| state.node_text(n))
-            .unwrap_or_else(|| "<anonymous>".to_string());
+            .map_or_else(|| "<anonymous>".to_string(), |n| state.node_text(n));
 
         if name == "<anonymous>" {
             return;
@@ -995,7 +988,7 @@ impl CExtractor {
         state.node_stack.pop();
     }
 
-    /// Create an Enum node with EnumVariant children.
+    /// Create an Enum node with `EnumVariant` children.
     fn create_enum_node(
         state: &mut ExtractionState,
         name: &str,
@@ -1059,8 +1052,7 @@ impl CExtractor {
     /// Extract a preprocessor #define.
     fn visit_preproc_def(state: &mut ExtractionState, node: TsNode<'_>) {
         let name = Self::find_child_by_kind(node, "identifier")
-            .map(|n| state.node_text(n))
-            .unwrap_or_else(|| "<anonymous>".to_string());
+            .map_or_else(|| "<anonymous>".to_string(), |n| state.node_text(n));
 
         let text = state.node_text(node);
         let start_line = node.start_position().row as u32;
@@ -1116,13 +1108,15 @@ impl CExtractor {
         // The include path is in a string_literal or system_lib_string child
         let path = Self::find_child_by_kind(node, "string_literal")
             .or_else(|| Self::find_child_by_kind(node, "system_lib_string"))
-            .map(|n| {
-                let text = state.node_text(n);
-                // Strip quotes/angle brackets
-                text.trim_matches(|c| c == '"' || c == '<' || c == '>')
-                    .to_string()
-            })
-            .unwrap_or_else(|| "<unknown>".to_string());
+            .map_or_else(
+                || "<unknown>".to_string(),
+                |n| {
+                    let text = state.node_text(n);
+                    // Strip quotes/angle brackets
+                    text.trim_matches(|c| c == '"' || c == '<' || c == '>')
+                        .to_string()
+                },
+            );
 
         let text = state.node_text(node);
         let start_line = node.start_position().row as u32;
@@ -1190,13 +1184,12 @@ impl CExtractor {
         }
     }
 
-    /// Extract a single field from a field_declaration node.
+    /// Extract a single field from a `field_declaration` node.
     fn extract_single_field(state: &mut ExtractionState, node: TsNode<'_>) {
         // In C, the field name is a field_identifier child of the field_declaration
         // or inside a field_declarator child.
         let name = Self::find_descendant_by_kind(node, "field_identifier")
-            .map(|n| state.node_text(n))
-            .unwrap_or_else(|| "<anonymous>".to_string());
+            .map_or_else(|| "<anonymous>".to_string(), |n| state.node_text(n));
 
         let text = state.node_text(node);
         let start_line = node.start_position().row as u32;
@@ -1242,7 +1235,7 @@ impl CExtractor {
         }
     }
 
-    /// Extract enum variants from an enum_specifier node.
+    /// Extract enum variants from an `enum_specifier` node.
     fn extract_enum_variants(state: &mut ExtractionState, enum_spec: TsNode<'_>) {
         if let Some(enumerator_list) = Self::find_child_by_kind(enum_spec, "enumerator_list") {
             let mut cursor = enumerator_list.walk();
@@ -1260,11 +1253,10 @@ impl CExtractor {
         }
     }
 
-    /// Extract a single enumerator as an EnumVariant node.
+    /// Extract a single enumerator as an `EnumVariant` node.
     fn extract_single_enumerator(state: &mut ExtractionState, node: TsNode<'_>) {
         let name = Self::find_child_by_kind(node, "identifier")
-            .map(|n| state.node_text(n))
-            .unwrap_or_else(|| "<anonymous>".to_string());
+            .map_or_else(|| "<anonymous>".to_string(), |n| state.node_text(n));
 
         let text = state.node_text(node);
         let start_line = node.start_position().row as u32;
@@ -1314,7 +1306,7 @@ impl CExtractor {
     // Call site extraction
     // -------------------------------------------------------
 
-    /// Recursively find call_expression nodes and create unresolved Calls references.
+    /// Recursively find `call_expression` nodes and create unresolved Calls references.
     fn extract_call_sites(state: &mut ExtractionState, node: TsNode<'_>, fn_node_id: &str) {
         let mut cursor = node.walk();
         if cursor.goto_first_child() {
@@ -1467,7 +1459,7 @@ impl CExtractor {
         None
     }
 
-    /// Build the final ExtractionResult from the accumulated state.
+    /// Build the final `ExtractionResult` from the accumulated state.
     fn build_result(state: ExtractionState, start: Instant) -> ExtractionResult {
         ExtractionResult {
             nodes: state.nodes,
@@ -1484,7 +1476,7 @@ impl crate::extraction::LanguageExtractor for CExtractor {
         &["c", "h"]
     }
 
-    fn language_name(&self) -> &str {
+    fn language_name(&self) -> &'static str {
         "C"
     }
 

--- a/src/extraction/cobol_extractor.rs
+++ b/src/extraction/cobol_extractor.rs
@@ -21,7 +21,7 @@ struct ExtractionState {
     edges: Vec<Edge>,
     unresolved_refs: Vec<UnresolvedRef>,
     errors: Vec<String>,
-    /// Stack of (name, node_id) for building qualified names and parent edges.
+    /// Stack of (name, `node_id`) for building qualified names and parent edges.
     node_stack: Vec<(String, String)>,
     file_path: String,
     source: Vec<u8>,
@@ -75,13 +75,11 @@ impl ExtractionState {
         let line_start = self.source[..byte_offset]
             .iter()
             .rposition(|&b| b == b'\n')
-            .map(|p| p + 1)
-            .unwrap_or(0);
+            .map_or(0, |p| p + 1);
         let line_end = self.source[byte_offset..]
             .iter()
             .position(|&b| b == b'\n')
-            .map(|p| byte_offset + p)
-            .unwrap_or(self.source.len());
+            .map_or(self.source.len(), |p| byte_offset + p);
         String::from_utf8_lossy(&self.source[line_start..line_end]).to_string()
     }
 }
@@ -173,7 +171,7 @@ impl CobolExtractor {
         }
     }
 
-    /// Visit a program_definition node, which contains all four divisions.
+    /// Visit a `program_definition` node, which contains all four divisions.
     fn visit_program_definition(state: &mut ExtractionState, node: TsNode<'_>) {
         let mut cursor = node.walk();
         if cursor.goto_first_child() {
@@ -433,7 +431,7 @@ impl CobolExtractor {
         }
     }
 
-    /// Gather preceding comment lines before a paragraph_header.
+    /// Gather preceding comment lines before a `paragraph_header`.
     fn gather_preceding_comments(
         state: &ExtractionState,
         children: &[TsNode<'_>],
@@ -617,7 +615,7 @@ impl CobolExtractor {
         }
     }
 
-    /// Extract the label name from a perform_procedure node.
+    /// Extract the label name from a `perform_procedure` node.
     fn extract_label_name(state: &ExtractionState, node: TsNode<'_>) -> Option<String> {
         // perform_procedure -> label -> qualified_word -> WORD
         let label = Self::find_child_by_kind(node, "label")?;
@@ -643,7 +641,7 @@ impl CobolExtractor {
         None
     }
 
-    /// Build the final ExtractionResult from the accumulated state.
+    /// Build the final `ExtractionResult` from the accumulated state.
     fn build_result(state: ExtractionState, start: Instant) -> ExtractionResult {
         ExtractionResult {
             nodes: state.nodes,
@@ -660,7 +658,7 @@ impl crate::extraction::LanguageExtractor for CobolExtractor {
         &["cob", "cbl", "cpy"]
     }
 
-    fn language_name(&self) -> &str {
+    fn language_name(&self) -> &'static str {
         "COBOL"
     }
 

--- a/src/extraction/complexity.rs
+++ b/src/extraction/complexity.rs
@@ -16,7 +16,7 @@ pub struct ComplexityConfig {
     pub loop_types: &'static [&'static str],
     /// Node types that count as early exits (return, break, continue, throw).
     pub return_types: &'static [&'static str],
-    /// Node types that introduce a new nesting level (block, compound_statement).
+    /// Node types that introduce a new nesting level (block, `compound_statement`).
     pub nesting_types: &'static [&'static str],
     /// Node types representing unsafe blocks (e.g. `unsafe_block` in Rust, `unsafe_statement` in C#).
     pub unsafe_types: &'static [&'static str],
@@ -25,7 +25,7 @@ pub struct ComplexityConfig {
     /// Method names that represent unchecked/force-unwrap calls (e.g. `unwrap`, `get`).
     /// Matched against the method name in call expressions.
     pub unchecked_methods: &'static [&'static str],
-    /// Node types representing method/function call expressions, used for unchecked_methods matching.
+    /// Node types representing method/function call expressions, used for `unchecked_methods` matching.
     pub call_expression_types: &'static [&'static str],
     /// Field name used to extract the method name from a call expression node.
     /// e.g. "function" for TS, "method" for Rust. Empty to skip.
@@ -48,7 +48,7 @@ pub struct ComplexityMetrics {
     pub unsafe_blocks: u32,
     /// Number of unchecked/force-unwrap calls or assertions.
     pub unchecked_calls: u32,
-    /// Number of assertion calls (assert, debug_assert, assertEquals, etc.).
+    /// Number of assertion calls (assert, `debug_assert`, assertEquals, etc.).
     pub assertions: u32,
 }
 
@@ -64,6 +64,7 @@ pub fn count_complexity(
     config: &ComplexityConfig,
     source: &[u8],
 ) -> ComplexityMetrics {
+    const MAX_ITERATIONS: usize = 500_000;
     debug_assert!(
         !config.branch_types.is_empty() || !config.loop_types.is_empty(),
         "count_complexity called with config that has no branch or loop types"
@@ -88,7 +89,6 @@ pub fn count_complexity(
         idx += 1;
     }
 
-    const MAX_ITERATIONS: usize = 500_000;
     let mut iterations: usize = 0;
 
     while let Some((current, depth)) = stack.pop() {

--- a/src/extraction/cpp_extractor.rs
+++ b/src/extraction/cpp_extractor.rs
@@ -20,7 +20,7 @@ struct ExtractionState {
     edges: Vec<Edge>,
     unresolved_refs: Vec<UnresolvedRef>,
     errors: Vec<String>,
-    /// Stack of (name, node_id) for building qualified names and parent edges.
+    /// Stack of (name, `node_id`) for building qualified names and parent edges.
     node_stack: Vec<(String, String)>,
     file_path: String,
     source: Vec<u8>,
@@ -209,7 +209,7 @@ impl CppExtractor {
 
         let name =
             Self::extract_function_name(state, node).unwrap_or_else(|| "<anonymous>".to_string());
-        let signature = Self::extract_function_signature(state, node);
+        let signature = Some(Self::extract_function_signature(state, node));
         let docstring = Self::extract_docstring(state, node);
         let start_line = node.start_position().row as u32;
         let end_line = node.end_position().row as u32;
@@ -273,7 +273,7 @@ impl CppExtractor {
         }
     }
 
-    /// Check if a function_definition is a constructor.
+    /// Check if a `function_definition` is a constructor.
     fn is_constructor(state: &ExtractionState, node: TsNode<'_>) -> bool {
         let name = Self::extract_function_name(state, node);
         if let Some(name) = &name {
@@ -286,7 +286,7 @@ impl CppExtractor {
         false
     }
 
-    /// Check if a function_definition is a destructor.
+    /// Check if a `function_definition` is a destructor.
     fn is_destructor(state: &ExtractionState, node: TsNode<'_>) -> bool {
         let name = Self::extract_function_name(state, node);
         if let Some(name) = &name {
@@ -301,7 +301,7 @@ impl CppExtractor {
     fn visit_constructor(state: &mut ExtractionState, node: TsNode<'_>) {
         let name =
             Self::extract_function_name(state, node).unwrap_or_else(|| "<anonymous>".to_string());
-        let signature = Self::extract_function_signature(state, node);
+        let signature = Some(Self::extract_function_signature(state, node));
         let docstring = Self::extract_docstring(state, node);
         let start_line = node.start_position().row as u32;
         let end_line = node.end_position().row as u32;
@@ -354,7 +354,7 @@ impl CppExtractor {
     fn visit_destructor(state: &mut ExtractionState, node: TsNode<'_>) {
         let name = Self::extract_function_name(state, node)
             .unwrap_or_else(|| Self::extract_destructor_name(state, node));
-        let signature = Self::extract_function_signature(state, node);
+        let signature = Some(Self::extract_function_signature(state, node));
         let docstring = Self::extract_docstring(state, node);
         let start_line = node.start_position().row as u32;
         let end_line = node.end_position().row as u32;
@@ -409,12 +409,12 @@ impl CppExtractor {
             return state.node_text(dtor);
         }
         if let Some((class_name, _)) = state.node_stack.last() {
-            return format!("~{}", class_name);
+            return format!("~{class_name}");
         }
         "~<unknown>".to_string()
     }
 
-    /// Extract the function name from a function_definition or declaration node.
+    /// Extract the function name from a `function_definition` or declaration node.
     fn extract_function_name(state: &ExtractionState, node: TsNode<'_>) -> Option<String> {
         if let Some(declarator) = Self::find_descendant_by_kind(node, "function_declarator") {
             // Check for destructor_name first
@@ -450,13 +450,12 @@ impl CppExtractor {
     }
 
     /// Extract the function signature (everything except the body).
-    fn extract_function_signature(state: &ExtractionState, node: TsNode<'_>) -> Option<String> {
+    fn extract_function_signature(state: &ExtractionState, node: TsNode<'_>) -> String {
         let text = state.node_text(node);
         if let Some(brace_pos) = text.find('{') {
-            Some(text[..brace_pos].trim().to_string())
+            text[..brace_pos].trim().to_string()
         } else {
-            let trimmed = text.trim().trim_end_matches(';').trim().to_string();
-            Some(trimmed)
+            text.trim().trim_end_matches(';').trim().to_string()
         }
     }
 
@@ -808,8 +807,7 @@ impl CppExtractor {
             return;
         }
         let name = Self::find_child_by_kind(node, "type_identifier")
-            .map(|n| state.node_text(n))
-            .unwrap_or_else(|| "<anonymous>".to_string());
+            .map_or_else(|| "<anonymous>".to_string(), |n| state.node_text(n));
 
         if name == "<anonymous>" {
             return;
@@ -825,8 +823,7 @@ impl CppExtractor {
             return;
         }
         let name = Self::find_child_by_kind(node, "type_identifier")
-            .map(|n| state.node_text(n))
-            .unwrap_or_else(|| "<anonymous>".to_string());
+            .map_or_else(|| "<anonymous>".to_string(), |n| state.node_text(n));
 
         if name == "<anonymous>" {
             return;
@@ -1016,7 +1013,7 @@ impl CppExtractor {
         }
     }
 
-    /// Visit a field_declaration inside a class/struct body.
+    /// Visit a `field_declaration` inside a class/struct body.
     fn visit_field_declaration(state: &mut ExtractionState, node: TsNode<'_>) {
         // Check if this is actually a method declaration (has a function_declarator)
         if Self::find_descendant_by_kind(node, "function_declarator").is_some() {
@@ -1026,8 +1023,7 @@ impl CppExtractor {
 
         // It's a field
         let name = Self::find_descendant_by_kind(node, "field_identifier")
-            .map(|n| state.node_text(n))
-            .unwrap_or_else(|| "<anonymous>".to_string());
+            .map_or_else(|| "<anonymous>".to_string(), |n| state.node_text(n));
 
         if name == "<anonymous>" {
             return;
@@ -1083,7 +1079,7 @@ impl CppExtractor {
     // access_specifier
     // -------------------------------------------------------
 
-    /// Update the current access specifier based on an access_specifier node.
+    /// Update the current access specifier based on an `access_specifier` node.
     fn visit_access_specifier(state: &mut ExtractionState, node: TsNode<'_>) {
         let text = state
             .node_text(node)
@@ -1107,8 +1103,7 @@ impl CppExtractor {
     fn visit_namespace(state: &mut ExtractionState, node: TsNode<'_>) {
         let name = Self::find_child_by_kind(node, "identifier")
             .or_else(|| Self::find_child_by_kind(node, "namespace_identifier"))
-            .map(|n| state.node_text(n))
-            .unwrap_or_else(|| "<anonymous>".to_string());
+            .map_or_else(|| "<anonymous>".to_string(), |n| state.node_text(n));
 
         let docstring = Self::extract_docstring(state, node);
         let start_line = node.start_position().row as u32;
@@ -1249,7 +1244,7 @@ impl CppExtractor {
     // type_definition (typedef)
     // -------------------------------------------------------
 
-    /// Visit a type_definition node (typedef).
+    /// Visit a `type_definition` node (typedef).
     fn visit_type_definition(state: &mut ExtractionState, node: TsNode<'_>) {
         if let Some(struct_spec) = Self::find_child_by_kind(node, "struct_specifier") {
             Self::visit_typedef_struct(state, node, struct_spec);
@@ -1329,8 +1324,7 @@ impl CppExtractor {
 
         if Self::find_child_by_kind(struct_spec, "field_declaration_list").is_some() {
             let struct_name = Self::find_child_by_kind(struct_spec, "type_identifier")
-                .map(|n| state.node_text(n))
-                .unwrap_or_else(|| typedef_name.clone());
+                .map_or_else(|| typedef_name.clone(), |n| state.node_text(n));
             Self::create_struct_node(state, &struct_name, struct_spec, docstring);
         }
     }
@@ -1394,8 +1388,7 @@ impl CppExtractor {
 
         if Self::find_child_by_kind(union_spec, "field_declaration_list").is_some() {
             let union_name = Self::find_child_by_kind(union_spec, "type_identifier")
-                .map(|n| state.node_text(n))
-                .unwrap_or_else(|| typedef_name.clone());
+                .map_or_else(|| typedef_name.clone(), |n| state.node_text(n));
             Self::create_union_node(state, &union_name, union_spec, docstring);
         }
     }
@@ -1459,8 +1452,7 @@ impl CppExtractor {
 
         if Self::find_child_by_kind(enum_spec, "enumerator_list").is_some() {
             let enum_name = Self::find_child_by_kind(enum_spec, "type_identifier")
-                .map(|n| state.node_text(n))
-                .unwrap_or_else(|| typedef_name.clone());
+                .map_or_else(|| typedef_name.clone(), |n| state.node_text(n));
             Self::create_enum_node(state, &enum_name, enum_spec, docstring);
         }
     }
@@ -1584,7 +1576,7 @@ impl CppExtractor {
         }
     }
 
-    /// Find the typedef name (last type_identifier direct child).
+    /// Find the typedef name (last `type_identifier` direct child).
     fn find_typedef_name(state: &ExtractionState, node: TsNode<'_>) -> Option<String> {
         let mut last_type_id = None;
         let mut cursor = node.walk();
@@ -1612,8 +1604,7 @@ impl CppExtractor {
             return;
         }
         let name = Self::find_child_by_kind(node, "type_identifier")
-            .map(|n| state.node_text(n))
-            .unwrap_or_else(|| "<anonymous>".to_string());
+            .map_or_else(|| "<anonymous>".to_string(), |n| state.node_text(n));
 
         if name == "<anonymous>" {
             return;
@@ -1629,8 +1620,7 @@ impl CppExtractor {
             return;
         }
         let name = Self::find_child_by_kind(node, "type_identifier")
-            .map(|n| state.node_text(n))
-            .unwrap_or_else(|| "<anonymous>".to_string());
+            .map_or_else(|| "<anonymous>".to_string(), |n| state.node_text(n));
 
         if name == "<anonymous>" {
             return;
@@ -1754,7 +1744,7 @@ impl CppExtractor {
         }
     }
 
-    /// Create an Enum node with EnumVariant children.
+    /// Create an Enum node with `EnumVariant` children.
     fn create_enum_node(
         state: &mut ExtractionState,
         name: &str,
@@ -1816,8 +1806,7 @@ impl CppExtractor {
     /// Extract a preprocessor #define.
     fn visit_preproc_def(state: &mut ExtractionState, node: TsNode<'_>) {
         let name = Self::find_child_by_kind(node, "identifier")
-            .map(|n| state.node_text(n))
-            .unwrap_or_else(|| "<anonymous>".to_string());
+            .map_or_else(|| "<anonymous>".to_string(), |n| state.node_text(n));
 
         let text = state.node_text(node);
         let start_line = node.start_position().row as u32;
@@ -1871,12 +1860,14 @@ impl CppExtractor {
     fn visit_preproc_include(state: &mut ExtractionState, node: TsNode<'_>) {
         let path = Self::find_child_by_kind(node, "string_literal")
             .or_else(|| Self::find_child_by_kind(node, "system_lib_string"))
-            .map(|n| {
-                let text = state.node_text(n);
-                text.trim_matches(|c| c == '"' || c == '<' || c == '>')
-                    .to_string()
-            })
-            .unwrap_or_else(|| "<unknown>".to_string());
+            .map_or_else(
+                || "<unknown>".to_string(),
+                |n| {
+                    let text = state.node_text(n);
+                    text.trim_matches(|c| c == '"' || c == '<' || c == '>')
+                        .to_string()
+                },
+            );
 
         let text = state.node_text(node);
         let start_line = node.start_position().row as u32;
@@ -1925,7 +1916,7 @@ impl CppExtractor {
     // Enum variant extraction
     // -------------------------------------------------------
 
-    /// Extract enum variants from an enum_specifier node.
+    /// Extract enum variants from an `enum_specifier` node.
     fn extract_enum_variants(state: &mut ExtractionState, enum_spec: TsNode<'_>) {
         if let Some(enumerator_list) = Self::find_child_by_kind(enum_spec, "enumerator_list") {
             let mut cursor = enumerator_list.walk();
@@ -1943,11 +1934,10 @@ impl CppExtractor {
         }
     }
 
-    /// Extract a single enumerator as an EnumVariant node.
+    /// Extract a single enumerator as an `EnumVariant` node.
     fn extract_single_enumerator(state: &mut ExtractionState, node: TsNode<'_>) {
         let name = Self::find_child_by_kind(node, "identifier")
-            .map(|n| state.node_text(n))
-            .unwrap_or_else(|| "<anonymous>".to_string());
+            .map_or_else(|| "<anonymous>".to_string(), |n| state.node_text(n));
 
         let text = state.node_text(node);
         let start_line = node.start_position().row as u32;
@@ -2037,7 +2027,7 @@ impl CppExtractor {
     // Call site extraction
     // -------------------------------------------------------
 
-    /// Recursively find call_expression nodes and create unresolved Calls references.
+    /// Recursively find `call_expression` nodes and create unresolved Calls references.
     fn extract_call_sites(state: &mut ExtractionState, node: TsNode<'_>, fn_node_id: &str) {
         let mut cursor = node.walk();
         if cursor.goto_first_child() {
@@ -2199,10 +2189,10 @@ impl CppExtractor {
     // -----------------------------------------------------------------------
 
     /// Extract C++ attributes from a declaration node and create
-    /// AnnotationUsage nodes and Annotates edges.
+    /// `AnnotationUsage` nodes and Annotates edges.
     ///
     /// C++ attributes appear as `attribute_declaration` children of the
-    /// declaration node. Structure: attribute_declaration > attribute > identifier.
+    /// declaration node. Structure: `attribute_declaration` > attribute > identifier.
     fn extract_annotations(state: &mut ExtractionState, node: TsNode<'_>, target_id: &str) {
         let mut cursor = node.walk();
         if cursor.goto_first_child() {
@@ -2218,8 +2208,8 @@ impl CppExtractor {
         }
     }
 
-    /// Walk an attribute_declaration node, iterating over attribute children
-    /// to create AnnotationUsage nodes.
+    /// Walk an `attribute_declaration` node, iterating over attribute children
+    /// to create `AnnotationUsage` nodes.
     fn extract_attributes_from_decl(
         state: &mut ExtractionState,
         attr_decl: TsNode<'_>,
@@ -2303,7 +2293,7 @@ impl CppExtractor {
         text.split('(').next().unwrap_or(&text).trim().to_string()
     }
 
-    /// Build the final ExtractionResult from the accumulated state.
+    /// Build the final `ExtractionResult` from the accumulated state.
     fn build_result(state: ExtractionState, start: Instant) -> ExtractionResult {
         ExtractionResult {
             nodes: state.nodes,
@@ -2320,7 +2310,7 @@ impl crate::extraction::LanguageExtractor for CppExtractor {
         &["cpp", "cc", "cxx", "hpp", "hxx", "hh"]
     }
 
-    fn language_name(&self) -> &str {
+    fn language_name(&self) -> &'static str {
         "C++"
     }
 

--- a/src/extraction/csharp_extractor.rs
+++ b/src/extraction/csharp_extractor.rs
@@ -19,7 +19,7 @@ struct ExtractionState {
     edges: Vec<Edge>,
     unresolved_refs: Vec<UnresolvedRef>,
     errors: Vec<String>,
-    /// Stack of (name, node_id) for building qualified names and parent edges.
+    /// Stack of (name, `node_id`) for building qualified names and parent edges.
     node_stack: Vec<(String, String)>,
     file_path: String,
     source: Vec<u8>,
@@ -153,7 +153,7 @@ impl CSharpExtractor {
     fn visit_node(state: &mut ExtractionState, node: TsNode<'_>) {
         match node.kind() {
             "namespace_declaration" | "file_scoped_namespace_declaration" => {
-                Self::visit_namespace(state, node)
+                Self::visit_namespace(state, node);
             }
             "using_directive" => Self::visit_using(state, node),
             "class_declaration" => Self::visit_class(state, node),
@@ -199,7 +199,7 @@ impl CSharpExtractor {
             end_line,
             start_column,
             end_column,
-            signature: Some(format!("namespace {}", name)),
+            signature: Some(format!("namespace {name}")),
             docstring: None,
             visibility: Visibility::Pub,
             is_async: false,
@@ -309,7 +309,7 @@ impl CSharpExtractor {
         let name = Self::extract_name(state, node).unwrap_or_else(|| "<anonymous>".to_string());
         let visibility = Self::extract_csharp_visibility(node, state);
         let docstring = Self::extract_xml_docstring(state, node);
-        let signature = Self::extract_declaration_signature(state, node);
+        let signature = Some(Self::extract_declaration_signature(state, node));
         let start_line = node.start_position().row as u32;
         let end_line = node.end_position().row as u32;
         let start_column = node.start_position().column as u32;
@@ -380,7 +380,7 @@ impl CSharpExtractor {
         let name = Self::extract_name(state, node).unwrap_or_else(|| "<anonymous>".to_string());
         let visibility = Self::extract_csharp_visibility(node, state);
         let docstring = Self::extract_xml_docstring(state, node);
-        let signature = Self::extract_declaration_signature(state, node);
+        let signature = Some(Self::extract_declaration_signature(state, node));
         let start_line = node.start_position().row as u32;
         let end_line = node.end_position().row as u32;
         let start_column = node.start_position().column as u32;
@@ -441,7 +441,7 @@ impl CSharpExtractor {
         let name = Self::extract_name(state, node).unwrap_or_else(|| "<anonymous>".to_string());
         let visibility = Self::extract_csharp_visibility(node, state);
         let docstring = Self::extract_xml_docstring(state, node);
-        let signature = Self::extract_declaration_signature(state, node);
+        let signature = Some(Self::extract_declaration_signature(state, node));
         let start_line = node.start_position().row as u32;
         let end_line = node.end_position().row as u32;
         let start_column = node.start_position().column as u32;
@@ -502,7 +502,7 @@ impl CSharpExtractor {
         let name = Self::extract_name(state, node).unwrap_or_else(|| "<anonymous>".to_string());
         let visibility = Self::extract_csharp_visibility(node, state);
         let docstring = Self::extract_xml_docstring(state, node);
-        let signature = Self::extract_declaration_signature(state, node);
+        let signature = Some(Self::extract_declaration_signature(state, node));
         let start_line = node.start_position().row as u32;
         let end_line = node.end_position().row as u32;
         let start_column = node.start_position().column as u32;
@@ -553,7 +553,7 @@ impl CSharpExtractor {
         state.node_stack.pop();
     }
 
-    /// Extract enum members from an enum_member_declaration_list.
+    /// Extract enum members from an `enum_member_declaration_list`.
     fn extract_enum_members(state: &mut ExtractionState, body: TsNode<'_>) {
         let mut cursor = body.walk();
         if cursor.goto_first_child() {
@@ -569,7 +569,7 @@ impl CSharpExtractor {
         }
     }
 
-    /// Extract a single enum member as an EnumVariant node.
+    /// Extract a single enum member as an `EnumVariant` node.
     fn extract_single_enum_member(state: &mut ExtractionState, node: TsNode<'_>) {
         let name = Self::extract_name(state, node).unwrap_or_else(|| {
             // Fallback: try to get the identifier child directly
@@ -635,7 +635,7 @@ impl CSharpExtractor {
         let name = Self::extract_name(state, node).unwrap_or_else(|| "<anonymous>".to_string());
         let visibility = Self::extract_csharp_visibility(node, state);
         let docstring = Self::extract_xml_docstring(state, node);
-        let signature = Self::extract_declaration_signature(state, node);
+        let signature = Some(Self::extract_declaration_signature(state, node));
         let start_line = node.start_position().row as u32;
         let end_line = node.end_position().row as u32;
         let start_column = node.start_position().column as u32;
@@ -703,7 +703,7 @@ impl CSharpExtractor {
         let name = Self::extract_name(state, node).unwrap_or_else(|| "<anonymous>".to_string());
         let visibility = Self::extract_csharp_visibility(node, state);
         let docstring = Self::extract_xml_docstring(state, node);
-        let signature = Self::extract_declaration_signature(state, node);
+        let signature = Some(Self::extract_declaration_signature(state, node));
         let start_line = node.start_position().row as u32;
         let end_line = node.end_position().row as u32;
         let start_column = node.start_position().column as u32;
@@ -778,7 +778,7 @@ impl CSharpExtractor {
             .child_by_field_name("type")
             .map(|n| state.node_text(n))
             .unwrap_or_default();
-        let sig = format!("{} {}", type_str, name);
+        let sig = format!("{type_str} {name}");
 
         let graph_node = Node {
             id: id.clone(),
@@ -836,7 +836,7 @@ impl CSharpExtractor {
         }
     }
 
-    /// Extract variable declarators from a variable_declaration node.
+    /// Extract variable declarators from a `variable_declaration` node.
     fn extract_variable_declarators(
         state: &mut ExtractionState,
         node: TsNode<'_>,
@@ -871,8 +871,7 @@ impl CSharpExtractor {
                             }
                             None
                         })
-                        .map(|n| state.node_text(n))
-                        .unwrap_or_else(|| state.node_text(child));
+                        .map_or_else(|| state.node_text(child), |n| state.node_text(n));
 
                     let qualified_name = format!("{}::{}", state.qualified_prefix(), field_name);
                     let id = generate_node_id(
@@ -892,7 +891,7 @@ impl CSharpExtractor {
                         end_line,
                         start_column,
                         end_column,
-                        signature: Some(signature_text.to_string()),
+                        signature: Some(signature_text.clone()),
                         docstring: None,
                         visibility: visibility.clone(),
                         is_async: false,
@@ -929,7 +928,7 @@ impl CSharpExtractor {
         let name = Self::extract_name(state, node).unwrap_or_else(|| "<anonymous>".to_string());
         let visibility = Self::extract_csharp_visibility(node, state);
         let docstring = Self::extract_xml_docstring(state, node);
-        let signature = Self::extract_declaration_signature(state, node);
+        let signature = Some(Self::extract_declaration_signature(state, node));
         let start_line = node.start_position().row as u32;
         let end_line = node.end_position().row as u32;
         let start_column = node.start_position().column as u32;
@@ -1091,7 +1090,7 @@ impl CSharpExtractor {
         }
     }
 
-    /// Extract attribute lists as AnnotationUsage nodes with Annotates edges.
+    /// Extract attribute lists as `AnnotationUsage` nodes with Annotates edges.
     fn visit_attribute_list(state: &mut ExtractionState, node: TsNode<'_>) {
         // Find the next declaration sibling - that's the declaration this attribute annotates.
         let target_id = Self::find_next_declaration_id(state, node);
@@ -1175,7 +1174,7 @@ impl CSharpExtractor {
         node.child_by_field_name("name").map(|n| state.node_text(n))
     }
 
-    /// Try to extract a qualified_name child for namespace declarations.
+    /// Try to extract a `qualified_name` child for namespace declarations.
     fn extract_qualified_name_child(state: &ExtractionState, node: TsNode<'_>) -> Option<String> {
         let mut cursor = node.walk();
         if cursor.goto_first_child() {
@@ -1287,12 +1286,12 @@ impl CSharpExtractor {
     }
 
     /// Extract the declaration signature (text from start up to the opening `{`).
-    fn extract_declaration_signature(state: &ExtractionState, node: TsNode<'_>) -> Option<String> {
+    fn extract_declaration_signature(state: &ExtractionState, node: TsNode<'_>) -> String {
         let text = state.node_text(node);
         if let Some(brace_pos) = text.find('{') {
-            Some(text[..brace_pos].trim().to_string())
+            text[..brace_pos].trim().to_string()
         } else {
-            Some(text.trim_end_matches(';').trim().to_string())
+            text.trim_end_matches(';').trim().to_string()
         }
     }
 
@@ -1378,7 +1377,7 @@ impl CSharpExtractor {
         }
     }
 
-    /// Extract types from a base_list node.
+    /// Extract types from a `base_list` node.
     fn extract_base_types(
         state: &mut ExtractionState,
         node: TsNode<'_>,
@@ -1419,8 +1418,8 @@ impl CSharpExtractor {
         }
     }
 
-    /// Extract attributes from a declaration node's attribute_list children.
-    /// Creates AnnotationUsage nodes and Annotates edges pointing to the target declaration.
+    /// Extract attributes from a declaration node's `attribute_list` children.
+    /// Creates `AnnotationUsage` nodes and Annotates edges pointing to the target declaration.
     fn extract_attributes_from_declaration(
         state: &mut ExtractionState,
         node: TsNode<'_>,
@@ -1440,7 +1439,7 @@ impl CSharpExtractor {
         }
     }
 
-    /// Visit an attribute_list node and create AnnotationUsage nodes targeting a known declaration.
+    /// Visit an `attribute_list` node and create `AnnotationUsage` nodes targeting a known declaration.
     fn visit_attribute_list_for_target(
         state: &mut ExtractionState,
         node: TsNode<'_>,
@@ -1535,7 +1534,7 @@ impl CSharpExtractor {
         state.node_text(node).trim().to_string()
     }
 
-    /// Find the next declaration sibling after an attribute_list and compute its ID.
+    /// Find the next declaration sibling after an `attribute_list` and compute its ID.
     fn find_next_declaration_id(state: &ExtractionState, node: TsNode<'_>) -> Option<String> {
         let mut current = node.next_named_sibling();
         while let Some(sibling) = current {
@@ -1578,7 +1577,6 @@ impl CSharpExtractor {
                         }
                         "constructor_declaration" => NodeKind::Constructor,
                         "property_declaration" => NodeKind::CSharpProperty,
-                        "field_declaration" => return None, // Fields have complex ID generation
                         "record_declaration" | "record_struct_declaration" => NodeKind::Record,
                         "delegate_declaration" => NodeKind::Delegate,
                         "event_declaration" | "event_field_declaration" => NodeKind::Event,
@@ -1593,7 +1591,7 @@ impl CSharpExtractor {
         None
     }
 
-    /// Recursively find invocation_expression nodes and create unresolved Calls references.
+    /// Recursively find `invocation_expression` nodes and create unresolved Calls references.
     fn extract_call_sites(state: &mut ExtractionState, node: TsNode<'_>, fn_node_id: &str) {
         let mut cursor = node.walk();
         if cursor.goto_first_child() {
@@ -1638,7 +1636,7 @@ impl CSharpExtractor {
         }
     }
 
-    /// Extract the name from an invocation_expression node.
+    /// Extract the name from an `invocation_expression` node.
     fn extract_invocation_name(state: &ExtractionState, node: TsNode<'_>) -> String {
         // invocation_expression: function + argument_list
         if let Some(func_node) = node.child_by_field_name("function") {
@@ -1653,7 +1651,7 @@ impl CSharpExtractor {
         state.node_text(node)
     }
 
-    /// Extract the type name from an object_creation_expression.
+    /// Extract the type name from an `object_creation_expression`.
     fn extract_object_creation_type(state: &ExtractionState, node: TsNode<'_>) -> String {
         if let Some(type_node) = node.child_by_field_name("type") {
             return state.node_text(type_node);
@@ -1678,7 +1676,7 @@ impl CSharpExtractor {
         "<unknown>".to_string()
     }
 
-    /// Build the final ExtractionResult from the accumulated state.
+    /// Build the final `ExtractionResult` from the accumulated state.
     fn build_result(state: ExtractionState, start: Instant) -> ExtractionResult {
         ExtractionResult {
             nodes: state.nodes,
@@ -1695,7 +1693,7 @@ impl crate::extraction::LanguageExtractor for CSharpExtractor {
         &["cs"]
     }
 
-    fn language_name(&self) -> &str {
+    fn language_name(&self) -> &'static str {
         "C#"
     }
 

--- a/src/extraction/dart_extractor.rs
+++ b/src/extraction/dart_extractor.rs
@@ -5,7 +5,7 @@ use std::time::{Instant, SystemTime, UNIX_EPOCH};
 
 use tree_sitter::{Node as TsNode, Parser, Tree};
 
-use crate::extraction::complexity::{count_complexity, DART_COMPLEXITY};
+use crate::extraction::complexity::{count_complexity, ComplexityMetrics, DART_COMPLEXITY};
 use crate::types::{
     generate_node_id, Edge, EdgeKind, ExtractionResult, Node, NodeKind, UnresolvedRef, Visibility,
 };
@@ -19,7 +19,7 @@ struct ExtractionState {
     edges: Vec<Edge>,
     unresolved_refs: Vec<UnresolvedRef>,
     errors: Vec<String>,
-    /// Stack of (name, node_id) for building qualified names and parent edges.
+    /// Stack of (name, `node_id`) for building qualified names and parent edges.
     node_stack: Vec<(String, String)>,
     file_path: String,
     source: Vec<u8>,
@@ -136,7 +136,7 @@ impl DartExtractor {
     }
 
     /// Visit children of the program node. In Dart's grammar, top-level items
-    /// like function_signature + function_body appear as siblings at the program level.
+    /// like `function_signature` + `function_body` appear as siblings at the program level.
     fn visit_program_children(state: &mut ExtractionState, node: TsNode<'_>) {
         let mut cursor = node.walk();
         if !cursor.goto_first_child() {
@@ -174,9 +174,10 @@ impl DartExtractor {
     // ----------------------------------
 
     fn visit_library(state: &mut ExtractionState, node: TsNode<'_>) {
-        let name = Self::find_child_by_kind(node, "dotted_identifier_list")
-            .map(|n| state.node_text(n))
-            .unwrap_or_else(|| state.node_text(node).trim().to_string());
+        let name = Self::find_child_by_kind(node, "dotted_identifier_list").map_or_else(
+            || state.node_text(node).trim().to_string(),
+            |n| state.node_text(n),
+        );
 
         let start_line = node.start_position().row as u32;
         let end_line = node.end_position().row as u32;
@@ -297,8 +298,8 @@ impl DartExtractor {
     // Top-level function
     // ----------------------------------
 
-    /// Visit a top-level function. In Dart's grammar, function_signature and
-    /// function_body are siblings at the program level.
+    /// Visit a top-level function. In Dart's grammar, `function_signature` and
+    /// `function_body` are siblings at the program level.
     fn visit_top_level_function(
         state: &mut ExtractionState,
         sig_node: TsNode<'_>,
@@ -306,8 +307,7 @@ impl DartExtractor {
     ) {
         let name = sig_node
             .child_by_field_name("name")
-            .map(|n| state.node_text(n))
-            .unwrap_or_else(|| "<anonymous>".to_string());
+            .map_or_else(|| "<anonymous>".to_string(), |n| state.node_text(n));
 
         let visibility = Self::dart_visibility(&name);
         let docstring = Self::extract_docstring(state, sig_node);
@@ -333,7 +333,7 @@ impl DartExtractor {
         });
         let qualified_name = format!("{}::{}", state.qualified_prefix(), name);
         let id = generate_node_id(&state.file_path, &NodeKind::Function, &name, start_line);
-        let metrics = body.map_or(Default::default(), |b| {
+        let metrics = body.map_or(ComplexityMetrics::default(), |b| {
             count_complexity(b, &DART_COMPLEXITY, &state.source)
         });
 
@@ -389,12 +389,11 @@ impl DartExtractor {
 
         let name = node
             .child_by_field_name("name")
-            .map(|n| state.node_text(n))
-            .unwrap_or_else(|| "<anonymous>".to_string());
+            .map_or_else(|| "<anonymous>".to_string(), |n| state.node_text(n));
 
         let visibility = Self::dart_visibility(&name);
         let docstring = Self::extract_docstring(state, node);
-        let signature = Self::extract_signature_to_brace(state, node);
+        let signature = Some(Self::extract_signature_to_brace(state, node));
         let start_line = node.start_position().row as u32;
         let end_line = node.end_position().row as u32;
         let start_column = node.start_position().column as u32;
@@ -476,12 +475,11 @@ impl DartExtractor {
 
     fn visit_mixin(state: &mut ExtractionState, node: TsNode<'_>) {
         let name = Self::find_child_by_kind(node, "identifier")
-            .map(|n| state.node_text(n))
-            .unwrap_or_else(|| "<anonymous>".to_string());
+            .map_or_else(|| "<anonymous>".to_string(), |n| state.node_text(n));
 
         let visibility = Self::dart_visibility(&name);
         let docstring = Self::extract_docstring(state, node);
-        let signature = Self::extract_signature_to_brace(state, node);
+        let signature = Some(Self::extract_signature_to_brace(state, node));
         let start_line = node.start_position().row as u32;
         let end_line = node.end_position().row as u32;
         let start_column = node.start_position().column as u32;
@@ -542,12 +540,11 @@ impl DartExtractor {
 
     fn visit_extension(state: &mut ExtractionState, node: TsNode<'_>) {
         let name = Self::find_child_by_kind(node, "identifier")
-            .map(|n| state.node_text(n))
-            .unwrap_or_else(|| "<anonymous>".to_string());
+            .map_or_else(|| "<anonymous>".to_string(), |n| state.node_text(n));
 
         let visibility = Self::dart_visibility(&name);
         let docstring = Self::extract_docstring(state, node);
-        let signature = Self::extract_signature_to_brace(state, node);
+        let signature = Some(Self::extract_signature_to_brace(state, node));
         let start_line = node.start_position().row as u32;
         let end_line = node.end_position().row as u32;
         let start_column = node.start_position().column as u32;
@@ -606,12 +603,11 @@ impl DartExtractor {
     fn visit_enum(state: &mut ExtractionState, node: TsNode<'_>) {
         let name = node
             .child_by_field_name("name")
-            .map(|n| state.node_text(n))
-            .unwrap_or_else(|| "<anonymous>".to_string());
+            .map_or_else(|| "<anonymous>".to_string(), |n| state.node_text(n));
 
         let visibility = Self::dart_visibility(&name);
         let docstring = Self::extract_docstring(state, node);
-        let signature = Self::extract_signature_to_brace(state, node);
+        let signature = Some(Self::extract_signature_to_brace(state, node));
         let start_line = node.start_position().row as u32;
         let end_line = node.end_position().row as u32;
         let start_column = node.start_position().column as u32;
@@ -687,8 +683,7 @@ impl DartExtractor {
     fn visit_enum_constant(state: &mut ExtractionState, node: TsNode<'_>) {
         let name = node
             .child_by_field_name("name")
-            .map(|n| state.node_text(n))
-            .unwrap_or_else(|| "<anonymous>".to_string());
+            .map_or_else(|| "<anonymous>".to_string(), |n| state.node_text(n));
 
         let start_line = node.start_position().row as u32;
         let end_line = node.end_position().row as u32;
@@ -739,8 +734,7 @@ impl DartExtractor {
     fn visit_type_alias(state: &mut ExtractionState, node: TsNode<'_>) {
         let name = Self::find_child_by_kind(node, "type_identifier")
             .or_else(|| Self::find_child_by_kind(node, "identifier"))
-            .map(|n| state.node_text(n))
-            .unwrap_or_else(|| "<anonymous>".to_string());
+            .map_or_else(|| "<anonymous>".to_string(), |n| state.node_text(n));
 
         let visibility = Self::dart_visibility(&name);
         let docstring = Self::extract_docstring(state, node);
@@ -843,11 +837,7 @@ impl DartExtractor {
                         Self::visit_constructor(state, node, child);
                         return;
                     }
-                    "getter_signature" => {
-                        Self::visit_getter_or_setter(state, node, child);
-                        return;
-                    }
-                    "setter_signature" => {
+                    "getter_signature" | "setter_signature" => {
                         Self::visit_getter_or_setter(state, node, child);
                         return;
                     }
@@ -892,11 +882,7 @@ impl DartExtractor {
                     Self::visit_constructor(state, node, child);
                     return;
                 }
-                "getter_signature" => {
-                    Self::visit_getter_or_setter(state, node, child);
-                    return;
-                }
-                "setter_signature" => {
+                "getter_signature" | "setter_signature" => {
                     Self::visit_getter_or_setter(state, node, child);
                     return;
                 }
@@ -934,7 +920,7 @@ impl DartExtractor {
         }
     }
 
-    /// Visit a method from a function_signature node (inside a class body).
+    /// Visit a method from a `function_signature` node (inside a class body).
     fn visit_method_from_sig(
         state: &mut ExtractionState,
         sig_node: TsNode<'_>,
@@ -942,8 +928,7 @@ impl DartExtractor {
     ) {
         let name = sig_node
             .child_by_field_name("name")
-            .map(|n| state.node_text(n))
-            .unwrap_or_else(|| "<anonymous>".to_string());
+            .map_or_else(|| "<anonymous>".to_string(), |n| state.node_text(n));
 
         let visibility = Self::dart_visibility(&name);
         let docstring = Self::extract_docstring(state, sig_node);
@@ -965,7 +950,7 @@ impl DartExtractor {
         });
         let qualified_name = format!("{}::{}", state.qualified_prefix(), name);
         let id = generate_node_id(&state.file_path, &NodeKind::Method, &name, start_line);
-        let metrics = body.map_or(Default::default(), |b| {
+        let metrics = body.map_or(ComplexityMetrics::default(), |b| {
             count_complexity(b, &DART_COMPLEXITY, &state.source)
         });
 
@@ -1102,8 +1087,7 @@ impl DartExtractor {
         sig_node: TsNode<'_>,
     ) {
         let name = Self::find_child_by_kind(sig_node, "identifier")
-            .map(|n| state.node_text(n))
-            .unwrap_or_else(|| "<anonymous>".to_string());
+            .map_or_else(|| "<anonymous>".to_string(), |n| state.node_text(n));
 
         let visibility = Self::dart_visibility(&name);
         let docstring = Self::extract_docstring(state, decl_node);
@@ -1167,9 +1151,9 @@ impl DartExtractor {
 
     fn visit_operator(state: &mut ExtractionState, decl_node: TsNode<'_>, _sig_node: TsNode<'_>) {
         let text = state.node_text(decl_node);
-        let name = text
-            .find("operator")
-            .map(|pos| {
+        let name = text.find("operator").map_or_else(
+            || "operator".to_string(),
+            |pos| {
                 let after = &text[pos + 8..];
                 after
                     .trim()
@@ -1178,9 +1162,9 @@ impl DartExtractor {
                     .unwrap_or("")
                     .trim()
                     .to_string()
-            })
-            .unwrap_or_else(|| "operator".to_string());
-        let name = format!("operator {}", name);
+            },
+        );
+        let name = format!("operator {name}");
 
         let docstring = Self::extract_docstring(state, decl_node);
         let signature = text.find('{').map_or_else(
@@ -1235,27 +1219,26 @@ impl DartExtractor {
     // Fields
     // ----------------------------------
 
-    /// Visit initialized_variable_definition: `Type name = value;`
+    /// Visit `initialized_variable_definition`: `Type name = value;`
     fn visit_initialized_var_def(
         state: &mut ExtractionState,
         decl_node: TsNode<'_>,
         var_def: TsNode<'_>,
         _has_static: bool,
     ) {
-        let name = var_def
-            .child_by_field_name("name")
-            .map(|n| state.node_text(n))
-            .unwrap_or_else(|| {
+        let name = var_def.child_by_field_name("name").map_or_else(
+            || {
                 Self::find_child_by_kind(var_def, "identifier")
-                    .map(|n| state.node_text(n))
-                    .unwrap_or_else(|| "<anonymous>".to_string())
-            });
+                    .map_or_else(|| "<anonymous>".to_string(), |n| state.node_text(n))
+            },
+            |n| state.node_text(n),
+        );
 
         Self::emit_field(state, decl_node, &name);
     }
 
-    /// Visit initialized_identifier_list field: `Type name;` pattern
-    /// where declaration has type_identifier + initialized_identifier_list children.
+    /// Visit `initialized_identifier_list` field: `Type name;` pattern
+    /// where declaration has `type_identifier` + `initialized_identifier_list` children.
     fn visit_identifier_list_field(
         state: &mut ExtractionState,
         decl_node: TsNode<'_>,
@@ -1279,7 +1262,7 @@ impl DartExtractor {
         }
     }
 
-    /// Visit static_final_declaration_list fields.
+    /// Visit `static_final_declaration_list` fields.
     fn visit_static_final_declarations(
         state: &mut ExtractionState,
         decl_node: TsNode<'_>,
@@ -1476,16 +1459,16 @@ impl DartExtractor {
     // ----------------------------
 
     /// Extract a signature by trimming at the first `{`.
-    fn extract_signature_to_brace(state: &ExtractionState, node: TsNode<'_>) -> Option<String> {
+    fn extract_signature_to_brace(state: &ExtractionState, node: TsNode<'_>) -> String {
         let text = state.node_text(node);
         if let Some(brace_pos) = text.find('{') {
-            Some(text[..brace_pos].trim().to_string())
+            text[..brace_pos].trim().to_string()
         } else {
-            Some(text.trim().to_string())
+            text.trim().to_string()
         }
     }
 
-    /// Extract docstrings from preceding documentation_comment or `///` comment nodes.
+    /// Extract docstrings from preceding `documentation_comment` or `///` comment nodes.
     fn extract_docstring(state: &ExtractionState, node: TsNode<'_>) -> Option<String> {
         let mut comments = Vec::new();
         let mut current = node.prev_named_sibling();
@@ -1705,7 +1688,7 @@ impl DartExtractor {
             .to_string()
     }
 
-    /// Build the final ExtractionResult from the accumulated state.
+    /// Build the final `ExtractionResult` from the accumulated state.
     fn build_result(state: ExtractionState, start: Instant) -> ExtractionResult {
         ExtractionResult {
             nodes: state.nodes,
@@ -1722,7 +1705,7 @@ impl crate::extraction::LanguageExtractor for DartExtractor {
         &["dart"]
     }
 
-    fn language_name(&self) -> &str {
+    fn language_name(&self) -> &'static str {
         "Dart"
     }
 

--- a/src/extraction/dockerfile_extractor.rs
+++ b/src/extraction/dockerfile_extractor.rs
@@ -17,7 +17,7 @@ struct ExtractionState {
     nodes: Vec<Node>,
     edges: Vec<Edge>,
     errors: Vec<String>,
-    /// Stack of (name, node_id) for building qualified names and parent edges.
+    /// Stack of (name, `node_id`) for building qualified names and parent edges.
     node_stack: Vec<(String, String)>,
     file_path: String,
     source: Vec<u8>,
@@ -289,7 +289,7 @@ impl DockerfileExtractor {
         }
     }
 
-    /// Extract a single env_pair as a Const node.
+    /// Extract a single `env_pair` as a Const node.
     fn extract_env_pair(state: &mut ExtractionState, node: TsNode<'_>) {
         let name = match node.child_by_field_name("name") {
             Some(n) => state.node_text(n),
@@ -463,14 +463,13 @@ impl DockerfileExtractor {
             loop {
                 let child = cursor.node();
                 if child.kind() == "label_pair" {
-                    let key = match child.child_by_field_name("key") {
-                        Some(n) => state.node_text(n),
-                        None => {
-                            if !cursor.goto_next_sibling() {
-                                break;
-                            }
-                            continue;
+                    let key = if let Some(n) = child.child_by_field_name("key") {
+                        state.node_text(n)
+                    } else {
+                        if !cursor.goto_next_sibling() {
+                            break;
                         }
+                        continue;
                     };
 
                     let start_line = child.start_position().row as u32;
@@ -594,7 +593,7 @@ impl DockerfileExtractor {
         None
     }
 
-    /// Build the final ExtractionResult from the accumulated state.
+    /// Build the final `ExtractionResult` from the accumulated state.
     fn build_result(state: ExtractionState, start: Instant) -> ExtractionResult {
         ExtractionResult {
             nodes: state.nodes,
@@ -611,7 +610,7 @@ impl crate::extraction::LanguageExtractor for DockerfileExtractor {
         &["dockerfile", "Dockerfile"]
     }
 
-    fn language_name(&self) -> &str {
+    fn language_name(&self) -> &'static str {
         "Dockerfile"
     }
 

--- a/src/extraction/fortran_extractor.rs
+++ b/src/extraction/fortran_extractor.rs
@@ -19,7 +19,7 @@ struct ExtractionState {
     edges: Vec<Edge>,
     unresolved_refs: Vec<UnresolvedRef>,
     errors: Vec<String>,
-    /// Stack of (name, node_id) for building qualified names and parent edges.
+    /// Stack of (name, `node_id`) for building qualified names and parent edges.
     node_stack: Vec<(String, String)>,
     file_path: String,
     source: Vec<u8>,
@@ -458,7 +458,7 @@ impl FortranExtractor {
         state.node_stack.pop();
     }
 
-    /// Visit variable_declaration children inside a derived_type_definition to extract fields.
+    /// Visit `variable_declaration` children inside a `derived_type_definition` to extract fields.
     fn visit_derived_type_fields(state: &mut ExtractionState, node: TsNode<'_>) {
         let mut cursor = node.walk();
         if cursor.goto_first_child() {
@@ -474,13 +474,12 @@ impl FortranExtractor {
         }
     }
 
-    /// Extract a field from a variable_declaration inside a derived type.
+    /// Extract a field from a `variable_declaration` inside a derived type.
     fn visit_field(state: &mut ExtractionState, node: TsNode<'_>) {
         // The field name is in the `declarator` field, which is an `identifier`.
         let name = node
             .child_by_field_name("declarator")
-            .map(|n| state.node_text(n))
-            .unwrap_or_else(|| "<anonymous>".to_string());
+            .map_or_else(|| "<anonymous>".to_string(), |n| state.node_text(n));
 
         let start_line = node.start_position().row as u32;
         let end_line = node.end_position().row as u32;
@@ -580,9 +579,9 @@ impl FortranExtractor {
         }
     }
 
-    /// Extract a variable_declaration at module/program scope.
+    /// Extract a `variable_declaration` at module/program scope.
     ///
-    /// If it has a `parameter` type_qualifier and an init_declarator, treat it as a Const.
+    /// If it has a `parameter` `type_qualifier` and an `init_declarator`, treat it as a Const.
     fn visit_variable_declaration(state: &mut ExtractionState, node: TsNode<'_>) {
         // Check for `parameter` attribute (Fortran constant).
         if !Self::has_parameter_attribute(state, node) {
@@ -595,8 +594,7 @@ impl FortranExtractor {
             if decl.kind() == "init_declarator" {
                 let name = decl
                     .child_by_field_name("left")
-                    .map(|n| state.node_text(n))
-                    .unwrap_or_else(|| "<anonymous>".to_string());
+                    .map_or_else(|| "<anonymous>".to_string(), |n| state.node_text(n));
 
                 let docstring = Self::extract_docstring(state, node);
                 let start_line = node.start_position().row as u32;
@@ -648,8 +646,7 @@ impl FortranExtractor {
     /// Extract a use statement.
     fn visit_use_statement(state: &mut ExtractionState, node: TsNode<'_>) {
         let name = Self::find_child_by_kind(node, "module_name")
-            .map(|n| state.node_text(n))
-            .unwrap_or_else(|| "<unknown>".to_string());
+            .map_or_else(|| "<unknown>".to_string(), |n| state.node_text(n));
 
         let start_line = node.start_position().row as u32;
         let end_line = node.end_position().row as u32;
@@ -699,43 +696,39 @@ impl FortranExtractor {
     // ----------------------------
 
     /// Find the module name from a module node.
-    /// Structure: module -> module_statement -> name
+    /// Structure: module -> `module_statement` -> name
     fn find_module_name(state: &ExtractionState, node: TsNode<'_>) -> String {
         Self::find_child_by_kind(node, "module_statement")
             .and_then(|stmt| Self::find_child_by_kind(stmt, "name"))
-            .map(|n| state.node_text(n))
-            .unwrap_or_else(|| "<anonymous>".to_string())
+            .map_or_else(|| "<anonymous>".to_string(), |n| state.node_text(n))
     }
 
     /// Find the program name from a program node.
-    /// Structure: program -> program_statement -> name
+    /// Structure: program -> `program_statement` -> name
     fn find_program_name(state: &ExtractionState, node: TsNode<'_>) -> String {
         Self::find_child_by_kind(node, "program_statement")
             .and_then(|stmt| Self::find_child_by_kind(stmt, "name"))
-            .map(|n| state.node_text(n))
-            .unwrap_or_else(|| "<anonymous>".to_string())
+            .map_or_else(|| "<anonymous>".to_string(), |n| state.node_text(n))
     }
 
     /// Find the subroutine name from a subroutine node.
-    /// Structure: subroutine -> subroutine_statement (field name="name")
+    /// Structure: subroutine -> `subroutine_statement` (field name="name")
     fn find_subroutine_name(state: &ExtractionState, node: TsNode<'_>) -> String {
         Self::find_child_by_kind(node, "subroutine_statement")
             .and_then(|stmt| stmt.child_by_field_name("name"))
-            .map(|n| state.node_text(n))
-            .unwrap_or_else(|| "<anonymous>".to_string())
+            .map_or_else(|| "<anonymous>".to_string(), |n| state.node_text(n))
     }
 
     /// Find the function name from a function node.
-    /// Structure: function -> function_statement (field name="name")
+    /// Structure: function -> `function_statement` (field name="name")
     fn find_function_name(state: &ExtractionState, node: TsNode<'_>) -> String {
         Self::find_child_by_kind(node, "function_statement")
             .and_then(|stmt| stmt.child_by_field_name("name"))
-            .map(|n| state.node_text(n))
-            .unwrap_or_else(|| "<anonymous>".to_string())
+            .map_or_else(|| "<anonymous>".to_string(), |n| state.node_text(n))
     }
 
     /// Find the derived type name and optional base type.
-    /// Structure: derived_type_definition -> derived_type_statement -> type_name, optional base_type_specifier
+    /// Structure: `derived_type_definition` -> `derived_type_statement` -> `type_name`, optional `base_type_specifier`
     fn find_derived_type_info(
         state: &ExtractionState,
         node: TsNode<'_>,
@@ -743,8 +736,7 @@ impl FortranExtractor {
         let stmt = Self::find_child_by_kind(node, "derived_type_statement");
         let name = stmt
             .and_then(|s| Self::find_child_by_kind(s, "type_name"))
-            .map(|n| state.node_text(n))
-            .unwrap_or_else(|| "<anonymous>".to_string());
+            .map_or_else(|| "<anonymous>".to_string(), |n| state.node_text(n));
 
         let base_type = stmt
             .and_then(|s| s.child_by_field_name("base"))
@@ -755,15 +747,14 @@ impl FortranExtractor {
     }
 
     /// Find the interface name.
-    /// Structure: interface -> interface_statement -> name
+    /// Structure: interface -> `interface_statement` -> name
     fn find_interface_name(state: &ExtractionState, node: TsNode<'_>) -> String {
         Self::find_child_by_kind(node, "interface_statement")
             .and_then(|stmt| Self::find_child_by_kind(stmt, "name"))
-            .map(|n| state.node_text(n))
-            .unwrap_or_else(|| "<anonymous>".to_string())
+            .map_or_else(|| "<anonymous>".to_string(), |n| state.node_text(n))
     }
 
-    /// Check if a variable_declaration has a `parameter` attribute.
+    /// Check if a `variable_declaration` has a `parameter` attribute.
     fn has_parameter_attribute(state: &ExtractionState, node: TsNode<'_>) -> bool {
         let mut cursor = node.walk();
         if cursor.goto_first_child() {
@@ -894,7 +885,7 @@ impl FortranExtractor {
         None
     }
 
-    /// Build the final ExtractionResult from the accumulated state.
+    /// Build the final `ExtractionResult` from the accumulated state.
     fn build_result(state: ExtractionState, start: Instant) -> ExtractionResult {
         ExtractionResult {
             nodes: state.nodes,
@@ -911,7 +902,7 @@ impl crate::extraction::LanguageExtractor for FortranExtractor {
         &["f90", "f95", "f03", "f08", "f18", "f", "for"]
     }
 
-    fn language_name(&self) -> &str {
+    fn language_name(&self) -> &'static str {
         "Fortran"
     }
 

--- a/src/extraction/glsl_extractor.rs
+++ b/src/extraction/glsl_extractor.rs
@@ -20,7 +20,7 @@ struct ExtractionState {
     edges: Vec<Edge>,
     unresolved_refs: Vec<UnresolvedRef>,
     errors: Vec<String>,
-    /// Stack of (name, node_id) for building qualified names and parent edges.
+    /// Stack of (name, `node_id`) for building qualified names and parent edges.
     node_stack: Vec<(String, String)>,
     file_path: String,
     source: Vec<u8>,
@@ -155,7 +155,7 @@ impl GlslExtractor {
     fn visit_function_definition(state: &mut ExtractionState, node: TsNode<'_>) {
         let name =
             Self::extract_function_name(state, node).unwrap_or_else(|| "<anonymous>".to_string());
-        let signature = Self::extract_function_signature(state, node);
+        let signature = Some(Self::extract_function_signature(state, node));
         let docstring = Self::extract_docstring(state, node);
         let start_line = node.start_position().row as u32;
         let end_line = node.end_position().row as u32;
@@ -214,12 +214,12 @@ impl GlslExtractor {
         None
     }
 
-    fn extract_function_signature(state: &ExtractionState, node: TsNode<'_>) -> Option<String> {
+    fn extract_function_signature(state: &ExtractionState, node: TsNode<'_>) -> String {
         let text = state.node_text(node);
         if let Some(brace_pos) = text.find('{') {
-            Some(text[..brace_pos].trim().to_string())
+            text[..brace_pos].trim().to_string()
         } else {
-            Some(text.trim().trim_end_matches(';').trim().to_string())
+            text.trim().trim_end_matches(';').trim().to_string()
         }
     }
 
@@ -395,8 +395,7 @@ impl GlslExtractor {
         }
 
         let name = Self::find_child_by_kind(node, "type_identifier")
-            .map(|n| state.node_text(n))
-            .unwrap_or_else(|| "<anonymous>".to_string());
+            .map_or_else(|| "<anonymous>".to_string(), |n| state.node_text(n));
 
         let start_line = node.start_position().row as u32;
         let end_line = node.end_position().row as u32;
@@ -537,8 +536,7 @@ impl GlslExtractor {
 
     fn visit_preproc_def(state: &mut ExtractionState, node: TsNode<'_>) {
         let name = Self::find_child_by_kind(node, "identifier")
-            .map(|n| state.node_text(n))
-            .unwrap_or_else(|| "<anonymous>".to_string());
+            .map_or_else(|| "<anonymous>".to_string(), |n| state.node_text(n));
 
         let start_line = node.start_position().row as u32;
         let end_line = node.end_position().row as u32;
@@ -586,8 +584,7 @@ impl GlslExtractor {
     fn visit_preproc_include(state: &mut ExtractionState, node: TsNode<'_>) {
         let include_path = Self::find_child_by_kind(node, "string_literal")
             .or_else(|| Self::find_child_by_kind(node, "system_lib_string"))
-            .map(|n| state.node_text(n))
-            .unwrap_or_else(|| "<unknown>".to_string());
+            .map_or_else(|| "<unknown>".to_string(), |n| state.node_text(n));
 
         let line = node.start_position().row as u32;
         let column = node.start_position().column as u32;
@@ -777,7 +774,7 @@ impl crate::extraction::LanguageExtractor for GlslExtractor {
         &["glsl", "vert", "frag", "geom", "comp", "tesc", "tese"]
     }
 
-    fn language_name(&self) -> &str {
+    fn language_name(&self) -> &'static str {
         "GLSL"
     }
 

--- a/src/extraction/go_extractor.rs
+++ b/src/extraction/go_extractor.rs
@@ -19,7 +19,7 @@ struct ExtractionState {
     edges: Vec<Edge>,
     unresolved_refs: Vec<UnresolvedRef>,
     errors: Vec<String>,
-    /// Stack of (name, node_id) for building qualified names and parent edges.
+    /// Stack of (name, `node_id`) for building qualified names and parent edges.
     node_stack: Vec<(String, String)>,
     file_path: String,
     source: Vec<u8>,
@@ -166,8 +166,7 @@ impl GoExtractor {
     /// Extract a package clause node.
     fn visit_package(state: &mut ExtractionState, node: TsNode<'_>) {
         let name = Self::find_child_by_kind(node, "package_identifier")
-            .map(|n| state.node_text(n))
-            .unwrap_or_else(|| "<unknown>".to_string());
+            .map_or_else(|| "<unknown>".to_string(), |n| state.node_text(n));
         let start_line = node.start_position().row as u32;
         let end_line = node.end_position().row as u32;
         let start_column = node.start_position().column as u32;
@@ -308,10 +307,9 @@ impl GoExtractor {
     fn visit_function(state: &mut ExtractionState, node: TsNode<'_>) {
         // In Go, function name is an `identifier` child.
         let name = Self::find_child_by_kind(node, "identifier")
-            .map(|n| state.node_text(n))
-            .unwrap_or_else(|| "<anonymous>".to_string());
+            .map_or_else(|| "<anonymous>".to_string(), |n| state.node_text(n));
         let visibility = Self::go_visibility(&name);
-        let signature = Self::extract_signature(state, node);
+        let signature = Some(Self::extract_signature(state, node));
         let docstring = Self::extract_docstring(state, node);
         let start_line = node.start_position().row as u32;
         let end_line = node.end_position().row as u32;
@@ -369,10 +367,9 @@ impl GoExtractor {
     fn visit_method(state: &mut ExtractionState, node: TsNode<'_>) {
         // In Go, method name is a `field_identifier` child.
         let name = Self::find_child_by_kind(node, "field_identifier")
-            .map(|n| state.node_text(n))
-            .unwrap_or_else(|| "<anonymous>".to_string());
+            .map_or_else(|| "<anonymous>".to_string(), |n| state.node_text(n));
         let visibility = Self::go_visibility(&name);
-        let signature = Self::extract_signature(state, node);
+        let signature = Some(Self::extract_signature(state, node));
         let docstring = Self::extract_docstring(state, node);
         let start_line = node.start_position().row as u32;
         let end_line = node.end_position().row as u32;
@@ -445,11 +442,10 @@ impl GoExtractor {
         }
     }
 
-    /// Extract a type_spec node, dispatching on whether it defines a struct or interface.
+    /// Extract a `type_spec` node, dispatching on whether it defines a struct or interface.
     fn visit_type_spec(state: &mut ExtractionState, spec_node: TsNode<'_>, decl_node: TsNode<'_>) {
         let name = Self::find_child_by_kind(spec_node, "type_identifier")
-            .map(|n| state.node_text(n))
-            .unwrap_or_else(|| "<anonymous>".to_string());
+            .map_or_else(|| "<anonymous>".to_string(), |n| state.node_text(n));
 
         // Check what type is being defined.
         if let Some(struct_type) = Self::find_child_by_kind(spec_node, "struct_type") {
@@ -522,7 +518,7 @@ impl GoExtractor {
         state.node_stack.pop();
     }
 
-    /// Extract fields from a struct_type node.
+    /// Extract fields from a `struct_type` node.
     fn extract_struct_fields(state: &mut ExtractionState, struct_type: TsNode<'_>) {
         if let Some(field_list) = Self::find_child_by_kind(struct_type, "field_declaration_list") {
             let mut cursor = field_list.walk();
@@ -540,11 +536,10 @@ impl GoExtractor {
         }
     }
 
-    /// Extract a single field from a field_declaration node.
+    /// Extract a single field from a `field_declaration` node.
     fn extract_single_field(state: &mut ExtractionState, node: TsNode<'_>) {
         let name = Self::find_child_by_kind(node, "field_identifier")
-            .map(|n| state.node_text(n))
-            .unwrap_or_else(|| "<anonymous>".to_string());
+            .map_or_else(|| "<anonymous>".to_string(), |n| state.node_text(n));
         let visibility = Self::go_visibility(&name);
         let text = state.node_text(node);
         let start_line = node.start_position().row as u32;
@@ -595,7 +590,7 @@ impl GoExtractor {
         }
     }
 
-    /// Extract a struct tag from a raw_string_literal node.
+    /// Extract a struct tag from a `raw_string_literal` node.
     fn extract_struct_tag(
         state: &mut ExtractionState,
         tag_node: TsNode<'_>,
@@ -607,7 +602,7 @@ impl GoExtractor {
         let end_line = tag_node.end_position().row as u32;
         let start_column = tag_node.start_position().column as u32;
         let end_column = tag_node.end_position().column as u32;
-        let tag_name = format!("{}:tag", field_name);
+        let tag_name = format!("{field_name}:tag");
         let qualified_name = format!("{}::{}", state.qualified_prefix(), tag_name);
         let id = generate_node_id(
             &state.file_path,
@@ -707,7 +702,7 @@ impl GoExtractor {
         Self::extract_interface_embeddings(state, iface_type, &id);
     }
 
-    /// Extract embedded interface types from an interface_type node.
+    /// Extract embedded interface types from an `interface_type` node.
     fn extract_interface_embeddings(
         state: &mut ExtractionState,
         iface_type: TsNode<'_>,
@@ -747,8 +742,7 @@ impl GoExtractor {
         decl_node: TsNode<'_>,
     ) {
         let name = Self::find_child_by_kind(alias_node, "type_identifier")
-            .map(|n| state.node_text(n))
-            .unwrap_or_else(|| "<anonymous>".to_string());
+            .map_or_else(|| "<anonymous>".to_string(), |n| state.node_text(n));
         let visibility = Self::go_visibility(&name);
         let docstring = Self::extract_docstring(state, decl_node);
         let text = state.node_text(decl_node);
@@ -843,7 +837,7 @@ impl GoExtractor {
         }
     }
 
-    /// Extract a const declaration. May contain multiple const_spec children.
+    /// Extract a const declaration. May contain multiple `const_spec` children.
     fn visit_const_declaration(state: &mut ExtractionState, node: TsNode<'_>) {
         let mut cursor = node.walk();
         if cursor.goto_first_child() {
@@ -862,8 +856,7 @@ impl GoExtractor {
     /// Extract a single const spec.
     fn visit_const_spec(state: &mut ExtractionState, node: TsNode<'_>) {
         let name = Self::find_child_by_kind(node, "identifier")
-            .map(|n| state.node_text(n))
-            .unwrap_or_else(|| "<anonymous>".to_string());
+            .map_or_else(|| "<anonymous>".to_string(), |n| state.node_text(n));
         let visibility = Self::go_visibility(&name);
         let text = state.node_text(node);
         let start_line = node.start_position().row as u32;
@@ -909,7 +902,7 @@ impl GoExtractor {
         }
     }
 
-    /// Extract a var declaration. May contain multiple var_spec children.
+    /// Extract a var declaration. May contain multiple `var_spec` children.
     fn visit_var_declaration(state: &mut ExtractionState, node: TsNode<'_>) {
         let mut cursor = node.walk();
         if cursor.goto_first_child() {
@@ -928,8 +921,7 @@ impl GoExtractor {
     /// Extract a single var spec as a Static node (Go vars are package-level state).
     fn visit_var_spec(state: &mut ExtractionState, node: TsNode<'_>) {
         let name = Self::find_child_by_kind(node, "identifier")
-            .map(|n| state.node_text(n))
-            .unwrap_or_else(|| "<anonymous>".to_string());
+            .map_or_else(|| "<anonymous>".to_string(), |n| state.node_text(n));
         let visibility = Self::go_visibility(&name);
         let text = state.node_text(node);
         let start_line = node.start_position().row as u32;
@@ -979,7 +971,7 @@ impl GoExtractor {
     // Helper extraction methods
     // ----------------------------
 
-    /// Extract the receiver type from a method_declaration and create a Receives edge.
+    /// Extract the receiver type from a `method_declaration` and create a Receives edge.
     fn extract_receiver(state: &mut ExtractionState, node: TsNode<'_>, method_id: &str) {
         // The first parameter_list child is the receiver.
         let mut cursor = node.walk();
@@ -1029,7 +1021,7 @@ impl GoExtractor {
         }
     }
 
-    /// Extract the type name from a receiver parameter_declaration.
+    /// Extract the type name from a receiver `parameter_declaration`.
     /// Handles both `c Circle` and `c *Circle` forms.
     fn extract_receiver_type_name(state: &ExtractionState, param: TsNode<'_>) -> Option<String> {
         // Look for type_identifier directly or inside pointer_type.
@@ -1110,7 +1102,7 @@ impl GoExtractor {
         }
     }
 
-    /// Recursively find call_expression and selector_expression nodes inside a
+    /// Recursively find `call_expression` and `selector_expression` nodes inside a
     /// given node and create unresolved Calls references.
     fn extract_call_sites(state: &mut ExtractionState, node: TsNode<'_>, fn_node_id: &str) {
         let mut cursor = node.walk();
@@ -1149,12 +1141,12 @@ impl GoExtractor {
     }
 
     /// Extract the function/method signature (everything up to the body `{`).
-    fn extract_signature(state: &ExtractionState, node: TsNode<'_>) -> Option<String> {
+    fn extract_signature(state: &ExtractionState, node: TsNode<'_>) -> String {
         let text = state.node_text(node);
         if let Some(brace_pos) = text.find('{') {
-            Some(text[..brace_pos].trim().to_string())
+            text[..brace_pos].trim().to_string()
         } else {
-            Some(text.trim().to_string())
+            text.trim().to_string()
         }
     }
 
@@ -1236,7 +1228,7 @@ impl GoExtractor {
         None
     }
 
-    /// Build the final ExtractionResult from the accumulated state.
+    /// Build the final `ExtractionResult` from the accumulated state.
     fn build_result(state: ExtractionState, start: Instant) -> ExtractionResult {
         ExtractionResult {
             nodes: state.nodes,
@@ -1253,7 +1245,7 @@ impl crate::extraction::LanguageExtractor for GoExtractor {
         &["go"]
     }
 
-    fn language_name(&self) -> &str {
+    fn language_name(&self) -> &'static str {
         "Go"
     }
 

--- a/src/extraction/gwbasic_extractor.rs
+++ b/src/extraction/gwbasic_extractor.rs
@@ -22,7 +22,7 @@ struct ExtractionState {
     edges: Vec<Edge>,
     unresolved_refs: Vec<UnresolvedRef>,
     errors: Vec<String>,
-    /// Stack of (name, node_id) for building qualified names and parent edges.
+    /// Stack of (name, `node_id`) for building qualified names and parent edges.
     node_stack: Vec<(String, String)>,
     file_path: String,
     source: Vec<u8>,
@@ -179,7 +179,7 @@ impl GwBasicExtractor {
         lines
     }
 
-    /// Parse a single `line` node into a BasicLine struct.
+    /// Parse a single `line` node into a `BasicLine` struct.
     fn parse_line<'a>(state: &ExtractionState, node: TsNode<'a>) -> Option<BasicLine<'a>> {
         let line_number_node = Self::find_child_by_kind(node, "line_number")?;
         let line_number_text = state.node_text(line_number_node);
@@ -224,23 +224,20 @@ impl GwBasicExtractor {
             if basic_line.statement_kind != "def_fn_statement" {
                 continue;
             }
-            let statement_list = match Self::find_child_by_kind(basic_line.node, "statement_list") {
-                Some(sl) => sl,
-                None => continue,
+            let Some(statement_list) = Self::find_child_by_kind(basic_line.node, "statement_list")
+            else {
+                continue;
             };
-            let statement = match Self::find_child_by_kind(statement_list, "statement") {
-                Some(s) => s,
-                None => continue,
+            let Some(statement) = Self::find_child_by_kind(statement_list, "statement") else {
+                continue;
             };
-            let def_fn = match Self::find_child_by_kind(statement, "def_fn_statement") {
-                Some(d) => d,
-                None => continue,
+            let Some(def_fn) = Self::find_child_by_kind(statement, "def_fn_statement") else {
+                continue;
             };
 
             // Extract function name from user_function child.
-            let fn_name_node = match Self::find_child_by_kind(def_fn, "user_function") {
-                Some(n) => n,
-                None => continue,
+            let Some(fn_name_node) = Self::find_child_by_kind(def_fn, "user_function") else {
+                continue;
             };
             let fn_name = state.node_text(fn_name_node);
 
@@ -311,27 +308,23 @@ impl GwBasicExtractor {
 
     /// Extract a LET statement as a Const node.
     fn visit_let_statement(state: &mut ExtractionState, basic_line: &BasicLine<'_>) {
-        let statement_list = match Self::find_child_by_kind(basic_line.node, "statement_list") {
-            Some(sl) => sl,
-            None => return,
+        let Some(statement_list) = Self::find_child_by_kind(basic_line.node, "statement_list")
+        else {
+            return;
         };
-        let statement = match Self::find_child_by_kind(statement_list, "statement") {
-            Some(s) => s,
-            None => return,
+        let Some(statement) = Self::find_child_by_kind(statement_list, "statement") else {
+            return;
         };
-        let let_stmt = match Self::find_child_by_kind(statement, "let_statement") {
-            Some(ls) => ls,
-            None => return,
+        let Some(let_stmt) = Self::find_child_by_kind(statement, "let_statement") else {
+            return;
         };
 
         // Extract the variable name from: let_statement -> variable -> identifier
-        let var_node = match Self::find_child_by_kind(let_stmt, "variable") {
-            Some(v) => v,
-            None => return,
+        let Some(var_node) = Self::find_child_by_kind(let_stmt, "variable") else {
+            return;
         };
-        let id_node = match Self::find_child_by_kind(var_node, "identifier") {
-            Some(i) => i,
-            None => return,
+        let Some(id_node) = Self::find_child_by_kind(var_node, "identifier") else {
+            return;
         };
         let name = state.node_text(id_node);
 
@@ -468,7 +461,7 @@ impl GwBasicExtractor {
                     // Use the line number of the first code line (after REMs) as the
                     // signature, so callers can reference it by GOSUB <line_number>.
                     let sig_line_num = lines[body_start].line_number;
-                    let signature = format!("GOSUB {}", sig_line_num);
+                    let signature = format!("GOSUB {sig_line_num}");
 
                     let graph_node = Node {
                         id: fn_id.clone(),
@@ -548,7 +541,7 @@ impl GwBasicExtractor {
         }
     }
 
-    /// Check if a line node contains a return_statement anywhere in its AST.
+    /// Check if a line node contains a `return_statement` anywhere in its AST.
     fn line_has_return(node: TsNode<'_>) -> bool {
         if node.kind() == "return_statement" {
             return true;
@@ -634,7 +627,7 @@ impl GwBasicExtractor {
         Self::walk_for_calls(state, line.node, from_node_id);
     }
 
-    /// Recursively walk AST nodes looking for gosub_statement and goto_statement.
+    /// Recursively walk AST nodes looking for `gosub_statement` and `goto_statement`.
     fn walk_for_calls(state: &mut ExtractionState, node: TsNode<'_>, from_node_id: &str) {
         let kind = node.kind();
         match kind {
@@ -670,7 +663,7 @@ impl GwBasicExtractor {
     /// Derive a function name from REM comment text.
     ///
     /// Takes the first REM line text and converts it into a snake_case-like
-    /// identifier. For example, "VALIDATE CONFIGURATION" becomes "VALIDATE_CONFIGURATION".
+    /// identifier. For example, "VALIDATE CONFIGURATION" becomes "`VALIDATE_CONFIGURATION`".
     fn derive_function_name(rem_comments: &[String]) -> String {
         if rem_comments.is_empty() {
             return "UNNAMED_SUB".to_string();
@@ -726,7 +719,7 @@ impl GwBasicExtractor {
         None
     }
 
-    /// Build the final ExtractionResult from the accumulated state.
+    /// Build the final `ExtractionResult` from the accumulated state.
     fn build_result(state: ExtractionState, start: Instant) -> ExtractionResult {
         ExtractionResult {
             nodes: state.nodes,
@@ -743,7 +736,7 @@ impl crate::extraction::LanguageExtractor for GwBasicExtractor {
         &["gw"]
     }
 
-    fn language_name(&self) -> &str {
+    fn language_name(&self) -> &'static str {
         "GW-BASIC"
     }
 

--- a/src/extraction/java_extractor.rs
+++ b/src/extraction/java_extractor.rs
@@ -19,7 +19,7 @@ struct ExtractionState {
     edges: Vec<Edge>,
     unresolved_refs: Vec<UnresolvedRef>,
     errors: Vec<String>,
-    /// Stack of (name, node_id) for building qualified names and parent edges.
+    /// Stack of (name, `node_id`) for building qualified names and parent edges.
     node_stack: Vec<(String, String)>,
     file_path: String,
     source: Vec<u8>,
@@ -305,7 +305,7 @@ impl JavaExtractor {
         let name = Self::extract_name(state, node).unwrap_or_else(|| "<anonymous>".to_string());
         let visibility = Self::extract_java_visibility(node, state);
         let docstring = Self::extract_java_docstring(state, node);
-        let signature = Self::extract_declaration_signature(state, node);
+        let signature = Some(Self::extract_declaration_signature(state, node));
         let start_line = node.start_position().row as u32;
         let end_line = node.end_position().row as u32;
         let start_column = node.start_position().column as u32;
@@ -378,7 +378,7 @@ impl JavaExtractor {
         let name = Self::extract_name(state, node).unwrap_or_else(|| "<anonymous>".to_string());
         let visibility = Self::extract_java_visibility(node, state);
         let docstring = Self::extract_java_docstring(state, node);
-        let signature = Self::extract_declaration_signature(state, node);
+        let signature = Some(Self::extract_declaration_signature(state, node));
         let start_line = node.start_position().row as u32;
         let end_line = node.end_position().row as u32;
         let start_column = node.start_position().column as u32;
@@ -442,7 +442,7 @@ impl JavaExtractor {
         let name = Self::extract_name(state, node).unwrap_or_else(|| "<anonymous>".to_string());
         let visibility = Self::extract_java_visibility(node, state);
         let docstring = Self::extract_java_docstring(state, node);
-        let signature = Self::extract_declaration_signature(state, node);
+        let signature = Some(Self::extract_declaration_signature(state, node));
         let start_line = node.start_position().row as u32;
         let end_line = node.end_position().row as u32;
         let start_column = node.start_position().column as u32;
@@ -493,7 +493,7 @@ impl JavaExtractor {
         state.node_stack.pop();
     }
 
-    /// Extract enum constants from an enum_body node.
+    /// Extract enum constants from an `enum_body` node.
     fn extract_enum_constants(state: &mut ExtractionState, body: TsNode<'_>) {
         let mut cursor = body.walk();
         if cursor.goto_first_child() {
@@ -509,7 +509,7 @@ impl JavaExtractor {
         }
     }
 
-    /// Extract a single enum constant as an EnumVariant node.
+    /// Extract a single enum constant as an `EnumVariant` node.
     fn extract_single_enum_constant(state: &mut ExtractionState, node: TsNode<'_>) {
         let name = Self::extract_name(state, node).unwrap_or_else(|| "<anonymous>".to_string());
         let start_line = node.start_position().row as u32;
@@ -560,7 +560,7 @@ impl JavaExtractor {
         let name = Self::extract_name(state, node).unwrap_or_else(|| "<anonymous>".to_string());
         let visibility = Self::extract_java_visibility(node, state);
         let docstring = Self::extract_java_docstring(state, node);
-        let signature = Self::extract_declaration_signature(state, node);
+        let signature = Some(Self::extract_declaration_signature(state, node));
         let start_line = node.start_position().row as u32;
         let end_line = node.end_position().row as u32;
         let start_column = node.start_position().column as u32;
@@ -609,7 +609,7 @@ impl JavaExtractor {
         let name = Self::extract_name(state, node).unwrap_or_else(|| "<anonymous>".to_string());
         let visibility = Self::extract_java_visibility(node, state);
         let docstring = Self::extract_java_docstring(state, node);
-        let signature = Self::extract_declaration_signature(state, node);
+        let signature = Some(Self::extract_declaration_signature(state, node));
         let start_line = node.start_position().row as u32;
         let end_line = node.end_position().row as u32;
         let start_column = node.start_position().column as u32;
@@ -686,7 +686,7 @@ impl JavaExtractor {
         let name = Self::extract_name(state, node).unwrap_or_else(|| "<anonymous>".to_string());
         let visibility = Self::extract_java_visibility(node, state);
         let docstring = Self::extract_java_docstring(state, node);
-        let signature = Self::extract_declaration_signature(state, node);
+        let signature = Some(Self::extract_declaration_signature(state, node));
         let start_line = node.start_position().row as u32;
         let end_line = node.end_position().row as u32;
         let start_column = node.start_position().column as u32;
@@ -737,7 +737,7 @@ impl JavaExtractor {
         Self::extract_call_sites(state, node, &id);
     }
 
-    /// Extract field declarations. Each variable_declarator in the field becomes a Field node.
+    /// Extract field declarations. Each `variable_declarator` in the field becomes a Field node.
     fn visit_field(state: &mut ExtractionState, node: TsNode<'_>) {
         let visibility = Self::extract_java_visibility(node, state);
         let start_line = node.start_position().row as u32;
@@ -753,13 +753,13 @@ impl JavaExtractor {
                 let child = cursor.node();
                 if child.kind() == "variable_declarator" {
                     // The variable_declarator contains an identifier as its "name" field.
-                    let field_name = child
-                        .child_by_field_name("name")
-                        .map(|n| state.node_text(n))
-                        .unwrap_or_else(|| {
+                    let field_name = child.child_by_field_name("name").map_or_else(
+                        || {
                             Self::extract_name(state, child)
                                 .unwrap_or_else(|| "<anonymous>".to_string())
-                        });
+                        },
+                        |n| state.node_text(n),
+                    );
 
                     let qualified_name = format!("{}::{}", state.qualified_prefix(), field_name);
                     let id = generate_node_id(
@@ -928,13 +928,13 @@ impl JavaExtractor {
     }
 
     /// Extract the declaration signature (text from start up to the opening `{`).
-    fn extract_declaration_signature(state: &ExtractionState, node: TsNode<'_>) -> Option<String> {
+    fn extract_declaration_signature(state: &ExtractionState, node: TsNode<'_>) -> String {
         let text = state.node_text(node);
         if let Some(brace_pos) = text.find('{') {
-            Some(text[..brace_pos].trim().to_string())
+            text[..brace_pos].trim().to_string()
         } else {
             // For declarations without a body (e.g., abstract methods ending with `;`).
-            Some(text.trim_end_matches(';').trim().to_string())
+            text.trim_end_matches(';').trim().to_string()
         }
     }
 
@@ -984,7 +984,7 @@ impl JavaExtractor {
             .to_string()
     }
 
-    /// Extract superclass (extends) from a class_declaration.
+    /// Extract superclass (extends) from a `class_declaration`.
     fn extract_superclass(state: &mut ExtractionState, node: TsNode<'_>, class_id: &str) {
         // In tree-sitter-java, `superclass` is a named child of class_declaration.
         let mut cursor = node.walk();
@@ -1025,7 +1025,7 @@ impl JavaExtractor {
         }
     }
 
-    /// Extract super_interfaces (implements) from a class_declaration.
+    /// Extract `super_interfaces` (implements) from a `class_declaration`.
     fn extract_super_interfaces(state: &mut ExtractionState, node: TsNode<'_>, class_id: &str) {
         let mut cursor = node.walk();
         if cursor.goto_first_child() {
@@ -1042,7 +1042,7 @@ impl JavaExtractor {
         }
     }
 
-    /// Extract types from a type_list as Implements unresolved refs.
+    /// Extract types from a `type_list` as Implements unresolved refs.
     fn extract_type_list_as_implements(
         state: &mut ExtractionState,
         node: TsNode<'_>,
@@ -1091,7 +1091,7 @@ impl JavaExtractor {
         }
     }
 
-    /// Extract individual type_parameter nodes from a type_parameters node.
+    /// Extract individual `type_parameter` nodes from a `type_parameters` node.
     fn extract_type_params_from_list(
         state: &mut ExtractionState,
         node: TsNode<'_>,
@@ -1158,7 +1158,7 @@ impl JavaExtractor {
     }
 
     /// Extract annotations from the modifiers of a declaration and create
-    /// AnnotationUsage nodes and Annotates edges/refs.
+    /// `AnnotationUsage` nodes and Annotates edges/refs.
     fn extract_annotations_from_modifiers(
         state: &mut ExtractionState,
         node: TsNode<'_>,
@@ -1178,7 +1178,7 @@ impl JavaExtractor {
         }
     }
 
-    /// Search inside a modifiers node for marker_annotation and annotation nodes.
+    /// Search inside a modifiers node for `marker_annotation` and annotation nodes.
     fn extract_annotations_from_node(
         state: &mut ExtractionState,
         node: TsNode<'_>,
@@ -1277,7 +1277,7 @@ impl JavaExtractor {
     /// Extract type references from parameter types and return type.
     ///
     /// In Java, `formal_parameter` children contain a `type_identifier` (or
-    /// generic_type wrapping one). The method's return type also appears as a
+    /// `generic_type` wrapping one). The method's return type also appears as a
     /// `type_identifier` direct child.
     fn extract_type_refs(state: &mut ExtractionState, node: TsNode<'_>, fn_node_id: &str) {
         let java_builtins: &[&str] = &[
@@ -1313,11 +1313,7 @@ impl JavaExtractor {
                 "formal_parameters" => {
                     Self::extract_type_refs(state, child, fn_node_id);
                 }
-                "formal_parameter" | "spread_parameter" => {
-                    Self::collect_java_type_ids(state, child, fn_node_id, java_builtins);
-                }
-                // Return type
-                "type_identifier" | "generic_type" => {
+                "formal_parameter" | "spread_parameter" | "type_identifier" | "generic_type" => {
                     Self::collect_java_type_ids(state, child, fn_node_id, java_builtins);
                 }
                 _ => {}
@@ -1360,7 +1356,7 @@ impl JavaExtractor {
         }
     }
 
-    /// Recursively find method_invocation and object_creation_expression nodes inside a
+    /// Recursively find `method_invocation` and `object_creation_expression` nodes inside a
     /// given node and create unresolved Calls references.
     fn extract_call_sites(state: &mut ExtractionState, node: TsNode<'_>, fn_node_id: &str) {
         let mut cursor = node.walk();
@@ -1407,7 +1403,7 @@ impl JavaExtractor {
         }
     }
 
-    /// Extract the method name from a method_invocation node.
+    /// Extract the method name from a `method_invocation` node.
     fn extract_method_invocation_name(state: &ExtractionState, node: TsNode<'_>) -> String {
         // method_invocation can be like:
         //   identifier "helper" + argument_list
@@ -1427,7 +1423,7 @@ impl JavaExtractor {
         text.split('(').next().unwrap_or(&text).trim().to_string()
     }
 
-    /// Extract the type name from an object_creation_expression.
+    /// Extract the type name from an `object_creation_expression`.
     fn extract_object_creation_type(state: &ExtractionState, node: TsNode<'_>) -> String {
         // object_creation_expression: "new" type argument_list
         // The "type" field gives the type name.
@@ -1454,7 +1450,7 @@ impl JavaExtractor {
         "<unknown>".to_string()
     }
 
-    /// Build the final ExtractionResult from the accumulated state.
+    /// Build the final `ExtractionResult` from the accumulated state.
     fn build_result(state: ExtractionState, start: Instant) -> ExtractionResult {
         ExtractionResult {
             nodes: state.nodes,
@@ -1471,7 +1467,7 @@ impl crate::extraction::LanguageExtractor for JavaExtractor {
         &["java"]
     }
 
-    fn language_name(&self) -> &str {
+    fn language_name(&self) -> &'static str {
         "Java"
     }
 

--- a/src/extraction/kotlin_extractor.rs
+++ b/src/extraction/kotlin_extractor.rs
@@ -21,7 +21,7 @@ struct ExtractionState {
     edges: Vec<Edge>,
     unresolved_refs: Vec<UnresolvedRef>,
     errors: Vec<String>,
-    /// Stack of (name, node_id) for building qualified names and parent edges.
+    /// Stack of (name, `node_id`) for building qualified names and parent edges.
     node_stack: Vec<(String, String)>,
     file_path: String,
     source: Vec<u8>,
@@ -180,8 +180,7 @@ impl KotlinExtractor {
     /// Extract a package header.
     fn visit_package(state: &mut ExtractionState, node: TsNode<'_>) {
         let name = Self::find_child_by_kind(node, "identifier")
-            .map(|n| state.node_text(n))
-            .unwrap_or_else(|| "<unknown>".to_string());
+            .map_or_else(|| "<unknown>".to_string(), |n| state.node_text(n));
 
         let start_line = node.start_position().row as u32;
         let end_line = node.end_position().row as u32;
@@ -241,7 +240,7 @@ impl KotlinExtractor {
     // Imports
     // -----------------------------------------------------------------------
 
-    /// Extract imports from an import_list node.
+    /// Extract imports from an `import_list` node.
     fn visit_import_list(state: &mut ExtractionState, node: TsNode<'_>) {
         let mut cursor = node.walk();
         if cursor.goto_first_child() {
@@ -259,16 +258,17 @@ impl KotlinExtractor {
 
     /// Extract a single import header as a Use node.
     fn visit_import(state: &mut ExtractionState, node: TsNode<'_>) {
-        let path = Self::find_child_by_kind(node, "identifier")
-            .map(|n| state.node_text(n))
-            .unwrap_or_else(|| {
+        let path = Self::find_child_by_kind(node, "identifier").map_or_else(
+            || {
                 let text = state.node_text(node);
                 text.trim()
                     .strip_prefix("import ")
                     .unwrap_or(&text)
                     .trim()
                     .to_string()
-            });
+            },
+            |n| state.node_text(n),
+        );
 
         let start_line = node.start_position().row as u32;
         let end_line = node.end_position().row as u32;
@@ -325,7 +325,7 @@ impl KotlinExtractor {
     // Class declarations (class, data class, sealed class, interface, enum)
     // -----------------------------------------------------------------------
 
-    /// Dispatch a class_declaration based on its modifiers and leading keywords.
+    /// Dispatch a `class_declaration` based on its modifiers and leading keywords.
     fn visit_class_declaration(state: &mut ExtractionState, node: TsNode<'_>) {
         // Determine if this is an interface, enum, data class, sealed class, or regular class
         // by checking the unnamed children and modifiers.
@@ -352,7 +352,7 @@ impl KotlinExtractor {
         let name = Self::extract_class_name(state, node);
         let visibility = Self::extract_visibility(node, state);
         let docstring = Self::extract_kdoc(state, node);
-        let signature = Self::extract_declaration_signature(state, node);
+        let signature = Some(Self::extract_declaration_signature(state, node));
         let start_line = node.start_position().row as u32;
         let end_line = node.end_position().row as u32;
         let start_column = node.start_position().column as u32;
@@ -418,7 +418,7 @@ impl KotlinExtractor {
         let name = Self::extract_class_name(state, node);
         let visibility = Self::extract_visibility(node, state);
         let docstring = Self::extract_kdoc(state, node);
-        let signature = Self::extract_declaration_signature(state, node);
+        let signature = Some(Self::extract_declaration_signature(state, node));
         let start_line = node.start_position().row as u32;
         let end_line = node.end_position().row as u32;
         let start_column = node.start_position().column as u32;
@@ -477,7 +477,7 @@ impl KotlinExtractor {
         let name = Self::extract_class_name(state, node);
         let visibility = Self::extract_visibility(node, state);
         let docstring = Self::extract_kdoc(state, node);
-        let signature = Self::extract_declaration_signature(state, node);
+        let signature = Some(Self::extract_declaration_signature(state, node));
         let start_line = node.start_position().row as u32;
         let end_line = node.end_position().row as u32;
         let start_column = node.start_position().column as u32;
@@ -535,7 +535,7 @@ impl KotlinExtractor {
         let name = Self::extract_class_name(state, node);
         let visibility = Self::extract_visibility(node, state);
         let docstring = Self::extract_kdoc(state, node);
-        let signature = Self::extract_declaration_signature(state, node);
+        let signature = Some(Self::extract_declaration_signature(state, node));
         let start_line = node.start_position().row as u32;
         let end_line = node.end_position().row as u32;
         let start_column = node.start_position().column as u32;
@@ -596,7 +596,7 @@ impl KotlinExtractor {
         let name = Self::extract_class_name(state, node);
         let visibility = Self::extract_visibility(node, state);
         let docstring = Self::extract_kdoc(state, node);
-        let signature = Self::extract_declaration_signature(state, node);
+        let signature = Some(Self::extract_declaration_signature(state, node));
         let start_line = node.start_position().row as u32;
         let end_line = node.end_position().row as u32;
         let start_column = node.start_position().column as u32;
@@ -671,9 +671,10 @@ impl KotlinExtractor {
 
     /// Extract a single enum entry.
     fn visit_enum_entry(state: &mut ExtractionState, node: TsNode<'_>) {
-        let name = Self::find_child_by_kind(node, "simple_identifier")
-            .map(|n| state.node_text(n))
-            .unwrap_or_else(|| state.node_text(node).trim().to_string());
+        let name = Self::find_child_by_kind(node, "simple_identifier").map_or_else(
+            || state.node_text(node).trim().to_string(),
+            |n| state.node_text(n),
+        );
 
         let start_line = node.start_position().row as u32;
         let end_line = node.end_position().row as u32;
@@ -724,11 +725,10 @@ impl KotlinExtractor {
     /// Extract an object declaration (Kotlin singleton).
     fn visit_object(state: &mut ExtractionState, node: TsNode<'_>) {
         let name = Self::find_child_by_kind(node, "type_identifier")
-            .map(|n| state.node_text(n))
-            .unwrap_or_else(|| "<anonymous>".to_string());
+            .map_or_else(|| "<anonymous>".to_string(), |n| state.node_text(n));
         let visibility = Self::extract_visibility(node, state);
         let docstring = Self::extract_kdoc(state, node);
-        let signature = Self::extract_declaration_signature(state, node);
+        let signature = Some(Self::extract_declaration_signature(state, node));
         let start_line = node.start_position().row as u32;
         let end_line = node.end_position().row as u32;
         let start_column = node.start_position().column as u32;
@@ -789,8 +789,7 @@ impl KotlinExtractor {
     fn visit_companion_object(state: &mut ExtractionState, node: TsNode<'_>) {
         // Companion objects may have a name or be anonymous.
         let name = Self::find_child_by_kind(node, "type_identifier")
-            .map(|n| state.node_text(n))
-            .unwrap_or_else(|| "Companion".to_string());
+            .map_or_else(|| "Companion".to_string(), |n| state.node_text(n));
         let start_line = node.start_position().row as u32;
         let end_line = node.end_position().row as u32;
         let start_column = node.start_position().column as u32;
@@ -861,15 +860,14 @@ impl KotlinExtractor {
     /// Extract a function or method declaration.
     fn visit_function(state: &mut ExtractionState, node: TsNode<'_>) {
         let name = Self::find_child_by_kind(node, "simple_identifier")
-            .map(|n| state.node_text(n))
-            .unwrap_or_else(|| "<anonymous>".to_string());
+            .map_or_else(|| "<anonymous>".to_string(), |n| state.node_text(n));
 
         // Check if this is an extension function (has a receiver type before the dot and name).
         let is_extension = Self::is_extension_function(node);
 
         let visibility = Self::extract_visibility(node, state);
         let docstring = Self::extract_kdoc(state, node);
-        let signature = Self::extract_declaration_signature(state, node);
+        let signature = Some(Self::extract_declaration_signature(state, node));
         let start_line = node.start_position().row as u32;
         let end_line = node.end_position().row as u32;
         let start_column = node.start_position().column as u32;
@@ -954,12 +952,10 @@ impl KotlinExtractor {
         let name = Self::extract_property_name(state, node);
 
         // Determine val vs var.
-        let is_var = Self::find_child_by_kind(node, "binding_pattern_kind")
-            .map(|bpk| {
-                let text = state.node_text(bpk);
-                text.trim() == "var"
-            })
-            .unwrap_or(false);
+        let is_var = Self::find_child_by_kind(node, "binding_pattern_kind").is_some_and(|bpk| {
+            let text = state.node_text(bpk);
+            text.trim() == "var"
+        });
 
         let visibility = Self::extract_visibility(node, state);
         let start_line = node.start_position().row as u32;
@@ -1089,14 +1085,13 @@ impl KotlinExtractor {
     // Helpers
     // -----------------------------------------------------------------------
 
-    /// Extract the class name from a class_declaration node.
+    /// Extract the class name from a `class_declaration` node.
     fn extract_class_name(state: &ExtractionState, node: TsNode<'_>) -> String {
         Self::find_child_by_kind(node, "type_identifier")
-            .map(|n| state.node_text(n))
-            .unwrap_or_else(|| "<anonymous>".to_string())
+            .map_or_else(|| "<anonymous>".to_string(), |n| state.node_text(n))
     }
 
-    /// Extract the property name from a property_declaration node.
+    /// Extract the property name from a `property_declaration` node.
     fn extract_property_name(state: &ExtractionState, node: TsNode<'_>) -> String {
         // property_declaration has variable_declaration child which has simple_identifier
         if let Some(var_decl) = Self::find_child_by_kind(node, "variable_declaration") {
@@ -1111,8 +1106,8 @@ impl KotlinExtractor {
         "<anonymous>".to_string()
     }
 
-    /// Check if a function_declaration is an extension function.
-    /// Extension functions have a user_type child followed by a "." token before the name.
+    /// Check if a `function_declaration` is an extension function.
+    /// Extension functions have a `user_type` child followed by a "." token before the name.
     fn is_extension_function(node: TsNode<'_>) -> bool {
         let mut found_user_type = false;
         let mut cursor = node.walk();
@@ -1249,22 +1244,22 @@ impl KotlinExtractor {
     }
 
     /// Extract the declaration signature (everything before the body).
-    fn extract_declaration_signature(state: &ExtractionState, node: TsNode<'_>) -> Option<String> {
+    fn extract_declaration_signature(state: &ExtractionState, node: TsNode<'_>) -> String {
         let text = state.node_text(node);
         // Cut at first '{' for brace-delimited bodies.
         if let Some(brace_pos) = text.find('{') {
-            return Some(text[..brace_pos].trim().to_string());
+            return text[..brace_pos].trim().to_string();
         }
         // Cut at first '=' for expression-bodied definitions.
         if Self::find_child_by_kind(node, "function_body").is_some() {
             if let Some(eq_pos) = text.find('=') {
-                return Some(text[..eq_pos].trim().to_string());
+                return text[..eq_pos].trim().to_string();
             }
         }
-        Some(text.lines().next().unwrap_or("").trim().to_string())
+        text.lines().next().unwrap_or("").trim().to_string()
     }
 
-    /// Extract KDoc comments (/** ... */) preceding a declaration.
+    /// Extract `KDoc` comments (/** ... */) preceding a declaration.
     fn extract_kdoc(state: &ExtractionState, node: TsNode<'_>) -> Option<String> {
         let mut current = node.prev_named_sibling();
         while let Some(sibling) = current {
@@ -1285,7 +1280,7 @@ impl KotlinExtractor {
         None
     }
 
-    /// Clean a KDoc comment block, stripping markers.
+    /// Clean a `KDoc` comment block, stripping markers.
     fn clean_kdoc(comment: &str) -> String {
         let trimmed = comment.trim();
         let inner = if trimmed.starts_with("/**") && trimmed.ends_with("*/") {
@@ -1333,8 +1328,7 @@ impl KotlinExtractor {
         let type_name = Self::find_child_by_kind(node, "constructor_invocation")
             .and_then(|ci| Self::find_child_by_kind(ci, "user_type"))
             .or_else(|| Self::find_child_by_kind(node, "user_type"))
-            .map(|ut| state.node_text(ut))
-            .unwrap_or_else(|| state.node_text(node));
+            .map_or_else(|| state.node_text(node), |ut| state.node_text(ut));
 
         let base_name = type_name
             .split('<')
@@ -1356,7 +1350,7 @@ impl KotlinExtractor {
     }
 
     /// Extract annotations from the modifiers of a declaration and create
-    /// AnnotationUsage nodes and Annotates edges.
+    /// `AnnotationUsage` nodes and Annotates edges.
     fn extract_annotations_from_modifiers(
         state: &mut ExtractionState,
         node: TsNode<'_>,
@@ -1516,11 +1510,7 @@ impl KotlinExtractor {
                 "function_value_parameters" => {
                     Self::extract_type_refs(state, child, fn_node_id);
                 }
-                "parameter" => {
-                    Self::collect_kotlin_type_ids(state, child, fn_node_id, kotlin_builtins);
-                }
-                // Return type annotation
-                "user_type" | "nullable_type" => {
+                "parameter" | "user_type" | "nullable_type" => {
                     Self::collect_kotlin_type_ids(state, child, fn_node_id, kotlin_builtins);
                 }
                 _ => {}
@@ -1563,7 +1553,7 @@ impl KotlinExtractor {
         }
     }
 
-    /// Recursively find call_expression nodes and create unresolved Calls references.
+    /// Recursively find `call_expression` nodes and create unresolved Calls references.
     fn extract_call_sites(state: &mut ExtractionState, node: TsNode<'_>, fn_node_id: &str) {
         let mut cursor = node.walk();
         if cursor.goto_first_child() {
@@ -1598,20 +1588,13 @@ impl KotlinExtractor {
         }
     }
 
-    /// Extract the callee name from a call_expression.
+    /// Extract the callee name from a `call_expression`.
     fn extract_call_name(state: &ExtractionState, node: TsNode<'_>) -> String {
         // call_expression's first named child is the function reference.
         let mut cursor = node.walk();
         if cursor.goto_first_child() {
             let child = cursor.node();
-            match child.kind() {
-                "navigation_expression" | "simple_identifier" => {
-                    return state.node_text(child);
-                }
-                _ => {
-                    return state.node_text(child);
-                }
-            }
+            return state.node_text(child);
         }
         let text = state.node_text(node);
         text.split('(').next().unwrap_or(&text).trim().to_string()
@@ -1634,7 +1617,7 @@ impl KotlinExtractor {
         None
     }
 
-    /// Build the final ExtractionResult from the accumulated state.
+    /// Build the final `ExtractionResult` from the accumulated state.
     fn build_result(state: ExtractionState, start: Instant) -> ExtractionResult {
         ExtractionResult {
             nodes: state.nodes,
@@ -1651,7 +1634,7 @@ impl crate::extraction::LanguageExtractor for KotlinExtractor {
         &["kt", "kts"]
     }
 
-    fn language_name(&self) -> &str {
+    fn language_name(&self) -> &'static str {
         "Kotlin"
     }
 

--- a/src/extraction/lua_extractor.rs
+++ b/src/extraction/lua_extractor.rs
@@ -19,7 +19,7 @@ struct ExtractionState {
     edges: Vec<Edge>,
     unresolved_refs: Vec<UnresolvedRef>,
     errors: Vec<String>,
-    /// Stack of (name, node_id) for building qualified names and parent edges.
+    /// Stack of (name, `node_id`) for building qualified names and parent edges.
     node_stack: Vec<(String, String)>,
     file_path: String,
     source: Vec<u8>,
@@ -162,13 +162,11 @@ impl LuaExtractor {
     /// - `function Foo.bar(...)` → name is `dot_index_expression`, public function with class context
     /// - `function Foo:bar(...)` → name is `method_index_expression`, method
     fn visit_function_declaration(state: &mut ExtractionState, node: TsNode<'_>) {
-        let name_node = node.child_by_field_name("name");
-        let name_node = match name_node {
-            Some(n) => n,
-            None => return,
+        let Some(name_node) = node.child_by_field_name("name") else {
+            return;
         };
 
-        let is_local = node.child(0).map(|c| c.kind() == "local").unwrap_or(false);
+        let is_local = node.child(0).is_some_and(|c| c.kind() == "local");
 
         let (name, kind, visibility, class_context) = match name_node.kind() {
             "identifier" => {
@@ -191,8 +189,7 @@ impl LuaExtractor {
                     .map(|n| state.node_text(n));
                 let field_name = name_node
                     .child_by_field_name("field")
-                    .map(|n| state.node_text(n))
-                    .unwrap_or_else(|| "<anonymous>".to_string());
+                    .map_or_else(|| "<anonymous>".to_string(), |n| state.node_text(n));
                 (field_name, NodeKind::Function, Visibility::Pub, table_name)
             }
             "method_index_expression" => {
@@ -202,15 +199,14 @@ impl LuaExtractor {
                     .map(|n| state.node_text(n));
                 let method_name = name_node
                     .child_by_field_name("method")
-                    .map(|n| state.node_text(n))
-                    .unwrap_or_else(|| "<anonymous>".to_string());
+                    .map_or_else(|| "<anonymous>".to_string(), |n| state.node_text(n));
                 (method_name, NodeKind::Method, Visibility::Pub, table_name)
             }
             _ => return,
         };
 
         let docstring = Self::extract_docstring(state, node);
-        let signature = Self::extract_function_signature(state, node, &class_context);
+        let signature = Self::extract_function_signature(state, node, class_context.as_deref());
         let start_line = node.start_position().row as u32;
         let end_line = node.end_position().row as u32;
         let start_column = node.start_position().column as u32;
@@ -271,9 +267,8 @@ impl LuaExtractor {
     /// - `local CONST = <literal>` → Const node (uppercase names)
     fn visit_variable_declaration(state: &mut ExtractionState, node: TsNode<'_>) {
         // variable_declaration contains an assignment_statement child.
-        let assignment = match Self::find_child_by_kind(node, "assignment_statement") {
-            Some(a) => a,
-            None => return,
+        let Some(assignment) = Self::find_child_by_kind(node, "assignment_statement") else {
+            return;
         };
 
         // Get the variable name from the variable_list.
@@ -284,10 +279,10 @@ impl LuaExtractor {
             // The first named child of variable_list should be the identifier.
             Self::find_child_by_kind(vl, "identifier")
         });
-        let name = match name_node {
-            Some(n) => state.node_text(n),
-            None => return,
+        let Some(n) = name_node else {
+            return;
         };
+        let name = state.node_text(n);
 
         // Get the value from the expression_list.
         let expr_list = assignment
@@ -295,9 +290,8 @@ impl LuaExtractor {
             .or_else(|| Self::find_child_by_kind(assignment, "expression_list"));
         let value_node = expr_list.and_then(|el| el.named_child(0));
 
-        let value_node = match value_node {
-            Some(v) => v,
-            None => return,
+        let Some(value_node) = value_node else {
+            return;
         };
 
         // Check if this is a require call → Use node.
@@ -457,7 +451,7 @@ impl LuaExtractor {
     fn extract_function_signature(
         state: &ExtractionState,
         node: TsNode<'_>,
-        _class_context: &Option<String>,
+        _class_context: Option<&str>,
     ) -> Option<String> {
         let text = state.node_text(node);
         let first_line = text.lines().next()?.trim().to_string();
@@ -470,7 +464,7 @@ impl LuaExtractor {
 
     /// Extract docstrings from `--` or `---` comment lines preceding definitions.
     ///
-    /// Lua uses comment lines (-- or --- for LDoc) as documentation. We look for
+    /// Lua uses comment lines (-- or --- for `LDoc`) as documentation. We look for
     /// `comment` sibling nodes that immediately precede the given definition node.
     fn extract_docstring(state: &ExtractionState, node: TsNode<'_>) -> Option<String> {
         let mut comments: Vec<String> = Vec::new();
@@ -494,7 +488,7 @@ impl LuaExtractor {
         Some(comments.join("\n"))
     }
 
-    /// Recursively find function_call nodes inside a given node and create unresolved Calls references.
+    /// Recursively find `function_call` nodes inside a given node and create unresolved Calls references.
     fn extract_call_sites(state: &mut ExtractionState, node: TsNode<'_>, fn_node_id: &str) {
         let mut cursor = node.walk();
         if cursor.goto_first_child() {
@@ -557,7 +551,7 @@ impl LuaExtractor {
         None
     }
 
-    /// Build the final ExtractionResult from the accumulated state.
+    /// Build the final `ExtractionResult` from the accumulated state.
     fn build_result(state: ExtractionState, start: Instant) -> ExtractionResult {
         ExtractionResult {
             nodes: state.nodes,
@@ -574,7 +568,7 @@ impl crate::extraction::LanguageExtractor for LuaExtractor {
         &["lua"]
     }
 
-    fn language_name(&self) -> &str {
+    fn language_name(&self) -> &'static str {
         "Lua"
     }
 

--- a/src/extraction/mod.rs
+++ b/src/extraction/mod.rs
@@ -227,7 +227,7 @@ impl LanguageRegistry {
         self.extractors
             .iter()
             .find(|e| e.extensions().contains(&ext))
-            .map(|e| e.as_ref())
+            .map(std::convert::AsRef::as_ref)
     }
 
     /// Returns all supported file extensions across all extractors.

--- a/src/extraction/msbasic2_extractor.rs
+++ b/src/extraction/msbasic2_extractor.rs
@@ -23,7 +23,7 @@ struct ExtractionState {
     edges: Vec<Edge>,
     unresolved_refs: Vec<UnresolvedRef>,
     errors: Vec<String>,
-    /// Stack of (name, node_id) for building qualified names and parent edges.
+    /// Stack of (name, `node_id`) for building qualified names and parent edges.
     node_stack: Vec<(String, String)>,
     file_path: String,
     source: Vec<u8>,
@@ -177,7 +177,7 @@ impl MsBasic2Extractor {
         lines
     }
 
-    /// Parse a single `line` node into a BasicLine struct.
+    /// Parse a single `line` node into a `BasicLine` struct.
     fn parse_line<'a>(state: &ExtractionState, node: TsNode<'a>) -> Option<BasicLine<'a>> {
         let line_number_node = Self::find_child_by_kind(node, "line_number")?;
         let line_number_text = state.node_text(line_number_node);
@@ -236,27 +236,23 @@ impl MsBasic2Extractor {
 
     /// Extract a LET statement as a Const node.
     fn visit_let_statement(state: &mut ExtractionState, basic_line: &BasicLine<'_>) {
-        let statement_list = match Self::find_child_by_kind(basic_line.node, "statement_list") {
-            Some(sl) => sl,
-            None => return,
+        let Some(statement_list) = Self::find_child_by_kind(basic_line.node, "statement_list")
+        else {
+            return;
         };
-        let statement = match Self::find_child_by_kind(statement_list, "statement") {
-            Some(s) => s,
-            None => return,
+        let Some(statement) = Self::find_child_by_kind(statement_list, "statement") else {
+            return;
         };
-        let let_stmt = match Self::find_child_by_kind(statement, "let_statement") {
-            Some(ls) => ls,
-            None => return,
+        let Some(let_stmt) = Self::find_child_by_kind(statement, "let_statement") else {
+            return;
         };
 
         // Extract the variable name from: let_statement -> variable -> identifier
-        let var_node = match Self::find_child_by_kind(let_stmt, "variable") {
-            Some(v) => v,
-            None => return,
+        let Some(var_node) = Self::find_child_by_kind(let_stmt, "variable") else {
+            return;
         };
-        let id_node = match Self::find_child_by_kind(var_node, "identifier") {
-            Some(i) => i,
-            None => return,
+        let Some(id_node) = Self::find_child_by_kind(var_node, "identifier") else {
+            return;
         };
         let name = state.node_text(id_node);
 
@@ -399,7 +395,7 @@ impl MsBasic2Extractor {
                     // Use the line number of the first code line (after REMs) as the
                     // signature, so callers can reference it by GOSUB <line_number>.
                     let sig_line_num = lines[body_start].line_number;
-                    let signature = format!("GOSUB {}", sig_line_num);
+                    let signature = format!("GOSUB {sig_line_num}");
 
                     let graph_node = Node {
                         id: fn_id.clone(),
@@ -518,7 +514,7 @@ impl MsBasic2Extractor {
         Self::walk_for_calls(state, line.node, from_node_id);
     }
 
-    /// Recursively walk AST nodes looking for gosub_statement and goto_statement.
+    /// Recursively walk AST nodes looking for `gosub_statement` and `goto_statement`.
     fn walk_for_calls(state: &mut ExtractionState, node: TsNode<'_>, from_node_id: &str) {
         let kind = node.kind();
         match kind {
@@ -554,7 +550,7 @@ impl MsBasic2Extractor {
     /// Derive a function name from REM comment text.
     ///
     /// Takes the first REM line text and converts it into a snake_case-like
-    /// identifier. For example, "LOG A MESSAGE" becomes "LOG_A_MESSAGE".
+    /// identifier. For example, "LOG A MESSAGE" becomes "`LOG_A_MESSAGE`".
     fn derive_function_name(rem_comments: &[String]) -> String {
         if rem_comments.is_empty() {
             return "UNNAMED_SUB".to_string();
@@ -610,7 +606,7 @@ impl MsBasic2Extractor {
         None
     }
 
-    /// Build the final ExtractionResult from the accumulated state.
+    /// Build the final `ExtractionResult` from the accumulated state.
     fn build_result(state: ExtractionState, start: Instant) -> ExtractionResult {
         ExtractionResult {
             nodes: state.nodes,
@@ -627,7 +623,7 @@ impl crate::extraction::LanguageExtractor for MsBasic2Extractor {
         &["bas"]
     }
 
-    fn language_name(&self) -> &str {
+    fn language_name(&self) -> &'static str {
         "MS BASIC 2.0"
     }
 

--- a/src/extraction/nix_extractor.rs
+++ b/src/extraction/nix_extractor.rs
@@ -5,7 +5,7 @@ use std::time::{Instant, SystemTime, UNIX_EPOCH};
 
 use tree_sitter::{Node as TsNode, Parser, Tree};
 
-use crate::extraction::complexity::{count_complexity, NIX_COMPLEXITY};
+use crate::extraction::complexity::{count_complexity, ComplexityMetrics, NIX_COMPLEXITY};
 use crate::types::{
     generate_node_id, Edge, EdgeKind, ExtractionResult, Node, NodeKind, UnresolvedRef, Visibility,
 };
@@ -19,7 +19,7 @@ struct ExtractionState {
     edges: Vec<Edge>,
     unresolved_refs: Vec<UnresolvedRef>,
     errors: Vec<String>,
-    /// Stack of (name, node_id) for building qualified names and parent edges.
+    /// Stack of (name, `node_id`) for building qualified names and parent edges.
     node_stack: Vec<(String, String)>,
     file_path: String,
     source: Vec<u8>,
@@ -153,16 +153,10 @@ impl NixExtractor {
             "binding" => Self::visit_binding(state, node),
             "inherit" | "inherit_from" => Self::visit_inherit(state, node),
             // Recurse through structural nodes that wrap definitions.
-            "function_expression" | "binding_set" => {
-                Self::visit_children(state, node);
-            }
-            // Recurse through apply_expression to find nested definitions
-            // (e.g., flake outputs wrapped in eachDefaultSystem calls).
-            "apply_expression" => {
-                Self::visit_children(state, node);
-            }
-            // Recurse through parenthesized expressions.
-            "parenthesized_expression" => {
+            "function_expression"
+            | "binding_set"
+            | "apply_expression"
+            | "parenthesized_expression" => {
                 Self::visit_children(state, node);
             }
             // Recurse into top-level attrset expressions (e.g., flake.nix root).
@@ -173,7 +167,7 @@ impl NixExtractor {
         }
     }
 
-    /// Visit a let expression. Process bindings inside binding_set and the body.
+    /// Visit a let expression. Process bindings inside `binding_set` and the body.
     fn visit_let_expression(state: &mut ExtractionState, node: TsNode<'_>) {
         // Process binding_set for definitions
         let mut cursor = node.walk();
@@ -202,9 +196,8 @@ impl NixExtractor {
     fn visit_binding(state: &mut ExtractionState, node: TsNode<'_>) {
         // Extract name from attrpath child
         let name = Self::extract_binding_name(state, node);
-        let name = match name {
-            Some(n) => n,
-            None => return,
+        let Some(name) = name else {
+            return;
         };
 
         // Get the expression (value) child
@@ -247,10 +240,10 @@ impl NixExtractor {
                     if expr_node.child_count() > 0 {
                         count_complexity(expr_node, &NIX_COMPLEXITY, &state.source)
                     } else {
-                        Default::default()
+                        ComplexityMetrics::default()
                     }
                 } else {
-                    Default::default()
+                    ComplexityMetrics::default()
                 };
 
                 let graph_node = Node {
@@ -433,7 +426,7 @@ impl NixExtractor {
         }
     }
 
-    /// Visit bindings inside an attrset_expression (used for module bodies).
+    /// Visit bindings inside an `attrset_expression` (used for module bodies).
     fn visit_attrset_bindings(state: &mut ExtractionState, node: TsNode<'_>) {
         // attrset_expression contains binding_set
         let mut cursor = node.walk();
@@ -464,7 +457,7 @@ impl NixExtractor {
         }
     }
 
-    /// Visit an inherit or inherit_from node. Creates Use nodes for imported attributes.
+    /// Visit an inherit or `inherit_from` node. Creates Use nodes for imported attributes.
     fn visit_inherit(state: &mut ExtractionState, node: TsNode<'_>) {
         // inherit has `inherited_attrs` with attr children
         // inherit_from has `expression` and `inherited_attrs`
@@ -573,7 +566,7 @@ impl NixExtractor {
         }
     }
 
-    /// Check if an attrset_expression has named bindings (making it a module-like structure).
+    /// Check if an `attrset_expression` has named bindings (making it a module-like structure).
     fn attrset_has_named_bindings(node: TsNode<'_>) -> bool {
         let mut cursor = node.walk();
         if cursor.goto_first_child() {
@@ -602,8 +595,8 @@ impl NixExtractor {
     }
 
     /// Recurse into a function body to find nested definitions.
-    /// This walks through function_expression, apply_expression, let_expression, etc.
-    /// to find attrset_expression and let_expression nodes that contain bindings.
+    /// This walks through `function_expression`, `apply_expression`, `let_expression`, etc.
+    /// to find `attrset_expression` and `let_expression` nodes that contain bindings.
     fn visit_function_body_for_defs(state: &mut ExtractionState, node: TsNode<'_>) {
         match node.kind() {
             "function_expression" => {
@@ -835,7 +828,7 @@ impl NixExtractor {
         Some(comments.join("\n"))
     }
 
-    /// Recursively find call nodes (apply_expression) and create unresolved Calls references.
+    /// Recursively find call nodes (`apply_expression`) and create unresolved Calls references.
     /// Also handles Enhancement 2: import path resolution.
     fn extract_call_sites(state: &mut ExtractionState, node: TsNode<'_>, fn_node_id: &str) {
         let mut cursor = node.walk();
@@ -970,7 +963,7 @@ impl NixExtractor {
         });
     }
 
-    /// Extract the callee name from a function position in an apply_expression.
+    /// Extract the callee name from a function position in an `apply_expression`.
     fn extract_callee_name(state: &ExtractionState, node: TsNode<'_>) -> Option<String> {
         match node.kind() {
             "variable_expression" => {
@@ -991,7 +984,7 @@ impl NixExtractor {
         }
     }
 
-    /// Build the final ExtractionResult from the accumulated state.
+    /// Build the final `ExtractionResult` from the accumulated state.
     fn build_result(state: ExtractionState, start: Instant) -> ExtractionResult {
         ExtractionResult {
             nodes: state.nodes,
@@ -1038,7 +1031,7 @@ impl crate::extraction::LanguageExtractor for NixExtractor {
         &["nix"]
     }
 
-    fn language_name(&self) -> &str {
+    fn language_name(&self) -> &'static str {
         "Nix"
     }
 

--- a/src/extraction/objc_extractor.rs
+++ b/src/extraction/objc_extractor.rs
@@ -20,7 +20,7 @@ struct ExtractionState {
     edges: Vec<Edge>,
     unresolved_refs: Vec<UnresolvedRef>,
     errors: Vec<String>,
-    /// Stack of (name, node_id) for building qualified names and parent edges.
+    /// Stack of (name, `node_id`) for building qualified names and parent edges.
     node_stack: Vec<(String, String)>,
     file_path: String,
     source: Vec<u8>,
@@ -175,12 +175,14 @@ impl ObjcExtractor {
     fn visit_preproc_include(state: &mut ExtractionState, node: TsNode<'_>) {
         let path = Self::find_child_by_kind(node, "string_literal")
             .or_else(|| Self::find_child_by_kind(node, "system_lib_string"))
-            .map(|n| {
-                let text = state.node_text(n);
-                text.trim_matches(|c| c == '"' || c == '<' || c == '>')
-                    .to_string()
-            })
-            .unwrap_or_else(|| "<unknown>".to_string());
+            .map_or_else(
+                || "<unknown>".to_string(),
+                |n| {
+                    let text = state.node_text(n);
+                    text.trim_matches(|c| c == '"' || c == '<' || c == '>')
+                        .to_string()
+                },
+            );
 
         let text = state.node_text(node);
         let start_line = node.start_position().row as u32;
@@ -232,8 +234,7 @@ impl ObjcExtractor {
     /// Extract a preprocessor #define.
     fn visit_preproc_def(state: &mut ExtractionState, node: TsNode<'_>) {
         let name = Self::find_child_by_kind(node, "identifier")
-            .map(|n| state.node_text(n))
-            .unwrap_or_else(|| "<anonymous>".to_string());
+            .map_or_else(|| "<anonymous>".to_string(), |n| state.node_text(n));
 
         let text = state.node_text(node);
         let start_line = node.start_position().row as u32;
@@ -287,11 +288,11 @@ impl ObjcExtractor {
     // type_definition (typedef, including NS_ENUM)
     // -------------------------------------------------------
 
-    /// Visit a type_definition node (typedef).
+    /// Visit a `type_definition` node (typedef).
     ///
     /// For `typedef NS_ENUM(NSInteger, LogLevel) { ... };` the grammar produces
-    /// a type_definition whose first macro_type_specifier child has name "NS_ENUM".
-    /// The enum variant names appear as type_identifier children with field "declarator".
+    /// a `type_definition` whose first `macro_type_specifier` child has name "`NS_ENUM`".
+    /// The enum variant names appear as `type_identifier` children with field "declarator".
     fn visit_type_definition(state: &mut ExtractionState, node: TsNode<'_>) {
         // Check if this is an NS_ENUM pattern
         if let Some(macro_spec) = Self::find_child_by_kind(node, "macro_type_specifier") {
@@ -308,17 +309,17 @@ impl ObjcExtractor {
         Self::visit_simple_typedef(state, node);
     }
 
-    /// Handle NS_ENUM / NS_OPTIONS typedef.
+    /// Handle `NS_ENUM` / `NS_OPTIONS` typedef.
     ///
     /// The grammar parses this as:
-    /// type_definition
-    ///   macro_type_specifier (NS_ENUM)
-    ///     identifier (NS_ENUM)
-    ///     type_descriptor (NSInteger)
-    ///     ERROR (, LogLevel)
+    /// `type_definition`
+    ///   `macro_type_specifier` (`NS_ENUM`)
+    ///     identifier (`NS_ENUM`)
+    ///     `type_descriptor` (`NSInteger`)
+    ///     ERROR (, `LogLevel`)
     ///   ERROR ({)
-    ///   type_identifier (LogLevelDebug)   [field=declarator]
-    ///   type_identifier (LogLevelInfo)    [field=declarator]
+    ///   `type_identifier` (`LogLevelDebug`)   [field=declarator]
+    ///   `type_identifier` (`LogLevelInfo`)    [field=declarator]
     ///   ...
     ///   ERROR (})
     fn visit_ns_enum(state: &mut ExtractionState, node: TsNode<'_>, macro_spec: &TsNode<'_>) {
@@ -389,7 +390,7 @@ impl ObjcExtractor {
         state.node_stack.pop();
     }
 
-    /// Extract the NS_ENUM name from the macro_type_specifier.
+    /// Extract the `NS_ENUM` name from the `macro_type_specifier`.
     /// The name is inside an ERROR child as an identifier.
     fn extract_ns_enum_name(state: &ExtractionState, macro_spec: TsNode<'_>) -> Option<String> {
         // Look for ERROR child containing an identifier
@@ -456,7 +457,7 @@ impl ObjcExtractor {
         }
     }
 
-    /// Visit a simple typedef (not NS_ENUM).
+    /// Visit a simple typedef (not `NS_ENUM`).
     fn visit_simple_typedef(state: &mut ExtractionState, node: TsNode<'_>) {
         let name =
             Self::find_typedef_name(state, node).unwrap_or_else(|| "<anonymous>".to_string());
@@ -505,7 +506,7 @@ impl ObjcExtractor {
         }
     }
 
-    /// Find the typedef name (last type_identifier child).
+    /// Find the typedef name (last `type_identifier` child).
     fn find_typedef_name(state: &ExtractionState, node: TsNode<'_>) -> Option<String> {
         let mut last_type_id = None;
         let mut cursor = node.walk();
@@ -532,8 +533,7 @@ impl ObjcExtractor {
     /// Maps to Interface node kind with method declarations inside.
     fn visit_protocol(state: &mut ExtractionState, node: TsNode<'_>) {
         let name = Self::find_child_by_kind(node, "identifier")
-            .map(|n| state.node_text(n))
-            .unwrap_or_else(|| "<anonymous>".to_string());
+            .map_or_else(|| "<anonymous>".to_string(), |n| state.node_text(n));
 
         let docstring = Self::extract_docstring(state, node);
         let text = state.node_text(node);
@@ -608,7 +608,7 @@ impl ObjcExtractor {
         }
     }
 
-    /// Extract protocol references (inheritance/conformance) from a protocol_reference_list.
+    /// Extract protocol references (inheritance/conformance) from a `protocol_reference_list`.
     fn extract_protocol_refs(
         state: &mut ExtractionState,
         ref_list: TsNode<'_>,
@@ -646,8 +646,7 @@ impl ObjcExtractor {
     /// This includes properties, method declarations, superclass, and protocol conformance.
     fn visit_class_interface(state: &mut ExtractionState, node: TsNode<'_>) {
         let name = Self::find_child_by_kind(node, "identifier")
-            .map(|n| state.node_text(n))
-            .unwrap_or_else(|| "<anonymous>".to_string());
+            .map_or_else(|| "<anonymous>".to_string(), |n| state.node_text(n));
 
         let docstring = Self::extract_docstring(state, node);
         let text = state.node_text(node);
@@ -719,7 +718,7 @@ impl ObjcExtractor {
         state.class_depth -= 1;
     }
 
-    /// Extract protocol conformance from parameterized_arguments (<Serializable>).
+    /// Extract protocol conformance from `parameterized_arguments` (<Serializable>).
     fn extract_protocol_conformance(
         state: &mut ExtractionState,
         params: TsNode<'_>,
@@ -824,7 +823,7 @@ impl ObjcExtractor {
         }
     }
 
-    /// Extract the property name from a property_declaration node.
+    /// Extract the property name from a `property_declaration` node.
     fn extract_property_name(state: &ExtractionState, node: TsNode<'_>) -> Option<String> {
         if let Some(struct_decl) = Self::find_child_by_kind(node, "struct_declaration") {
             if let Some(struct_declarator) =
@@ -847,28 +846,6 @@ impl ObjcExtractor {
         None
     }
 
-    /// Check if a property has the "readonly" attribute.
-    fn is_property_readonly(state: &ExtractionState, node: TsNode<'_>) -> bool {
-        if let Some(attrs) = Self::find_child_by_kind(node, "property_attributes_declaration") {
-            let mut cursor = attrs.walk();
-            if cursor.goto_first_child() {
-                loop {
-                    let child = cursor.node();
-                    if child.kind() == "property_attribute" {
-                        let text = state.node_text(child);
-                        if text == "readonly" {
-                            return true;
-                        }
-                    }
-                    if !cursor.goto_next_sibling() {
-                        break;
-                    }
-                }
-            }
-        }
-        false
-    }
-
     // -------------------------------------------------------
     // method_declaration (in @interface or @protocol)
     // -------------------------------------------------------
@@ -877,7 +854,7 @@ impl ObjcExtractor {
     fn visit_method_declaration(state: &mut ExtractionState, node: TsNode<'_>) {
         let name =
             Self::extract_method_name(state, node).unwrap_or_else(|| "<anonymous>".to_string());
-        let is_class_method = Self::is_class_method(state, node);
+        let _is_class_method = Self::is_class_method(state, node);
 
         let text = state.node_text(node);
         let signature = Some(text.trim().trim_end_matches(';').trim().to_string());
@@ -936,8 +913,7 @@ impl ObjcExtractor {
     /// Maps to Impl node kind with method definitions inside.
     fn visit_class_implementation(state: &mut ExtractionState, node: TsNode<'_>) {
         let name = Self::find_child_by_kind(node, "identifier")
-            .map(|n| state.node_text(n))
-            .unwrap_or_else(|| "<anonymous>".to_string());
+            .map_or_else(|| "<anonymous>".to_string(), |n| state.node_text(n));
 
         let docstring = Self::extract_docstring(state, node);
         let text = state.node_text(node);
@@ -1007,7 +983,7 @@ impl ObjcExtractor {
         }
     }
 
-    /// Visit an implementation_definition which wraps a method_definition.
+    /// Visit an `implementation_definition` which wraps a `method_definition`.
     fn visit_implementation_definition(state: &mut ExtractionState, node: TsNode<'_>) {
         // The implementation_definition contains a method_definition child
         if let Some(method_def) = Self::find_child_by_kind(node, "method_definition") {
@@ -1018,8 +994,8 @@ impl ObjcExtractor {
         }
     }
 
-    /// Extract docstring for an implementation_definition by looking at preceding
-    /// sibling comments within the class_implementation.
+    /// Extract docstring for an `implementation_definition` by looking at preceding
+    /// sibling comments within the `class_implementation`.
     fn extract_impl_method_docstring(state: &ExtractionState, node: TsNode<'_>) -> Option<String> {
         let mut comments = Vec::new();
         let mut current = node.prev_named_sibling();
@@ -1116,7 +1092,7 @@ impl ObjcExtractor {
     fn visit_function_definition(state: &mut ExtractionState, node: TsNode<'_>) {
         let name =
             Self::extract_function_name(state, node).unwrap_or_else(|| "<anonymous>".to_string());
-        let signature = Self::extract_function_signature(state, node);
+        let signature = Some(Self::extract_function_signature(state, node));
         let docstring = Self::extract_docstring(state, node);
         let start_line = node.start_position().row as u32;
         let end_line = node.end_position().row as u32;
@@ -1227,7 +1203,7 @@ impl ObjcExtractor {
     // Call site extraction
     // -------------------------------------------------------
 
-    /// Recursively find call_expression and message_expression nodes and create
+    /// Recursively find `call_expression` and `message_expression` nodes and create
     /// unresolved Calls references.
     fn extract_call_sites(state: &mut ExtractionState, node: TsNode<'_>, fn_node_id: &str) {
         let mut cursor = node.walk();
@@ -1268,7 +1244,7 @@ impl ObjcExtractor {
 
     /// Extract a message expression call site.
     ///
-    /// For `[NSString stringWithFormat:...]`, the receiver is "NSString" and
+    /// For `[NSString stringWithFormat:...]`, the receiver is "`NSString`" and
     /// the method is "stringWithFormat".
     fn extract_message_call(state: &mut ExtractionState, node: TsNode<'_>, fn_node_id: &str) {
         let method_name = node
@@ -1280,7 +1256,7 @@ impl ObjcExtractor {
 
         if let Some(method) = method_name {
             let reference_name = if let Some(receiver) = receiver_name {
-                format!("{}.{}", receiver, method)
+                format!("{receiver}.{method}")
             } else {
                 method
             };
@@ -1299,9 +1275,9 @@ impl ObjcExtractor {
     // Method name and type extraction helpers
     // -------------------------------------------------------
 
-    /// Extract the method name from a method_definition or method_declaration node.
+    /// Extract the method name from a `method_definition` or `method_declaration` node.
     ///
-    /// The method name is the first identifier child (not inside method_type or method_parameter).
+    /// The method name is the first identifier child (not inside `method_type` or `method_parameter`).
     fn extract_method_name(state: &ExtractionState, node: TsNode<'_>) -> Option<String> {
         let mut cursor = node.walk();
         if cursor.goto_first_child() {
@@ -1327,7 +1303,7 @@ impl ObjcExtractor {
         false
     }
 
-    /// Extract the function name from a function_definition or declaration node.
+    /// Extract the function name from a `function_definition` or declaration node.
     fn extract_function_name(state: &ExtractionState, node: TsNode<'_>) -> Option<String> {
         if let Some(declarator) = Self::find_descendant_by_kind(node, "function_declarator") {
             if let Some(ident) = Self::find_child_by_kind(declarator, "identifier") {
@@ -1338,13 +1314,12 @@ impl ObjcExtractor {
     }
 
     /// Extract the function signature (everything except the body).
-    fn extract_function_signature(state: &ExtractionState, node: TsNode<'_>) -> Option<String> {
+    fn extract_function_signature(state: &ExtractionState, node: TsNode<'_>) -> String {
         let text = state.node_text(node);
         if let Some(brace_pos) = text.find('{') {
-            Some(text[..brace_pos].trim().to_string())
+            text[..brace_pos].trim().to_string()
         } else {
-            let trimmed = text.trim().trim_end_matches(';').trim().to_string();
-            Some(trimmed)
+            text.trim().trim_end_matches(';').trim().to_string()
         }
     }
 
@@ -1450,7 +1425,7 @@ impl ObjcExtractor {
         None
     }
 
-    /// Build the final ExtractionResult from the accumulated state.
+    /// Build the final `ExtractionResult` from the accumulated state.
     fn build_result(state: ExtractionState, start: Instant) -> ExtractionResult {
         ExtractionResult {
             nodes: state.nodes,
@@ -1467,7 +1442,7 @@ impl crate::extraction::LanguageExtractor for ObjcExtractor {
         &["m", "mm"]
     }
 
-    fn language_name(&self) -> &str {
+    fn language_name(&self) -> &'static str {
         "Objective-C"
     }
 

--- a/src/extraction/pascal_extractor.rs
+++ b/src/extraction/pascal_extractor.rs
@@ -317,8 +317,7 @@ impl PascalExtractor {
     /// Extract a single uses reference as a Use node.
     fn visit_single_use(state: &mut ExtractionState, node: TsNode<'_>) {
         let name = Self::find_child_by_kind(node, "identifier")
-            .map(|n| state.node_text(n))
-            .unwrap_or_else(|| state.node_text(node));
+            .map_or_else(|| state.node_text(node), |n| state.node_text(n));
         let start_line = node.start_position().row as u32;
         let end_line = node.end_position().row as u32;
         let start_column = node.start_position().column as u32;
@@ -392,8 +391,7 @@ impl PascalExtractor {
     /// Dispatches based on whether it's a class, record, interface, or type alias.
     fn visit_type_decl(state: &mut ExtractionState, node: TsNode<'_>) {
         let name = Self::find_child_by_kind(node, "identifier")
-            .map(|n| state.node_text(n))
-            .unwrap_or_else(|| "<anonymous>".to_string());
+            .map_or_else(|| "<anonymous>".to_string(), |n| state.node_text(n));
 
         // Look for the type body: declClass, declIntf, or plain type.
         if let Some(class_node) = Self::find_child_by_kind(node, "declClass") {
@@ -725,7 +723,7 @@ impl PascalExtractor {
         }
     }
 
-    /// Visit a visibility section (public, private, protected) and update current_visibility.
+    /// Visit a visibility section (public, private, protected) and update `current_visibility`.
     fn visit_visibility_section(state: &mut ExtractionState, node: TsNode<'_>) {
         // First child should be the visibility keyword.
         let mut cursor = node.walk();
@@ -751,8 +749,7 @@ impl PascalExtractor {
     /// Extract a field declaration.
     fn visit_field(state: &mut ExtractionState, node: TsNode<'_>) {
         let name = Self::find_child_by_kind(node, "identifier")
-            .map(|n| state.node_text(n))
-            .unwrap_or_else(|| "<anonymous>".to_string());
+            .map_or_else(|| "<anonymous>".to_string(), |n| state.node_text(n));
         let text = state.node_text(node);
         let start_line = node.start_position().row as u32;
         let end_line = node.end_position().row as u32;
@@ -899,8 +896,7 @@ impl PascalExtractor {
     /// Extract a property declaration.
     fn visit_property(state: &mut ExtractionState, node: TsNode<'_>) {
         let name = Self::find_child_by_kind(node, "identifier")
-            .map(|n| state.node_text(n))
-            .unwrap_or_else(|| "<anonymous>".to_string());
+            .map_or_else(|| "<anonymous>".to_string(), |n| state.node_text(n));
         let text = state.node_text(node);
         let start_line = node.start_position().row as u32;
         let end_line = node.end_position().row as u32;
@@ -964,8 +960,7 @@ impl PascalExtractor {
     /// Extract a single constant declaration.
     fn visit_const(state: &mut ExtractionState, node: TsNode<'_>) {
         let name = Self::find_child_by_kind(node, "identifier")
-            .map(|n| state.node_text(n))
-            .unwrap_or_else(|| "<anonymous>".to_string());
+            .map_or_else(|| "<anonymous>".to_string(), |n| state.node_text(n));
         let text = state.node_text(node);
         let start_line = node.start_position().row as u32;
         let end_line = node.end_position().row as u32;
@@ -1035,8 +1030,7 @@ impl PascalExtractor {
     /// Extract a single variable declaration.
     fn visit_var(state: &mut ExtractionState, node: TsNode<'_>) {
         let name = Self::find_child_by_kind(node, "identifier")
-            .map(|n| state.node_text(n))
-            .unwrap_or_else(|| "<anonymous>".to_string());
+            .map_or_else(|| "<anonymous>".to_string(), |n| state.node_text(n));
         let text = state.node_text(node);
         let start_line = node.start_position().row as u32;
         let end_line = node.end_position().row as u32;
@@ -1112,10 +1106,10 @@ impl PascalExtractor {
             };
 
             let actual_kind = if is_method {
-                match kind_str {
-                    "constructor" => NodeKind::Constructor,
-                    "destructor" => NodeKind::Method,
-                    _ => NodeKind::Method,
+                if kind_str == "constructor" {
+                    NodeKind::Constructor
+                } else {
+                    NodeKind::Method
                 }
             } else {
                 node_kind.clone()
@@ -1201,7 +1195,7 @@ impl PascalExtractor {
     }
 
     /// Determine the procedure kind from a declProc node.
-    /// Returns (kind_str, NodeKind).
+    /// Returns (`kind_str`, `NodeKind`).
     fn determine_proc_kind(node: TsNode<'_>) -> (&'static str, NodeKind) {
         if Self::find_child_by_kind(node, "kConstructor").is_some() {
             ("constructor", NodeKind::Constructor)
@@ -1225,12 +1219,11 @@ impl PascalExtractor {
         }
         // Otherwise look for a simple identifier.
         Self::find_child_by_kind(node, "identifier")
-            .map(|n| state.node_text(n))
-            .unwrap_or_else(|| "<anonymous>".to_string())
+            .map_or_else(|| "<anonymous>".to_string(), |n| state.node_text(n))
     }
 
     /// Parse a dotted name from a declProc node.
-    /// Returns (is_method, class_name, method_name).
+    /// Returns (`is_method`, `class_name`, `method_name`).
     fn parse_dotted_name(state: &ExtractionState, decl_node: TsNode<'_>) -> (bool, String, String) {
         if let Some(dot_node) = Self::find_child_by_kind(decl_node, "genericDot") {
             // genericDot has identifiers separated by kDot.
@@ -1364,7 +1357,7 @@ impl PascalExtractor {
             let inner = &trimmed[2..trimmed.len() - 2];
             inner
                 .lines()
-                .map(|line| line.trim())
+                .map(str::trim)
                 .collect::<Vec<_>>()
                 .join("\n")
                 .trim()
@@ -1391,7 +1384,7 @@ impl PascalExtractor {
         None
     }
 
-    /// Build the final ExtractionResult from the accumulated state.
+    /// Build the final `ExtractionResult` from the accumulated state.
     fn build_result(state: ExtractionState, start: Instant) -> ExtractionResult {
         ExtractionResult {
             nodes: state.nodes,
@@ -1408,7 +1401,7 @@ impl crate::extraction::LanguageExtractor for PascalExtractor {
         &["pas", "pp", "dpr", "lpr"]
     }
 
-    fn language_name(&self) -> &str {
+    fn language_name(&self) -> &'static str {
         "Pascal"
     }
 

--- a/src/extraction/perl_extractor.rs
+++ b/src/extraction/perl_extractor.rs
@@ -19,7 +19,7 @@ struct ExtractionState {
     edges: Vec<Edge>,
     unresolved_refs: Vec<UnresolvedRef>,
     errors: Vec<String>,
-    /// Stack of (name, node_id) for building qualified names and parent edges.
+    /// Stack of (name, `node_id`) for building qualified names and parent edges.
     node_stack: Vec<(String, String)>,
     file_path: String,
     source: Vec<u8>,
@@ -162,12 +162,11 @@ impl PerlExtractor {
 
     /// Extract a function/method definition (`sub name { ... }`).
     ///
-    /// If class_depth > 0, this is a method inside a package; otherwise it is a top-level function.
+    /// If `class_depth` > 0, this is a method inside a package; otherwise it is a top-level function.
     fn visit_function(state: &mut ExtractionState, node: TsNode<'_>) {
         let name = node
             .child_by_field_name("name")
-            .map(|n| state.node_text(n))
-            .unwrap_or_else(|| "<anonymous>".to_string());
+            .map_or_else(|| "<anonymous>".to_string(), |n| state.node_text(n));
 
         let kind = if state.class_depth > 0 {
             NodeKind::Method
@@ -232,11 +231,10 @@ impl PerlExtractor {
     /// belong to this package until another package statement or end of file.
     /// Since Perl packages don't have explicit end markers (no `end` keyword),
     /// we handle them by scanning ahead through siblings until the next
-    /// package_statement or end of the source_file children.
+    /// `package_statement` or end of the `source_file` children.
     fn visit_package(state: &mut ExtractionState, node: TsNode<'_>) {
         let name = Self::find_child_by_kind(node, "package_name")
-            .map(|pn| state.node_text(pn))
-            .unwrap_or_else(|| "<anonymous>".to_string());
+            .map_or_else(|| "<anonymous>".to_string(), |pn| state.node_text(pn));
 
         // Skip `package main;` — it just returns to the top-level scope.
         if name == "main" {
@@ -318,7 +316,7 @@ impl PerlExtractor {
     }
 
     /// Find the end line of a package scope by looking at the next sibling
-    /// that is a package_statement, or the last sibling in the source_file.
+    /// that is a `package_statement`, or the last sibling in the `source_file`.
     fn find_package_end_line(node: TsNode<'_>, _state: &ExtractionState) -> u32 {
         let mut sibling = node.next_named_sibling();
         let mut last_end = node.end_position().row as u32;
@@ -337,8 +335,7 @@ impl PerlExtractor {
     fn visit_use(state: &mut ExtractionState, node: TsNode<'_>) {
         let name = node
             .child_by_field_name("package_name")
-            .map(|n| state.node_text(n))
-            .unwrap_or_else(|| "<unknown>".to_string());
+            .map_or_else(|| "<unknown>".to_string(), |n| state.node_text(n));
 
         let start_line = node.start_position().row as u32;
         let end_line = node.end_position().row as u32;
@@ -386,17 +383,15 @@ impl PerlExtractor {
 
     /// Check if a binary expression is an `our $CAPS_VAR = value` constant declaration.
     ///
-    /// In tree-sitter-perl, `our $MAX_RETRIES = 3` is a binary_expression with:
-    ///   - left child: variable_declaration { scope("our"), scalar_variable("$MAX_RETRIES") }
+    /// In tree-sitter-perl, `our $MAX_RETRIES = 3` is a `binary_expression` with:
+    ///   - left child: `variable_declaration` { scope("our"), `scalar_variable("$MAX_RETRIES`") }
     ///   - right child: integer(3)
     fn visit_binary_expression_for_const(state: &mut ExtractionState, node: TsNode<'_>) {
         let left = node.child_by_field_name("variable");
         if let Some(left_node) = left {
             if left_node.kind() == "variable_declaration" {
                 let scope_node = Self::find_child_by_kind(left_node, "scope");
-                let is_our = scope_node
-                    .map(|s| state.node_text(s) == "our")
-                    .unwrap_or(false);
+                let is_our = scope_node.is_some_and(|s| state.node_text(s) == "our");
 
                 if is_our {
                     // Get the variable name from scalar_variable child.
@@ -545,7 +540,7 @@ impl PerlExtractor {
                                 let pkg_name = state.node_text(pkg);
                                 if let Some(fn_name) = ceb.child_by_field_name("function_name") {
                                     let fn_text = state.node_text(fn_name);
-                                    let qualified = format!("{}::{}", pkg_name, fn_text);
+                                    let qualified = format!("{pkg_name}::{fn_text}");
                                     state.unresolved_refs.push(UnresolvedRef {
                                         from_node_id: fn_node_id.to_string(),
                                         reference_name: qualified,
@@ -571,7 +566,7 @@ impl PerlExtractor {
                                 .map(|n| state.node_text(n));
 
                             if let Some(obj) = obj_name {
-                                let qualified = format!("{}->{}", obj, name);
+                                let qualified = format!("{obj}->{name}");
                                 state.unresolved_refs.push(UnresolvedRef {
                                     from_node_id: fn_node_id.to_string(),
                                     reference_name: qualified,
@@ -678,7 +673,7 @@ impl PerlExtractor {
         None
     }
 
-    /// Build the final ExtractionResult from the accumulated state.
+    /// Build the final `ExtractionResult` from the accumulated state.
     fn build_result(state: ExtractionState, start: Instant) -> ExtractionResult {
         ExtractionResult {
             nodes: state.nodes,
@@ -695,7 +690,7 @@ impl crate::extraction::LanguageExtractor for PerlExtractor {
         &["pl", "pm"]
     }
 
-    fn language_name(&self) -> &str {
+    fn language_name(&self) -> &'static str {
         "Perl"
     }
 

--- a/src/extraction/php_extractor.rs
+++ b/src/extraction/php_extractor.rs
@@ -19,7 +19,7 @@ struct ExtractionState {
     edges: Vec<Edge>,
     unresolved_refs: Vec<UnresolvedRef>,
     errors: Vec<String>,
-    /// Stack of (name, node_id) for building qualified names and parent edges.
+    /// Stack of (name, `node_id`) for building qualified names and parent edges.
     node_stack: Vec<(String, String)>,
     file_path: String,
     source: Vec<u8>,
@@ -170,11 +170,10 @@ impl PhpExtractor {
     /// Extract a top-level function definition.
     fn visit_function(state: &mut ExtractionState, node: TsNode<'_>) {
         let name = Self::find_child_by_kind(node, "name")
-            .map(|n| state.node_text(n))
-            .unwrap_or_else(|| "<anonymous>".to_string());
+            .map_or_else(|| "<anonymous>".to_string(), |n| state.node_text(n));
 
         let visibility = Visibility::Pub;
-        let signature = Self::extract_function_signature(state, node);
+        let signature = Some(Self::extract_function_signature(state, node));
         let docstring = Self::extract_docstring(state, node);
         let start_line = node.start_position().row as u32;
         let end_line = node.end_position().row as u32;
@@ -230,11 +229,10 @@ impl PhpExtractor {
     /// Extract a class method declaration.
     fn visit_method(state: &mut ExtractionState, node: TsNode<'_>) {
         let name = Self::find_child_by_kind(node, "name")
-            .map(|n| state.node_text(n))
-            .unwrap_or_else(|| "<anonymous>".to_string());
+            .map_or_else(|| "<anonymous>".to_string(), |n| state.node_text(n));
 
         let visibility = Self::extract_visibility(state, node);
-        let signature = Self::extract_function_signature(state, node);
+        let signature = Some(Self::extract_function_signature(state, node));
         let docstring = Self::extract_docstring(state, node);
         let start_line = node.start_position().row as u32;
         let end_line = node.end_position().row as u32;
@@ -290,12 +288,11 @@ impl PhpExtractor {
     /// Extract a class declaration.
     fn visit_class(state: &mut ExtractionState, node: TsNode<'_>) {
         let name = Self::find_child_by_kind(node, "name")
-            .map(|n| state.node_text(n))
-            .unwrap_or_else(|| "<anonymous>".to_string());
+            .map_or_else(|| "<anonymous>".to_string(), |n| state.node_text(n));
 
         let visibility = Visibility::Pub;
         let docstring = Self::extract_docstring(state, node);
-        let signature = Self::extract_class_signature(state, node);
+        let signature = Some(Self::extract_class_signature(state, node));
         let start_line = node.start_position().row as u32;
         let end_line = node.end_position().row as u32;
         let start_column = node.start_position().column as u32;
@@ -357,8 +354,7 @@ impl PhpExtractor {
     /// Extract an interface declaration.
     fn visit_interface(state: &mut ExtractionState, node: TsNode<'_>) {
         let name = Self::find_child_by_kind(node, "name")
-            .map(|n| state.node_text(n))
-            .unwrap_or_else(|| "<anonymous>".to_string());
+            .map_or_else(|| "<anonymous>".to_string(), |n| state.node_text(n));
 
         let visibility = Visibility::Pub;
         let docstring = Self::extract_docstring(state, node);
@@ -417,8 +413,7 @@ impl PhpExtractor {
     /// Extract a trait declaration.
     fn visit_trait(state: &mut ExtractionState, node: TsNode<'_>) {
         let name = Self::find_child_by_kind(node, "name")
-            .map(|n| state.node_text(n))
-            .unwrap_or_else(|| "<anonymous>".to_string());
+            .map_or_else(|| "<anonymous>".to_string(), |n| state.node_text(n));
 
         let visibility = Visibility::Pub;
         let docstring = Self::extract_docstring(state, node);
@@ -477,8 +472,7 @@ impl PhpExtractor {
     /// Extract an enum declaration.
     fn visit_enum(state: &mut ExtractionState, node: TsNode<'_>) {
         let name = Self::find_child_by_kind(node, "name")
-            .map(|n| state.node_text(n))
-            .unwrap_or_else(|| "<anonymous>".to_string());
+            .map_or_else(|| "<anonymous>".to_string(), |n| state.node_text(n));
 
         let visibility = Visibility::Pub;
         let docstring = Self::extract_docstring(state, node);
@@ -534,7 +528,7 @@ impl PhpExtractor {
         state.node_stack.pop();
     }
 
-    /// Visit enum body, extracting enum cases as EnumVariant nodes.
+    /// Visit enum body, extracting enum cases as `EnumVariant` nodes.
     fn visit_enum_body(state: &mut ExtractionState, node: TsNode<'_>) {
         let mut cursor = node.walk();
         if cursor.goto_first_child() {
@@ -553,11 +547,10 @@ impl PhpExtractor {
         }
     }
 
-    /// Extract an enum case as an EnumVariant.
+    /// Extract an enum case as an `EnumVariant`.
     fn visit_enum_case(state: &mut ExtractionState, node: TsNode<'_>) {
         let name = Self::find_child_by_kind(node, "name")
-            .map(|n| state.node_text(n))
-            .unwrap_or_else(|| "<anonymous>".to_string());
+            .map_or_else(|| "<anonymous>".to_string(), |n| state.node_text(n));
 
         let start_line = node.start_position().row as u32;
         let end_line = node.end_position().row as u32;
@@ -604,8 +597,7 @@ impl PhpExtractor {
     /// Extract a namespace definition.
     fn visit_namespace(state: &mut ExtractionState, node: TsNode<'_>) {
         let name = Self::find_child_by_kind(node, "namespace_name")
-            .map(|n| state.node_text(n))
-            .unwrap_or_else(|| "<anonymous>".to_string());
+            .map_or_else(|| "<anonymous>".to_string(), |n| state.node_text(n));
 
         let visibility = Visibility::Pub;
         let start_line = node.start_position().row as u32;
@@ -689,8 +681,7 @@ impl PhpExtractor {
     fn visit_use_clause(state: &mut ExtractionState, clause: TsNode<'_>, use_node: TsNode<'_>) {
         let name = Self::find_child_by_kind(clause, "qualified_name")
             .or_else(|| Self::find_child_by_kind(clause, "name"))
-            .map(|n| state.node_text(n))
-            .unwrap_or_else(|| state.node_text(clause));
+            .map_or_else(|| state.node_text(clause), |n| state.node_text(n));
         Self::create_use_node(state, &name, use_node);
     }
 
@@ -708,12 +699,11 @@ impl PhpExtractor {
                 if child.kind() == "namespace_use_clause" {
                     let item = Self::find_child_by_kind(child, "name")
                         .or_else(|| Self::find_child_by_kind(child, "qualified_name"))
-                        .map(|n| state.node_text(n))
-                        .unwrap_or_else(|| state.node_text(child));
+                        .map_or_else(|| state.node_text(child), |n| state.node_text(n));
                     let full_name = if prefix.is_empty() {
                         item
                     } else {
-                        format!("{}\\{}", prefix, item)
+                        format!("{prefix}\\{item}")
                     };
                     Self::create_use_node(state, &full_name, use_node);
                 }
@@ -799,8 +789,7 @@ impl PhpExtractor {
     /// Extract a single const element.
     fn visit_const_element(state: &mut ExtractionState, node: TsNode<'_>) {
         let name = Self::find_child_by_kind(node, "name")
-            .map(|n| state.node_text(n))
-            .unwrap_or_else(|| "<anonymous>".to_string());
+            .map_or_else(|| "<anonymous>".to_string(), |n| state.node_text(n));
 
         let start_line = node.start_position().row as u32;
         let end_line = node.end_position().row as u32;
@@ -856,8 +845,7 @@ impl PhpExtractor {
                 if child.kind() == "property_element" || child.kind() == "variable_name" {
                     let name = if child.kind() == "property_element" {
                         Self::find_child_by_kind(child, "variable_name")
-                            .map(|n| state.node_text(n))
-                            .unwrap_or_else(|| state.node_text(child))
+                            .map_or_else(|| state.node_text(child), |n| state.node_text(n))
                     } else {
                         state.node_text(child)
                     };
@@ -940,14 +928,12 @@ impl PhpExtractor {
     // Helper extraction methods
     // ----------------------------
 
-    /// Extract the visibility modifier from a node (looks for visibility_modifier child).
+    /// Extract the visibility modifier from a node (looks for `visibility_modifier` child).
     fn extract_visibility(state: &ExtractionState, node: TsNode<'_>) -> Visibility {
         if let Some(vis_node) = Self::find_child_by_kind(node, "visibility_modifier") {
             let text = state.node_text(vis_node);
             match text.trim() {
-                "public" => Visibility::Pub,
-                "protected" => Visibility::Private,
-                "private" => Visibility::Private,
+                "protected" | "private" => Visibility::Private,
                 _ => Visibility::Pub,
             }
         } else {
@@ -1007,30 +993,30 @@ impl PhpExtractor {
     }
 
     /// Extract the function/method signature (everything up to the body).
-    fn extract_function_signature(state: &ExtractionState, node: TsNode<'_>) -> Option<String> {
+    fn extract_function_signature(state: &ExtractionState, node: TsNode<'_>) -> String {
         // Use the compound_statement body's start byte to find where the body begins.
         if let Some(body) = Self::find_child_by_kind(node, "compound_statement") {
             let text = state.node_text(node);
             let body_offset = body.start_byte() - node.start_byte();
             if body_offset <= text.len() {
                 let before_body = &text[..body_offset];
-                return Some(before_body.trim().to_string());
+                return before_body.trim().to_string();
             }
         }
-        Some(state.node_text(node).trim().to_string())
+        state.node_text(node).trim().to_string()
     }
 
     /// Extract the class signature (class Name extends Base implements Iface).
-    fn extract_class_signature(state: &ExtractionState, node: TsNode<'_>) -> Option<String> {
+    fn extract_class_signature(state: &ExtractionState, node: TsNode<'_>) -> String {
         if let Some(body) = Self::find_child_by_kind(node, "declaration_list") {
             let text = state.node_text(node);
             let body_offset = body.start_byte() - node.start_byte();
             if body_offset <= text.len() {
                 let before_body = &text[..body_offset];
-                return Some(before_body.trim().to_string());
+                return before_body.trim().to_string();
             }
         }
-        Some(state.node_text(node).trim().to_string())
+        state.node_text(node).trim().to_string()
     }
 
     /// Extract PHP doc comments (`/** ... */`) preceding a node.
@@ -1163,10 +1149,10 @@ impl PhpExtractor {
     // -----------------------------------------------------------------------
 
     /// Extract PHP 8 attributes from a declaration node and create
-    /// AnnotationUsage nodes and Annotates edges.
+    /// `AnnotationUsage` nodes and Annotates edges.
     ///
     /// PHP 8 attributes appear as `attribute_list` children of the declaration.
-    /// Structure: attribute_list > attribute_group > attribute > name.
+    /// Structure: `attribute_list` > `attribute_group` > attribute > name.
     fn extract_annotations(state: &mut ExtractionState, node: TsNode<'_>, target_id: &str) {
         let mut cursor = node.walk();
         if cursor.goto_first_child() {
@@ -1182,8 +1168,8 @@ impl PhpExtractor {
         }
     }
 
-    /// Walk an attribute_list node, iterating over attribute_group > attribute
-    /// children to create AnnotationUsage nodes.
+    /// Walk an `attribute_list` node, iterating over `attribute_group` > attribute
+    /// children to create `AnnotationUsage` nodes.
     fn extract_annotations_from_attribute_list(
         state: &mut ExtractionState,
         attr_list: TsNode<'_>,
@@ -1303,7 +1289,7 @@ impl PhpExtractor {
         None
     }
 
-    /// Build the final ExtractionResult from the accumulated state.
+    /// Build the final `ExtractionResult` from the accumulated state.
     fn build_result(state: ExtractionState, start: Instant) -> ExtractionResult {
         ExtractionResult {
             nodes: state.nodes,
@@ -1320,7 +1306,7 @@ impl crate::extraction::LanguageExtractor for PhpExtractor {
         &["php"]
     }
 
-    fn language_name(&self) -> &str {
+    fn language_name(&self) -> &'static str {
         "PHP"
     }
 

--- a/src/extraction/powershell_extractor.rs
+++ b/src/extraction/powershell_extractor.rs
@@ -19,7 +19,7 @@ struct ExtractionState {
     edges: Vec<Edge>,
     unresolved_refs: Vec<UnresolvedRef>,
     errors: Vec<String>,
-    /// Stack of (name, node_id) for building qualified names and parent edges.
+    /// Stack of (name, `node_id`) for building qualified names and parent edges.
     node_stack: Vec<(String, String)>,
     file_path: String,
     source: Vec<u8>,
@@ -171,8 +171,7 @@ impl PowerShellExtractor {
     /// Extract a function definition.
     fn visit_function(state: &mut ExtractionState, node: TsNode<'_>) {
         let name = Self::find_child_by_kind(node, "function_name")
-            .map(|n| state.node_text(n))
-            .unwrap_or_else(|| "<anonymous>".to_string());
+            .map_or_else(|| "<anonymous>".to_string(), |n| state.node_text(n));
 
         let kind = NodeKind::Function;
         let visibility = Visibility::Pub;
@@ -228,25 +227,22 @@ impl PowerShellExtractor {
     /// Extract a typed variable assignment at the top level as a Const.
     ///
     /// Matches patterns like `[int]$MaxRetries = 3`.
-    /// The AST is: pipeline > assignment_expression > left_assignment_expression > ... > cast_expression > variable.
+    /// The AST is: pipeline > `assignment_expression` > `left_assignment_expression` > ... > `cast_expression` > variable.
     fn visit_assignment(state: &mut ExtractionState, node: TsNode<'_>, pipeline_node: TsNode<'_>) {
         // Only treat top-level typed assignments as constants.
         // We detect a cast_expression inside the left_assignment_expression.
-        let left = match Self::find_child_by_kind(node, "left_assignment_expression") {
-            Some(l) => l,
-            None => return,
+        let Some(left) = Self::find_child_by_kind(node, "left_assignment_expression") else {
+            return;
         };
 
         // Look for a cast_expression recursively inside the left side.
-        let cast = match Self::find_descendant_by_kind(left, "cast_expression") {
-            Some(c) => c,
-            None => return,
+        let Some(cast) = Self::find_descendant_by_kind(left, "cast_expression") else {
+            return;
         };
 
         // The variable is a child of the cast_expression.
-        let var_node = match Self::find_descendant_by_kind(cast, "variable") {
-            Some(v) => v,
-            None => return,
+        let Some(var_node) = Self::find_descendant_by_kind(cast, "variable") else {
+            return;
         };
 
         let var_text = state.node_text(var_node);
@@ -491,7 +487,7 @@ impl PowerShellExtractor {
         None
     }
 
-    /// Build the final ExtractionResult from the accumulated state.
+    /// Build the final `ExtractionResult` from the accumulated state.
     fn build_result(state: ExtractionState, start: Instant) -> ExtractionResult {
         ExtractionResult {
             nodes: state.nodes,
@@ -508,7 +504,7 @@ impl crate::extraction::LanguageExtractor for PowerShellExtractor {
         &["ps1", "psm1"]
     }
 
-    fn language_name(&self) -> &str {
+    fn language_name(&self) -> &'static str {
         "PowerShell"
     }
 

--- a/src/extraction/proto_extractor.rs
+++ b/src/extraction/proto_extractor.rs
@@ -17,7 +17,7 @@ struct ExtractionState {
     nodes: Vec<Node>,
     edges: Vec<Edge>,
     errors: Vec<String>,
-    /// Stack of (name, node_id) for building qualified names and parent edges.
+    /// Stack of (name, `node_id`) for building qualified names and parent edges.
     node_stack: Vec<(String, String)>,
     file_path: String,
     source: Vec<u8>,
@@ -157,8 +157,7 @@ impl ProtoExtractor {
         // package -> fullIdent -> ident
         let name = Self::find_child_by_kind(node, "fullIdent")
             .and_then(|fi| Self::find_child_by_kind(fi, "ident"))
-            .map(|n| state.node_text(n))
-            .unwrap_or_else(|| "<unknown>".to_string());
+            .map_or_else(|| "<unknown>".to_string(), |n| state.node_text(n));
 
         let start_line = node.start_position().row as u32;
         let end_line = node.end_position().row as u32;
@@ -212,13 +211,14 @@ impl ProtoExtractor {
     /// Extract an `import` statement.
     fn visit_import(state: &mut ExtractionState, node: TsNode<'_>) {
         // import -> strLit (the quoted path)
-        let name = Self::find_child_by_kind(node, "strLit")
-            .map(|n| {
+        let name = Self::find_child_by_kind(node, "strLit").map_or_else(
+            || "<unknown>".to_string(),
+            |n| {
                 let text = state.node_text(n);
                 // Strip surrounding quotes
                 text.trim_matches('"').trim_matches('\'').to_string()
-            })
-            .unwrap_or_else(|| "<unknown>".to_string());
+            },
+        );
 
         let start_line = node.start_position().row as u32;
         let end_line = node.end_position().row as u32;
@@ -274,8 +274,7 @@ impl ProtoExtractor {
         // message -> messageName -> ident, messageBody -> (field | message | oneof | enum | ...)
         let name = Self::find_child_by_kind(node, "messageName")
             .and_then(|mn| Self::find_child_by_kind(mn, "ident"))
-            .map(|n| state.node_text(n))
-            .unwrap_or_else(|| "<anonymous>".to_string());
+            .map_or_else(|| "<anonymous>".to_string(), |n| state.node_text(n));
 
         let docstring = Self::extract_docstring(state, node);
         let start_line = node.start_position().row as u32;
@@ -284,7 +283,7 @@ impl ProtoExtractor {
         let end_column = node.end_position().column as u32;
         let qualified_name = format!("{}::{}", state.qualified_prefix(), name);
         let id = generate_node_id(&state.file_path, &NodeKind::ProtoMessage, &name, start_line);
-        let signature = Some(format!("message {}", name));
+        let signature = Some(format!("message {name}"));
 
         let graph_node = Node {
             id: id.clone(),
@@ -353,17 +352,14 @@ impl ProtoExtractor {
         // field -> type, fieldName -> ident, fieldNumber -> intLit
         let name = Self::find_child_by_kind(node, "fieldName")
             .and_then(|fn_node| Self::find_child_by_kind(fn_node, "ident"))
-            .map(|n| state.node_text(n))
-            .unwrap_or_else(|| "<anonymous>".to_string());
+            .map_or_else(|| "<anonymous>".to_string(), |n| state.node_text(n));
 
         let type_text = Self::find_child_by_kind(node, "type")
-            .map(|n| state.node_text(n))
-            .unwrap_or_else(|| "unknown".to_string());
+            .map_or_else(|| "unknown".to_string(), |n| state.node_text(n));
 
         let field_number = Self::find_child_by_kind(node, "fieldNumber")
             .and_then(|fn_node| Self::find_child_by_kind(fn_node, "intLit"))
-            .map(|n| state.node_text(n))
-            .unwrap_or_else(|| "?".to_string());
+            .map_or_else(|| "?".to_string(), |n| state.node_text(n));
 
         let start_line = node.start_position().row as u32;
         let end_line = node.end_position().row as u32;
@@ -371,7 +367,7 @@ impl ProtoExtractor {
         let end_column = node.end_position().column as u32;
         let qualified_name = format!("{}::{}", state.qualified_prefix(), name);
         let id = generate_node_id(&state.file_path, &NodeKind::Field, &name, start_line);
-        let signature = Some(format!("{} {} = {}", type_text, name, field_number));
+        let signature = Some(format!("{type_text} {name} = {field_number}"));
 
         let graph_node = Node {
             id: id.clone(),
@@ -413,8 +409,7 @@ impl ProtoExtractor {
         // enum -> enumName -> ident, enumBody -> enumField*
         let name = Self::find_child_by_kind(node, "enumName")
             .and_then(|en| Self::find_child_by_kind(en, "ident"))
-            .map(|n| state.node_text(n))
-            .unwrap_or_else(|| "<anonymous>".to_string());
+            .map_or_else(|| "<anonymous>".to_string(), |n| state.node_text(n));
 
         let docstring = Self::extract_docstring(state, node);
         let start_line = node.start_position().row as u32;
@@ -423,7 +418,7 @@ impl ProtoExtractor {
         let end_column = node.end_position().column as u32;
         let qualified_name = format!("{}::{}", state.qualified_prefix(), name);
         let id = generate_node_id(&state.file_path, &NodeKind::Enum, &name, start_line);
-        let signature = Some(format!("enum {}", name));
+        let signature = Some(format!("enum {name}"));
 
         let graph_node = Node {
             id: id.clone(),
@@ -487,12 +482,10 @@ impl ProtoExtractor {
     fn visit_enum_field(state: &mut ExtractionState, node: TsNode<'_>) {
         // enumField -> ident, intLit
         let name = Self::find_child_by_kind(node, "ident")
-            .map(|n| state.node_text(n))
-            .unwrap_or_else(|| "<anonymous>".to_string());
+            .map_or_else(|| "<anonymous>".to_string(), |n| state.node_text(n));
 
         let value = Self::find_child_by_kind(node, "intLit")
-            .map(|n| state.node_text(n))
-            .unwrap_or_else(|| "?".to_string());
+            .map_or_else(|| "?".to_string(), |n| state.node_text(n));
 
         let start_line = node.start_position().row as u32;
         let end_line = node.end_position().row as u32;
@@ -500,7 +493,7 @@ impl ProtoExtractor {
         let end_column = node.end_position().column as u32;
         let qualified_name = format!("{}::{}", state.qualified_prefix(), name);
         let id = generate_node_id(&state.file_path, &NodeKind::EnumVariant, &name, start_line);
-        let signature = Some(format!("{} = {}", name, value));
+        let signature = Some(format!("{name} = {value}"));
 
         let graph_node = Node {
             id: id.clone(),
@@ -542,8 +535,7 @@ impl ProtoExtractor {
         // service -> serviceName -> ident, rpc*
         let name = Self::find_child_by_kind(node, "serviceName")
             .and_then(|sn| Self::find_child_by_kind(sn, "ident"))
-            .map(|n| state.node_text(n))
-            .unwrap_or_else(|| "<anonymous>".to_string());
+            .map_or_else(|| "<anonymous>".to_string(), |n| state.node_text(n));
 
         let docstring = Self::extract_docstring(state, node);
         let start_line = node.start_position().row as u32;
@@ -552,7 +544,7 @@ impl ProtoExtractor {
         let end_column = node.end_position().column as u32;
         let qualified_name = format!("{}::{}", state.qualified_prefix(), name);
         let id = generate_node_id(&state.file_path, &NodeKind::ProtoService, &name, start_line);
-        let signature = Some(format!("service {}", name));
+        let signature = Some(format!("service {name}"));
 
         let graph_node = Node {
             id: id.clone(),
@@ -615,8 +607,7 @@ impl ProtoExtractor {
         // rpc -> rpcName -> ident, enumMessageType (request), enumMessageType (response)
         let name = Self::find_child_by_kind(node, "rpcName")
             .and_then(|rn| Self::find_child_by_kind(rn, "ident"))
-            .map(|n| state.node_text(n))
-            .unwrap_or_else(|| "<anonymous>".to_string());
+            .map_or_else(|| "<anonymous>".to_string(), |n| state.node_text(n));
 
         let docstring = Self::extract_docstring(state, node);
         let start_line = node.start_position().row as u32;
@@ -692,17 +683,14 @@ impl ProtoExtractor {
         // oneofField -> type, fieldName -> ident, fieldNumber -> intLit
         let name = Self::find_child_by_kind(node, "fieldName")
             .and_then(|fn_node| Self::find_child_by_kind(fn_node, "ident"))
-            .map(|n| state.node_text(n))
-            .unwrap_or_else(|| "<anonymous>".to_string());
+            .map_or_else(|| "<anonymous>".to_string(), |n| state.node_text(n));
 
         let type_text = Self::find_child_by_kind(node, "type")
-            .map(|n| state.node_text(n))
-            .unwrap_or_else(|| "unknown".to_string());
+            .map_or_else(|| "unknown".to_string(), |n| state.node_text(n));
 
         let field_number = Self::find_child_by_kind(node, "fieldNumber")
             .and_then(|fn_node| Self::find_child_by_kind(fn_node, "intLit"))
-            .map(|n| state.node_text(n))
-            .unwrap_or_else(|| "?".to_string());
+            .map_or_else(|| "?".to_string(), |n| state.node_text(n));
 
         let start_line = node.start_position().row as u32;
         let end_line = node.end_position().row as u32;
@@ -710,7 +698,7 @@ impl ProtoExtractor {
         let end_column = node.end_position().column as u32;
         let qualified_name = format!("{}::{}", state.qualified_prefix(), name);
         let id = generate_node_id(&state.file_path, &NodeKind::Field, &name, start_line);
-        let signature = Some(format!("{} {} = {}", type_text, name, field_number));
+        let signature = Some(format!("{type_text} {name} = {field_number}"));
 
         let graph_node = Node {
             id: id.clone(),
@@ -792,7 +780,7 @@ impl ProtoExtractor {
         None
     }
 
-    /// Build the final ExtractionResult from the accumulated state.
+    /// Build the final `ExtractionResult` from the accumulated state.
     fn build_result(state: ExtractionState, start: Instant) -> ExtractionResult {
         ExtractionResult {
             nodes: state.nodes,
@@ -809,7 +797,7 @@ impl crate::extraction::LanguageExtractor for ProtoExtractor {
         &["proto"]
     }
 
-    fn language_name(&self) -> &str {
+    fn language_name(&self) -> &'static str {
         "Protobuf"
     }
 

--- a/src/extraction/python_extractor.rs
+++ b/src/extraction/python_extractor.rs
@@ -19,7 +19,7 @@ struct ExtractionState {
     edges: Vec<Edge>,
     unresolved_refs: Vec<UnresolvedRef>,
     errors: Vec<String>,
-    /// Stack of (name, node_id) for building qualified names and parent edges.
+    /// Stack of (name, `node_id`) for building qualified names and parent edges.
     node_stack: Vec<(String, String)>,
     file_path: String,
     source: Vec<u8>,
@@ -179,11 +179,10 @@ impl PythonExtractor {
         }
     }
 
-    /// Extract a function definition. If inside a class (class_depth > 0), it becomes a Method.
+    /// Extract a function definition. If inside a class (`class_depth` > 0), it becomes a Method.
     fn visit_function(state: &mut ExtractionState, node: TsNode<'_>, is_async: bool) {
         let name = Self::find_child_by_kind(node, "identifier")
-            .map(|n| state.node_text(n))
-            .unwrap_or_else(|| "<anonymous>".to_string());
+            .map_or_else(|| "<anonymous>".to_string(), |n| state.node_text(n));
 
         let in_class = state.class_depth > 0;
         let kind = if in_class {
@@ -192,7 +191,7 @@ impl PythonExtractor {
             NodeKind::Function
         };
         let visibility = Self::python_visibility(&name);
-        let signature = Self::extract_function_signature(state, node);
+        let signature = Some(Self::extract_function_signature(state, node));
         let docstring = Self::extract_docstring(state, node);
         let start_line = node.start_position().row as u32;
         let end_line = node.end_position().row as u32;
@@ -246,12 +245,11 @@ impl PythonExtractor {
     /// Extract a class definition.
     fn visit_class(state: &mut ExtractionState, node: TsNode<'_>) {
         let name = Self::find_child_by_kind(node, "identifier")
-            .map(|n| state.node_text(n))
-            .unwrap_or_else(|| "<anonymous>".to_string());
+            .map_or_else(|| "<anonymous>".to_string(), |n| state.node_text(n));
 
         let visibility = Self::python_visibility(&name);
         let docstring = Self::extract_docstring(state, node);
-        let signature = Self::extract_class_signature(state, node);
+        let signature = Some(Self::extract_class_signature(state, node));
         let start_line = node.start_position().row as u32;
         let end_line = node.end_position().row as u32;
         let start_column = node.start_position().column as u32;
@@ -320,8 +318,7 @@ impl PythonExtractor {
         // create Annotates edges from decorators to it.
         let inner_kind_and_name = if let Some(inner) = inner_def {
             let name = Self::find_child_by_kind(inner, "identifier")
-                .map(|n| state.node_text(n))
-                .unwrap_or_else(|| "<anonymous>".to_string());
+                .map_or_else(|| "<anonymous>".to_string(), |n| state.node_text(n));
             let kind = match inner.kind() {
                 "class_definition" => NodeKind::Class,
                 _ => {
@@ -420,8 +417,7 @@ impl PythonExtractor {
                     let import_name = if child.kind() == "aliased_import" {
                         // aliased_import has a dotted_name child
                         Self::find_child_by_kind(child, "dotted_name")
-                            .map(|n| state.node_text(n))
-                            .unwrap_or_else(|| state.node_text(child))
+                            .map_or_else(|| state.node_text(child), |n| state.node_text(n))
                     } else {
                         state.node_text(child)
                     };
@@ -448,7 +444,7 @@ impl PythonExtractor {
 
         // Check for wildcard import: from X import *
         if Self::find_child_by_kind(node, "wildcard_import").is_some() {
-            let full_name = format!("{}.*", module_name);
+            let full_name = format!("{module_name}.*");
             Self::create_use_node(state, &full_name, node);
             return;
         }
@@ -458,27 +454,17 @@ impl PythonExtractor {
         if cursor.goto_first_child() {
             loop {
                 let child = cursor.node();
-                match child.kind() {
-                    "dotted_name" => {
-                        // Skip the module name (first dotted_name) — only process
-                        // dotted_names that appear after "import" keyword.
-                        // We use position: module dotted_name is before "import",
-                        // imported names are after.
-                    }
-                    "aliased_import" => {
-                        // aliased_import has a dotted_name child for the original name
-                        let import_name = Self::find_child_by_kind(child, "dotted_name")
-                            .map(|n| state.node_text(n))
-                            .unwrap_or_else(|| state.node_text(child));
-                        let full_name = if module_name.is_empty() {
-                            import_name
-                        } else {
-                            format!("{}.{}", module_name, import_name)
-                        };
-                        Self::create_use_node(state, &full_name, node);
-                        found_names = true;
-                    }
-                    _ => {}
+                if child.kind() == "aliased_import" {
+                    // aliased_import has a dotted_name child for the original name
+                    let import_name = Self::find_child_by_kind(child, "dotted_name")
+                        .map_or_else(|| state.node_text(child), |n| state.node_text(n));
+                    let full_name = if module_name.is_empty() {
+                        import_name
+                    } else {
+                        format!("{module_name}.{import_name}")
+                    };
+                    Self::create_use_node(state, &full_name, node);
+                    found_names = true;
                 }
                 if !cursor.goto_next_sibling() {
                     break;
@@ -512,18 +498,17 @@ impl PythonExtractor {
                             let full_name = if module_name.is_empty() {
                                 import_name
                             } else {
-                                format!("{}.{}", module_name, import_name)
+                                format!("{module_name}.{import_name}")
                             };
                             Self::create_use_node(state, &full_name, node);
                         }
                         "aliased_import" => {
                             let import_name = Self::find_child_by_kind(child, "dotted_name")
-                                .map(|n| state.node_text(n))
-                                .unwrap_or_else(|| state.node_text(child));
+                                .map_or_else(|| state.node_text(child), |n| state.node_text(n));
                             let full_name = if module_name.is_empty() {
                                 import_name
                             } else {
-                                format!("{}.{}", module_name, import_name)
+                                format!("{module_name}.{import_name}")
                             };
                             Self::create_use_node(state, &full_name, node);
                         }
@@ -592,7 +577,7 @@ impl PythonExtractor {
         });
     }
 
-    /// Visit an assignment at module level and check if it's a constant (UPPER_CASE).
+    /// Visit an assignment at module level and check if it's a constant (`UPPER_CASE`).
     fn visit_assignment(state: &mut ExtractionState, node: TsNode<'_>) {
         // Get the left side of the assignment.
         let left = node.child_by_field_name("left");
@@ -649,7 +634,7 @@ impl PythonExtractor {
     // Helper extraction methods
     // ----------------------------
 
-    /// Extract base classes from a class definition's argument_list.
+    /// Extract base classes from a class definition's `argument_list`.
     fn extract_base_classes(state: &mut ExtractionState, node: TsNode<'_>, class_id: &str) {
         if let Some(arg_list) = Self::find_child_by_kind(node, "argument_list") {
             let mut cursor = arg_list.walk();
@@ -695,7 +680,7 @@ impl PythonExtractor {
     }
 
     /// Extract the function signature (def name(params) or async def name(params)).
-    fn extract_function_signature(state: &ExtractionState, node: TsNode<'_>) -> Option<String> {
+    fn extract_function_signature(state: &ExtractionState, node: TsNode<'_>) -> String {
         // Use the block child's start byte to find where the body begins,
         // so we don't truncate at `:` inside type annotations.
         if let Some(block) = Self::find_child_by_kind(node, "block") {
@@ -703,26 +688,26 @@ impl PythonExtractor {
             let block_offset = block.start_byte() - node.start_byte();
             let before_block = &text[..block_offset];
             // Strip the trailing `:` and whitespace before the block.
-            Some(before_block.trim().trim_end_matches(':').trim().to_string())
+            before_block.trim().trim_end_matches(':').trim().to_string()
         } else {
-            Some(state.node_text(node).trim().to_string())
+            state.node_text(node).trim().to_string()
         }
     }
 
     /// Extract the class signature (class Name or class Name(Base)).
-    fn extract_class_signature(state: &ExtractionState, node: TsNode<'_>) -> Option<String> {
+    fn extract_class_signature(state: &ExtractionState, node: TsNode<'_>) -> String {
         if let Some(block) = Self::find_child_by_kind(node, "block") {
             let text = state.node_text(node);
             let block_offset = block.start_byte() - node.start_byte();
             let before_block = &text[..block_offset];
-            Some(before_block.trim().trim_end_matches(':').trim().to_string())
+            before_block.trim().trim_end_matches(':').trim().to_string()
         } else {
-            Some(state.node_text(node).trim().to_string())
+            state.node_text(node).trim().to_string()
         }
     }
 
     /// Extract docstrings from the first statement in a function/class body.
-    /// Python convention: first expression_statement containing a string literal.
+    /// Python convention: first `expression_statement` containing a string literal.
     fn extract_docstring(state: &ExtractionState, node: TsNode<'_>) -> Option<String> {
         let body = Self::find_child_by_kind(node, "block")?;
         let mut cursor = body.walk();
@@ -770,7 +755,7 @@ impl PythonExtractor {
         trimmed.to_string()
     }
 
-    /// Check if a function_definition (possibly inside decorated_definition) has async keyword.
+    /// Check if a `function_definition` (possibly inside `decorated_definition`) has async keyword.
     fn has_async_keyword(node: TsNode<'_>) -> bool {
         let mut cursor = node.walk();
         if cursor.goto_first_child() {
@@ -816,8 +801,7 @@ impl PythonExtractor {
                         Self::extract_call_sites(state, child, fn_node_id);
                     }
                     // Skip nested function definitions to avoid polluting call sites.
-                    "function_definition" => {}
-                    "class_definition" => {}
+                    "function_definition" | "class_definition" => {}
                     _ => {
                         Self::extract_call_sites(state, child, fn_node_id);
                     }
@@ -844,7 +828,7 @@ impl PythonExtractor {
         }
     }
 
-    /// Check if a name is UPPER_SNAKE_CASE (module-level constant convention).
+    /// Check if a name is `UPPER_SNAKE_CASE` (module-level constant convention).
     fn is_upper_snake_case(name: &str) -> bool {
         if name.is_empty() {
             return false;
@@ -877,7 +861,7 @@ impl PythonExtractor {
         None
     }
 
-    /// Build the final ExtractionResult from the accumulated state.
+    /// Build the final `ExtractionResult` from the accumulated state.
     fn build_result(state: ExtractionState, start: Instant) -> ExtractionResult {
         ExtractionResult {
             nodes: state.nodes,
@@ -894,7 +878,7 @@ impl crate::extraction::LanguageExtractor for PythonExtractor {
         &["py"]
     }
 
-    fn language_name(&self) -> &str {
+    fn language_name(&self) -> &'static str {
         "Python"
     }
 

--- a/src/extraction/qbasic_extractor.rs
+++ b/src/extraction/qbasic_extractor.rs
@@ -1,7 +1,7 @@
-/// Tree-sitter based QBasic source code extractor.
+/// Tree-sitter based `QBasic` source code extractor.
 ///
-/// Parses QBasic source files and emits nodes and edges for the code graph.
-/// QBasic has proper structured programming constructs: SUB/END SUB,
+/// Parses `QBasic` source files and emits nodes and edges for the code graph.
+/// `QBasic` has proper structured programming constructs: SUB/END SUB,
 /// FUNCTION/END FUNCTION, TYPE/END TYPE, SELECT CASE, DO/LOOP. This
 /// extractor maps SUB and FUNCTION definitions to Function nodes, TYPE
 /// definitions to Struct nodes with Field children, CONST statements to
@@ -11,12 +11,12 @@ use std::time::{Instant, SystemTime, UNIX_EPOCH};
 
 use tree_sitter::{Node as TsNode, Parser, Tree};
 
-use crate::extraction::complexity::{count_complexity, QBASIC_COMPLEXITY};
+use crate::extraction::complexity::{count_complexity, ComplexityMetrics, QBASIC_COMPLEXITY};
 use crate::types::{
     generate_node_id, Edge, EdgeKind, ExtractionResult, Node, NodeKind, UnresolvedRef, Visibility,
 };
 
-/// Extracts code graph nodes and edges from QBasic source files using tree-sitter.
+/// Extracts code graph nodes and edges from `QBasic` source files using tree-sitter.
 pub struct QBasicExtractor;
 
 /// Internal state used during AST traversal.
@@ -25,7 +25,7 @@ struct ExtractionState {
     edges: Vec<Edge>,
     unresolved_refs: Vec<UnresolvedRef>,
     errors: Vec<String>,
-    /// Stack of (name, node_id) for building qualified names and parent edges.
+    /// Stack of (name, `node_id`) for building qualified names and parent edges.
     node_stack: Vec<(String, String)>,
     file_path: String,
     source: Vec<u8>,
@@ -73,10 +73,10 @@ impl ExtractionState {
 }
 
 impl QBasicExtractor {
-    /// Extract code graph nodes and edges from a QBasic source file.
+    /// Extract code graph nodes and edges from a `QBasic` source file.
     ///
     /// `file_path` is used for qualified names and node IDs (not for I/O).
-    /// `source` is the QBasic source code to parse.
+    /// `source` is the `QBasic` source code to parse.
     pub fn extract_qbasic(file_path: &str, source: &str) -> ExtractionResult {
         let start = Instant::now();
         let mut state = ExtractionState::new(file_path, source);
@@ -134,20 +134,24 @@ impl QBasicExtractor {
                             // Accumulate comments as potential docstrings.
                             pending_comment = Some(comment);
                         } else {
-                            Self::visit_line(&mut state, node, &pending_comment);
+                            Self::visit_line(&mut state, node, pending_comment.as_deref());
                             pending_comment = None;
                         }
                     }
                     "type_definition" => {
-                        Self::visit_type_definition(&mut state, node, &pending_comment);
+                        Self::visit_type_definition(&mut state, node, pending_comment.as_deref());
                         pending_comment = None;
                     }
                     "sub_definition" => {
-                        Self::visit_sub_definition(&mut state, node, &pending_comment);
+                        Self::visit_sub_definition(&mut state, node, pending_comment.as_deref());
                         pending_comment = None;
                     }
                     "function_definition" => {
-                        Self::visit_function_definition(&mut state, node, &pending_comment);
+                        Self::visit_function_definition(
+                            &mut state,
+                            node,
+                            pending_comment.as_deref(),
+                        );
                         pending_comment = None;
                     }
                     _ => {
@@ -189,14 +193,12 @@ impl QBasicExtractor {
     }
 
     /// Visit a top-level `line` node, extracting CONST, DIM SHARED, CALL, etc.
-    fn visit_line(state: &mut ExtractionState, line: TsNode<'_>, pending_comment: &Option<String>) {
-        let stmt_list = match Self::find_child_by_kind(line, "statement_list") {
-            Some(sl) => sl,
-            None => return,
+    fn visit_line(state: &mut ExtractionState, line: TsNode<'_>, pending_comment: Option<&str>) {
+        let Some(stmt_list) = Self::find_child_by_kind(line, "statement_list") else {
+            return;
         };
-        let stmt = match Self::find_child_by_kind(stmt_list, "statement") {
-            Some(s) => s,
-            None => return,
+        let Some(stmt) = Self::find_child_by_kind(stmt_list, "statement") else {
+            return;
         };
 
         // Get the first named child to determine the statement kind.
@@ -217,12 +219,6 @@ impl QBasicExtractor {
             "call_statement" => {
                 Self::extract_call_from_call_statement(state, child);
             }
-            "declare_statement" => {
-                // Skip forward declarations.
-            }
-            "let_statement" => {
-                // Top-level assignments — extract calls from within if any.
-            }
             _ => {}
         }
     }
@@ -232,13 +228,13 @@ impl QBasicExtractor {
         state: &mut ExtractionState,
         line: TsNode<'_>,
         const_stmt: TsNode<'_>,
-        pending_comment: &Option<String>,
+        pending_comment: Option<&str>,
     ) {
         // Find the identifier child of const_statement.
-        let name = match Self::find_child_by_kind(const_stmt, "identifier") {
-            Some(id_node) => state.node_text(id_node),
-            None => return,
+        let Some(id_node) = Self::find_child_by_kind(const_stmt, "identifier") else {
+            return;
         };
+        let name = state.node_text(id_node);
 
         let start_line = line.start_position().row as u32;
         let end_line = line.end_position().row as u32;
@@ -259,7 +255,7 @@ impl QBasicExtractor {
             start_column,
             end_column,
             signature: Some(text.trim().to_string()),
-            docstring: pending_comment.clone(),
+            docstring: pending_comment.map(std::string::ToString::to_string),
             visibility: Visibility::Pub,
             is_async: false,
             branches: 0,
@@ -288,7 +284,7 @@ impl QBasicExtractor {
         state: &mut ExtractionState,
         line: TsNode<'_>,
         dim_stmt: TsNode<'_>,
-        pending_comment: &Option<String>,
+        pending_comment: Option<&str>,
     ) {
         // Check if this is DIM SHARED by looking at the text.
         let text = state.node_text(line);
@@ -297,14 +293,13 @@ impl QBasicExtractor {
         }
 
         // Find the dim_variable child, then get its identifier.
-        let dim_var = match Self::find_child_by_kind(dim_stmt, "dim_variable") {
-            Some(dv) => dv,
-            None => return,
+        let Some(dim_var) = Self::find_child_by_kind(dim_stmt, "dim_variable") else {
+            return;
         };
-        let name = match Self::find_child_by_kind(dim_var, "identifier") {
-            Some(id_node) => state.node_text(id_node),
-            None => return,
+        let Some(id_node) = Self::find_child_by_kind(dim_var, "identifier") else {
+            return;
         };
+        let name = state.node_text(id_node);
 
         let start_line = line.start_position().row as u32;
         let end_line = line.end_position().row as u32;
@@ -324,7 +319,7 @@ impl QBasicExtractor {
             start_column,
             end_column,
             signature: Some(text.trim().to_string()),
-            docstring: pending_comment.clone(),
+            docstring: pending_comment.map(std::string::ToString::to_string),
             visibility: Visibility::Pub,
             is_async: false,
             branches: 0,
@@ -352,12 +347,11 @@ impl QBasicExtractor {
     fn visit_type_definition(
         state: &mut ExtractionState,
         node: TsNode<'_>,
-        pending_comment: &Option<String>,
+        pending_comment: Option<&str>,
     ) {
         // type_definition has name: (identifier) and type_member children.
-        let name_node = match node.child_by_field_name("name") {
-            Some(n) => n,
-            None => return,
+        let Some(name_node) = node.child_by_field_name("name") else {
+            return;
         };
         let name = state.node_text(name_node);
 
@@ -381,7 +375,7 @@ impl QBasicExtractor {
             start_column,
             end_column,
             signature: Some(signature),
-            docstring: pending_comment.clone(),
+            docstring: pending_comment.map(std::string::ToString::to_string),
             visibility: Visibility::Pub,
             is_async: false,
             branches: 0,
@@ -422,7 +416,7 @@ impl QBasicExtractor {
         state.node_stack.pop();
     }
 
-    /// Visit a type_member inside a TYPE block and emit a Field node.
+    /// Visit a `type_member` inside a TYPE block and emit a Field node.
     fn visit_type_member(state: &mut ExtractionState, member: TsNode<'_>) {
         let name = match Self::find_child_by_kind(member, "identifier") {
             Some(id_node) => state.node_text(id_node),
@@ -476,11 +470,10 @@ impl QBasicExtractor {
     fn visit_sub_definition(
         state: &mut ExtractionState,
         node: TsNode<'_>,
-        pending_comment: &Option<String>,
+        pending_comment: Option<&str>,
     ) {
-        let name_node = match node.child_by_field_name("name") {
-            Some(n) => n,
-            None => return,
+        let Some(name_node) = node.child_by_field_name("name") else {
+            return;
         };
         let name = state.node_text(name_node);
 
@@ -499,7 +492,7 @@ impl QBasicExtractor {
         let metrics = if node.child_count() > 0 {
             count_complexity(node, &QBASIC_COMPLEXITY, &state.source)
         } else {
-            Default::default()
+            ComplexityMetrics::default()
         };
 
         let graph_node = Node {
@@ -513,7 +506,7 @@ impl QBasicExtractor {
             start_column,
             end_column,
             signature: Some(signature),
-            docstring: pending_comment.clone(),
+            docstring: pending_comment.map(std::string::ToString::to_string),
             visibility: Visibility::Pub,
             is_async: false,
             branches: metrics.branches,
@@ -546,11 +539,10 @@ impl QBasicExtractor {
     fn visit_function_definition(
         state: &mut ExtractionState,
         node: TsNode<'_>,
-        pending_comment: &Option<String>,
+        pending_comment: Option<&str>,
     ) {
-        let name_node = match node.child_by_field_name("name") {
-            Some(n) => n,
-            None => return,
+        let Some(name_node) = node.child_by_field_name("name") else {
+            return;
         };
         let name = state.node_text(name_node);
 
@@ -567,7 +559,7 @@ impl QBasicExtractor {
         let metrics = if node.child_count() > 0 {
             count_complexity(node, &QBASIC_COMPLEXITY, &state.source)
         } else {
-            Default::default()
+            ComplexityMetrics::default()
         };
 
         let graph_node = Node {
@@ -581,7 +573,7 @@ impl QBasicExtractor {
             start_column,
             end_column,
             signature: Some(signature),
-            docstring: pending_comment.clone(),
+            docstring: pending_comment.map(std::string::ToString::to_string),
             visibility: Visibility::Pub,
             is_async: false,
             branches: metrics.branches,
@@ -610,7 +602,7 @@ impl QBasicExtractor {
         state.node_stack.pop();
     }
 
-    /// Extract a call reference from a call_statement node.
+    /// Extract a call reference from a `call_statement` node.
     fn extract_call_from_call_statement(state: &mut ExtractionState, call_stmt: TsNode<'_>) {
         let target_name = match Self::find_child_by_kind(call_stmt, "identifier") {
             Some(id_node) => state.node_text(id_node),
@@ -633,7 +625,7 @@ impl QBasicExtractor {
         });
     }
 
-    /// Recursively walk AST nodes looking for call_statement and function_call nodes.
+    /// Recursively walk AST nodes looking for `call_statement` and `function_call` nodes.
     fn walk_for_calls(state: &mut ExtractionState, node: TsNode<'_>) {
         let kind = node.kind();
         if kind == "call_statement" {
@@ -673,7 +665,7 @@ impl QBasicExtractor {
         None
     }
 
-    /// Build the final ExtractionResult from the accumulated state.
+    /// Build the final `ExtractionResult` from the accumulated state.
     fn build_result(state: ExtractionState, start: Instant) -> ExtractionResult {
         ExtractionResult {
             nodes: state.nodes,
@@ -690,7 +682,7 @@ impl crate::extraction::LanguageExtractor for QBasicExtractor {
         &["qb"]
     }
 
-    fn language_name(&self) -> &str {
+    fn language_name(&self) -> &'static str {
         "QBasic"
     }
 

--- a/src/extraction/quickbasic_extractor.rs
+++ b/src/extraction/quickbasic_extractor.rs
@@ -1,14 +1,14 @@
-/// Tree-sitter based QuickBasic 4.5 source code extractor.
+/// Tree-sitter based `QuickBasic` 4.5 source code extractor.
 ///
-/// QuickBasic 4.5 is a superset of QBasic with separate compilation,
+/// `QuickBasic` 4.5 is a superset of `QBasic` with separate compilation,
 /// `$INCLUDE` metacommands, `REDIM`, and compiled `.EXE` output.
-/// The grammar is identical to QBasic (parsed by `tree-sitter-qbasic`),
+/// The grammar is identical to `QBasic` (parsed by `tree-sitter-qbasic`),
 /// so this extractor delegates to `QBasicExtractor` for all extraction
 /// and registers the QuickBasic-specific file extensions (`.bi`, `.bm`).
 use crate::extraction::qbasic_extractor::QBasicExtractor;
 use crate::types::ExtractionResult;
 
-/// Extracts code graph nodes and edges from QuickBasic 4.5 source files.
+/// Extracts code graph nodes and edges from `QuickBasic` 4.5 source files.
 ///
 /// Uses the same tree-sitter grammar and extraction logic as
 /// [`QBasicExtractor`] — the languages are syntactically identical.
@@ -19,7 +19,7 @@ impl crate::extraction::LanguageExtractor for QuickBasicExtractor {
         &["bi", "bm"]
     }
 
-    fn language_name(&self) -> &str {
+    fn language_name(&self) -> &'static str {
         "QuickBASIC"
     }
 

--- a/src/extraction/ruby_extractor.rs
+++ b/src/extraction/ruby_extractor.rs
@@ -19,7 +19,7 @@ struct ExtractionState {
     edges: Vec<Edge>,
     unresolved_refs: Vec<UnresolvedRef>,
     errors: Vec<String>,
-    /// Stack of (name, node_id) for building qualified names and parent edges.
+    /// Stack of (name, `node_id`) for building qualified names and parent edges.
     node_stack: Vec<(String, String)>,
     file_path: String,
     source: Vec<u8>,
@@ -166,11 +166,10 @@ impl RubyExtractor {
     /// Extract a regular method definition (`def method_name`).
     ///
     /// `is_singleton` controls whether this becomes a Method regardless of class depth
-    /// (singleton methods are always NodeKind::Method).
+    /// (singleton methods are always `NodeKind::Method`).
     fn visit_method(state: &mut ExtractionState, node: TsNode<'_>, is_singleton: bool) {
         let name = Self::find_child_by_kind(node, "identifier")
-            .map(|n| state.node_text(n))
-            .unwrap_or_else(|| "<anonymous>".to_string());
+            .map_or_else(|| "<anonymous>".to_string(), |n| state.node_text(n));
 
         let in_class = state.class_depth > 0 || is_singleton;
         let kind = if in_class {
@@ -290,8 +289,7 @@ impl RubyExtractor {
     fn visit_class(state: &mut ExtractionState, node: TsNode<'_>) {
         // In tree-sitter-ruby, class node children include: "class", constant (name), superclass?, body
         let name = Self::find_child_by_kind(node, "constant")
-            .map(|n| state.node_text(n))
-            .unwrap_or_else(|| "<anonymous>".to_string());
+            .map_or_else(|| "<anonymous>".to_string(), |n| state.node_text(n));
 
         let visibility = Visibility::Pub;
         let docstring = Self::extract_docstring(state, node);
@@ -354,8 +352,7 @@ impl RubyExtractor {
     /// Extract a module definition.
     fn visit_module(state: &mut ExtractionState, node: TsNode<'_>) {
         let name = Self::find_child_by_kind(node, "constant")
-            .map(|n| state.node_text(n))
-            .unwrap_or_else(|| "<anonymous>".to_string());
+            .map_or_else(|| "<anonymous>".to_string(), |n| state.node_text(n));
 
         let visibility = Visibility::Pub;
         let docstring = Self::extract_docstring(state, node);
@@ -481,7 +478,7 @@ impl RubyExtractor {
 
     /// Extract the superclass from a class definition (`class Foo < Bar`).
     ///
-    /// Creates an Extends UnresolvedRef from the class to its superclass.
+    /// Creates an Extends `UnresolvedRef` from the class to its superclass.
     fn extract_superclass(state: &mut ExtractionState, node: TsNode<'_>, class_id: &str) {
         // In tree-sitter-ruby, the superclass is a child node with field name "superclass"
         // or a "superclass" kind node. The superclass node contains the constant name.
@@ -602,7 +599,7 @@ impl RubyExtractor {
     /// Find the method name identifier in a singleton method.
     ///
     /// In `def self.foo(args)`, we want "foo" (the identifier after the dot).
-    /// tree-sitter-ruby's singleton_method has: "def", object, ".", name (identifier), parameters?, body
+    /// tree-sitter-ruby's `singleton_method` has: "def", object, ".", name (identifier), parameters?, body
     fn find_last_identifier_before_params(
         state: &ExtractionState,
         node: TsNode<'_>,
@@ -692,7 +689,7 @@ impl RubyExtractor {
         None
     }
 
-    /// Build the final ExtractionResult from the accumulated state.
+    /// Build the final `ExtractionResult` from the accumulated state.
     fn build_result(state: ExtractionState, start: Instant) -> ExtractionResult {
         ExtractionResult {
             nodes: state.nodes,
@@ -709,7 +706,7 @@ impl crate::extraction::LanguageExtractor for RubyExtractor {
         &["rb"]
     }
 
-    fn language_name(&self) -> &str {
+    fn language_name(&self) -> &'static str {
         "Ruby"
     }
 

--- a/src/extraction/rust_extractor.rs
+++ b/src/extraction/rust_extractor.rs
@@ -19,7 +19,7 @@ struct ExtractionState {
     edges: Vec<Edge>,
     unresolved_refs: Vec<UnresolvedRef>,
     errors: Vec<String>,
-    /// Stack of (name, node_id) for building qualified names and parent edges.
+    /// Stack of (name, `node_id`) for building qualified names and parent edges.
     node_stack: Vec<(String, String)>,
     file_path: String,
     source: Vec<u8>,
@@ -184,7 +184,7 @@ impl RustExtractor {
             NodeKind::Function
         };
         let visibility = Self::extract_visibility(node, state);
-        let signature = Self::extract_function_signature(state, node);
+        let signature = Some(Self::extract_function_signature(state, node));
         let docstring = Self::extract_docstring(state, node);
         let is_async = Self::detect_async(state, node);
         let start_line = node.start_position().row as u32;
@@ -241,7 +241,7 @@ impl RustExtractor {
     fn visit_struct(state: &mut ExtractionState, node: TsNode<'_>) {
         let name = Self::extract_name(state, node).unwrap_or_else(|| "<anonymous>".to_string());
         let visibility = Self::extract_visibility(node, state);
-        let signature = Self::extract_struct_signature(state, node);
+        let signature = Some(Self::extract_struct_signature(state, node));
         let docstring = Self::extract_docstring(state, node);
         let start_line = node.start_position().row as u32;
         let end_line = node.end_position().row as u32;
@@ -765,14 +765,14 @@ impl RustExtractor {
 
     /// Record a macro invocation as an unresolved call reference.
     fn visit_macro_invocation(state: &mut ExtractionState, node: TsNode<'_>) {
-        let macro_name = node
-            .child_by_field_name("macro")
-            .map(|n| state.node_text(n))
-            .unwrap_or_else(|| {
+        let macro_name = node.child_by_field_name("macro").map_or_else(
+            || {
                 // Fallback: first named child is typically the macro name.
                 let text = state.node_text(node);
                 text.split('!').next().unwrap_or("").trim().to_string()
-            });
+            },
+            |n| state.node_text(n),
+        );
         let start_line = node.start_position().row as u32;
         let start_column = node.start_position().column as u32;
 
@@ -797,12 +797,12 @@ impl RustExtractor {
         node.child_by_field_name("name").map(|n| state.node_text(n))
     }
 
-    /// Extract the type name from an impl_item (the "type" field).
+    /// Extract the type name from an `impl_item` (the "type" field).
     fn extract_impl_type_name(state: &ExtractionState, node: TsNode<'_>) -> Option<String> {
         node.child_by_field_name("type").map(|n| state.node_text(n))
     }
 
-    /// Extract the trait name from an impl_item, if it is a trait impl.
+    /// Extract the trait name from an `impl_item`, if it is a trait impl.
     ///
     /// For `impl Trait for Type`, tree-sitter gives us a "trait" field.
     fn extract_impl_trait_name(state: &ExtractionState, node: TsNode<'_>) -> Option<String> {
@@ -834,25 +834,25 @@ impl RustExtractor {
     }
 
     /// Extract the function signature (everything from `fn` up to the body `{`).
-    fn extract_function_signature(state: &ExtractionState, node: TsNode<'_>) -> Option<String> {
+    fn extract_function_signature(state: &ExtractionState, node: TsNode<'_>) -> String {
         let text = state.node_text(node);
         // Find the opening brace and take everything before it.
         if let Some(brace_pos) = text.find('{') {
-            Some(text[..brace_pos].trim().to_string())
+            text[..brace_pos].trim().to_string()
         } else {
             // For trait method declarations without a body (ending with `;`).
-            Some(text.trim_end_matches(';').trim().to_string())
+            text.trim_end_matches(';').trim().to_string()
         }
     }
 
     /// Extract the struct signature (the header line).
-    fn extract_struct_signature(state: &ExtractionState, node: TsNode<'_>) -> Option<String> {
+    fn extract_struct_signature(state: &ExtractionState, node: TsNode<'_>) -> String {
         let text = state.node_text(node);
         // Take the first line, or up to the opening brace.
         if let Some(brace_pos) = text.find('{') {
-            Some(text[..brace_pos].trim().to_string())
+            text[..brace_pos].trim().to_string()
         } else {
-            Some(text.lines().next().unwrap_or("").trim().to_string())
+            text.lines().next().unwrap_or("").trim().to_string()
         }
     }
 
@@ -928,7 +928,7 @@ impl RustExtractor {
             || trimmed.starts_with("pub(super) async ")
     }
 
-    /// Extract fields from a struct's field_declaration_list.
+    /// Extract fields from a struct's `field_declaration_list`.
     fn extract_fields(state: &mut ExtractionState, struct_node: TsNode<'_>) {
         if let Some(body) = struct_node.child_by_field_name("body") {
             let mut cursor = body.walk();
@@ -946,7 +946,7 @@ impl RustExtractor {
         }
     }
 
-    /// Extract a single field_declaration node.
+    /// Extract a single `field_declaration` node.
     fn extract_single_field(state: &mut ExtractionState, node: TsNode<'_>) {
         let name = Self::extract_name(state, node).unwrap_or_else(|| "<anonymous>".to_string());
         let visibility = Self::extract_visibility(node, state);
@@ -1059,7 +1059,7 @@ impl RustExtractor {
         }
     }
 
-    /// Recursively find call_expression nodes inside a given node and create
+    /// Recursively find `call_expression` nodes inside a given node and create
     /// unresolved Calls references.
     fn extract_call_sites(state: &mut ExtractionState, node: TsNode<'_>, fn_node_id: &str) {
         let mut cursor = node.walk();
@@ -1083,13 +1083,13 @@ impl RustExtractor {
                         Self::extract_call_sites(state, child, fn_node_id);
                     }
                     "macro_invocation" => {
-                        let macro_name = child
-                            .child_by_field_name("macro")
-                            .map(|n| state.node_text(n))
-                            .unwrap_or_else(|| {
+                        let macro_name = child.child_by_field_name("macro").map_or_else(
+                            || {
                                 let text = state.node_text(child);
                                 text.split('!').next().unwrap_or("").trim().to_string()
-                            });
+                            },
+                            |n| state.node_text(n),
+                        );
                         state.unresolved_refs.push(UnresolvedRef {
                             from_node_id: fn_node_id.to_string(),
                             reference_name: macro_name,
@@ -1131,7 +1131,7 @@ impl RustExtractor {
         }
     }
 
-    /// Parse a derive attribute list and emit DerivesMacro edges.
+    /// Parse a derive attribute list and emit `DerivesMacro` edges.
     fn parse_derive_list(
         state: &mut ExtractionState,
         attr_text: &str,
@@ -1154,7 +1154,7 @@ impl RustExtractor {
                             reference_kind: EdgeKind::DerivesMacro,
                             line,
                             column: attr_node.start_position().column as u32,
-                            file_path: state.file_path.to_string(),
+                            file_path: state.file_path.clone(),
                         });
                     }
                 }
@@ -1250,7 +1250,7 @@ impl RustExtractor {
         });
     }
 
-    /// Extract the name from a Rust attribute_item node.
+    /// Extract the name from a Rust `attribute_item` node.
     ///
     /// Trims `#[` and `]`, then takes everything before `(` as the name.
     /// E.g. `#[cfg(test)]` -> `cfg`, `#[inline]` -> `inline`.
@@ -1265,7 +1265,7 @@ impl RustExtractor {
         inner.split('(').next().unwrap_or(inner).trim().to_string()
     }
 
-    /// Build the final ExtractionResult from the accumulated state.
+    /// Build the final `ExtractionResult` from the accumulated state.
     fn build_result(state: ExtractionState, start: Instant) -> ExtractionResult {
         ExtractionResult {
             nodes: state.nodes,
@@ -1282,7 +1282,7 @@ impl crate::extraction::LanguageExtractor for RustExtractor {
         &["rs"]
     }
 
-    fn language_name(&self) -> &str {
+    fn language_name(&self) -> &'static str {
         "Rust"
     }
 

--- a/src/extraction/scala_extractor.rs
+++ b/src/extraction/scala_extractor.rs
@@ -22,7 +22,7 @@ struct ExtractionState {
     edges: Vec<Edge>,
     unresolved_refs: Vec<UnresolvedRef>,
     errors: Vec<String>,
-    /// Stack of (name, node_id) for building qualified names and parent edges.
+    /// Stack of (name, `node_id`) for building qualified names and parent edges.
     node_stack: Vec<(String, String)>,
     file_path: String,
     source: Vec<u8>,
@@ -184,8 +184,7 @@ impl ScalaExtractor {
     fn visit_package(state: &mut ExtractionState, node: TsNode<'_>) {
         let name = node
             .child_by_field_name("name")
-            .map(|n| state.node_text(n))
-            .unwrap_or_else(|| "<unknown>".to_string());
+            .map_or_else(|| "<unknown>".to_string(), |n| state.node_text(n));
 
         let start_line = node.start_position().row as u32;
         let end_line = node.end_position().row as u32;
@@ -316,7 +315,7 @@ impl ScalaExtractor {
         let is_case = Self::has_modifier_keyword(node, state, "case");
         let visibility = Self::extract_visibility(node, state);
         let docstring = Self::extract_scaladoc(state, node);
-        let signature = Self::extract_declaration_signature(state, node);
+        let signature = Some(Self::extract_declaration_signature(state, node));
         let start_line = node.start_position().row as u32;
         let end_line = node.end_position().row as u32;
         let start_column = node.start_position().column as u32;
@@ -390,7 +389,7 @@ impl ScalaExtractor {
         let name = Self::extract_name(state, node).unwrap_or_else(|| "<anonymous>".to_string());
         let visibility = Self::extract_visibility(node, state);
         let docstring = Self::extract_scaladoc(state, node);
-        let signature = Self::extract_declaration_signature(state, node);
+        let signature = Some(Self::extract_declaration_signature(state, node));
         let start_line = node.start_position().row as u32;
         let end_line = node.end_position().row as u32;
         let start_column = node.start_position().column as u32;
@@ -457,7 +456,7 @@ impl ScalaExtractor {
         let name = Self::extract_name(state, node).unwrap_or_else(|| "<anonymous>".to_string());
         let visibility = Self::extract_visibility(node, state);
         let docstring = Self::extract_scaladoc(state, node);
-        let signature = Self::extract_declaration_signature(state, node);
+        let signature = Some(Self::extract_declaration_signature(state, node));
         let start_line = node.start_position().row as u32;
         let end_line = node.end_position().row as u32;
         let start_column = node.start_position().column as u32;
@@ -520,7 +519,7 @@ impl ScalaExtractor {
         let name = Self::extract_name(state, node).unwrap_or_else(|| "<anonymous>".to_string());
         let visibility = Self::extract_visibility(node, state);
         let docstring = Self::extract_scaladoc(state, node);
-        let signature = Self::extract_declaration_signature(state, node);
+        let signature = Some(Self::extract_declaration_signature(state, node));
         let start_line = node.start_position().row as u32;
         let end_line = node.end_position().row as u32;
         let start_column = node.start_position().column as u32;
@@ -604,8 +603,10 @@ impl ScalaExtractor {
         let name = node
             .child_by_field_name("name")
             .or_else(|| Self::find_child_by_kind(node, "identifier"))
-            .map(|n| state.node_text(n))
-            .unwrap_or_else(|| state.node_text(node).trim().to_string());
+            .map_or_else(
+                || state.node_text(node).trim().to_string(),
+                |n| state.node_text(n),
+            );
 
         let start_line = node.start_position().row as u32;
         let end_line = node.end_position().row as u32;
@@ -658,7 +659,7 @@ impl ScalaExtractor {
         let name = Self::extract_name(state, node).unwrap_or_else(|| "<anonymous>".to_string());
         let visibility = Self::extract_visibility(node, state);
         let docstring = Self::extract_scaladoc(state, node);
-        let signature = Self::extract_declaration_signature(state, node);
+        let signature = Some(Self::extract_declaration_signature(state, node));
         let start_line = node.start_position().row as u32;
         let end_line = node.end_position().row as u32;
         let start_column = node.start_position().column as u32;
@@ -721,7 +722,7 @@ impl ScalaExtractor {
         let name = Self::extract_name(state, node).unwrap_or_else(|| "<anonymous>".to_string());
         let visibility = Self::extract_visibility(node, state);
         let docstring = Self::extract_scaladoc(state, node);
-        let signature = Self::extract_declaration_signature(state, node);
+        let signature = Some(Self::extract_declaration_signature(state, node));
         let start_line = node.start_position().row as u32;
         let end_line = node.end_position().row as u32;
         let start_column = node.start_position().column as u32;
@@ -777,7 +778,7 @@ impl ScalaExtractor {
     // Val / Var
     // -----------------------------------------------------------------------
 
-    /// Extract a val definition or declaration as a ValField node.
+    /// Extract a val definition or declaration as a `ValField` node.
     fn visit_val(state: &mut ExtractionState, node: TsNode<'_>) {
         let name = Self::extract_val_var_name(state, node);
         let visibility = Self::extract_visibility(node, state);
@@ -838,7 +839,7 @@ impl ScalaExtractor {
         }
     }
 
-    /// Extract a var definition or declaration as a VarField node.
+    /// Extract a var definition or declaration as a `VarField` node.
     fn visit_var(state: &mut ExtractionState, node: TsNode<'_>) {
         let name = Self::extract_val_var_name(state, node);
         let visibility = Self::extract_visibility(node, state);
@@ -906,8 +907,7 @@ impl ScalaExtractor {
     fn visit_type_def(state: &mut ExtractionState, node: TsNode<'_>) {
         let name = node
             .child_by_field_name("name")
-            .map(|n| state.node_text(n))
-            .unwrap_or_else(|| "<anonymous>".to_string());
+            .map_or_else(|| "<anonymous>".to_string(), |n| state.node_text(n));
         let visibility = Self::extract_visibility(node, state);
         let start_line = node.start_position().row as u32;
         let end_line = node.end_position().row as u32;
@@ -962,7 +962,7 @@ impl ScalaExtractor {
 
     /// Extract the name from a val/var definition.
     ///
-    /// val_definition uses a "pattern" field; val_declaration uses "name".
+    /// `val_definition` uses a "pattern" field; `val_declaration` uses "name".
     fn extract_val_var_name(state: &ExtractionState, node: TsNode<'_>) -> String {
         if let Some(name_node) = node.child_by_field_name("name") {
             return state.node_text(name_node);
@@ -976,7 +976,7 @@ impl ScalaExtractor {
         "<anonymous>".to_string()
     }
 
-    /// Extract Scala visibility from access_modifier or modifiers children.
+    /// Extract Scala visibility from `access_modifier` or modifiers children.
     fn extract_visibility(node: TsNode<'_>, state: &ExtractionState) -> Visibility {
         let mut cursor = node.walk();
         if cursor.goto_first_child() {
@@ -1047,21 +1047,21 @@ impl ScalaExtractor {
     }
 
     /// Extract the declaration signature (everything before the body).
-    fn extract_declaration_signature(state: &ExtractionState, node: TsNode<'_>) -> Option<String> {
+    fn extract_declaration_signature(state: &ExtractionState, node: TsNode<'_>) -> String {
         let text = state.node_text(node);
         // Cut at first '{' for brace-delimited bodies.
         if let Some(brace_pos) = text.find('{') {
-            return Some(text[..brace_pos].trim().to_string());
+            return text[..brace_pos].trim().to_string();
         }
         // Cut at first '=' for expression-bodied definitions (but not inside type bounds).
         // Only if there's a body field (function_definition, val_definition).
         if node.child_by_field_name("body").is_some() || node.child_by_field_name("value").is_some()
         {
             if let Some(eq_pos) = text.find('=') {
-                return Some(text[..eq_pos].trim().to_string());
+                return text[..eq_pos].trim().to_string();
             }
         }
-        Some(text.lines().next().unwrap_or("").trim().to_string())
+        text.lines().next().unwrap_or("").trim().to_string()
     }
 
     /// Extract Scaladoc comments (/** ... */) preceding a declaration.
@@ -1142,7 +1142,7 @@ impl ScalaExtractor {
         }
     }
 
-    /// Extract type parameters and create GenericParam nodes.
+    /// Extract type parameters and create `GenericParam` nodes.
     fn extract_type_parameters(state: &mut ExtractionState, node: TsNode<'_>, owner_id: &str) {
         let tp_node = node
             .child_by_field_name("type_parameters")
@@ -1155,8 +1155,7 @@ impl ScalaExtractor {
                     if child.is_named() && child.kind().contains("type_parameter") {
                         let param_name = Self::find_child_by_kind(child, "identifier")
                             .or_else(|| Self::find_child_by_kind(child, "type_identifier"))
-                            .map(|n| state.node_text(n))
-                            .unwrap_or_else(|| state.node_text(child));
+                            .map_or_else(|| state.node_text(child), |n| state.node_text(n));
                         let start_line = child.start_position().row as u32;
                         let id = generate_node_id(
                             &state.file_path,
@@ -1220,8 +1219,7 @@ impl ScalaExtractor {
                     if child.kind() == "class_parameter" {
                         let param_name = child
                             .child_by_field_name("name")
-                            .map(|n| state.node_text(n))
-                            .unwrap_or_else(|| "<param>".to_string());
+                            .map_or_else(|| "<param>".to_string(), |n| state.node_text(n));
 
                         let text = state.node_text(child);
                         let is_val = text.contains("val ");
@@ -1278,7 +1276,7 @@ impl ScalaExtractor {
         }
     }
 
-    /// Recursively find call_expression nodes and create unresolved Calls references.
+    /// Recursively find `call_expression` nodes and create unresolved Calls references.
     fn extract_call_sites(state: &mut ExtractionState, node: TsNode<'_>, fn_node_id: &str) {
         let mut cursor = node.walk();
         if cursor.goto_first_child() {
@@ -1326,7 +1324,7 @@ impl ScalaExtractor {
         }
     }
 
-    /// Extract the callee name from a call_expression.
+    /// Extract the callee name from a `call_expression`.
     fn extract_call_name(state: &ExtractionState, node: TsNode<'_>) -> String {
         // call_expression's first named child is usually the function reference.
         let mut cursor = node.walk();
@@ -1351,7 +1349,7 @@ impl ScalaExtractor {
         text.split('(').next().unwrap_or(&text).trim().to_string()
     }
 
-    /// Extract the type name from an instance_expression (new Foo(...)).
+    /// Extract the type name from an `instance_expression` (new Foo(...)).
     fn extract_instance_type(state: &ExtractionState, node: TsNode<'_>) -> String {
         let mut cursor = node.walk();
         if cursor.goto_first_child() {
@@ -1376,11 +1374,11 @@ impl ScalaExtractor {
     // Annotations
     // -----------------------------------------------------------------------
 
-    /// Extract annotations from a declaration node and create AnnotationUsage
+    /// Extract annotations from a declaration node and create `AnnotationUsage`
     /// nodes and Annotates edges.
     ///
     /// Scala annotations appear as direct `"annotation"` children of the
-    /// declaration node (class_definition, function_definition, etc.).
+    /// declaration node (`class_definition`, `function_definition`, etc.).
     fn extract_annotations(state: &mut ExtractionState, node: TsNode<'_>, target_id: &str) {
         let mut cursor = node.walk();
         if cursor.goto_first_child() {
@@ -1487,7 +1485,7 @@ impl ScalaExtractor {
         None
     }
 
-    /// Build the final ExtractionResult from the accumulated state.
+    /// Build the final `ExtractionResult` from the accumulated state.
     fn build_result(state: ExtractionState, start: Instant) -> ExtractionResult {
         ExtractionResult {
             nodes: state.nodes,
@@ -1504,7 +1502,7 @@ impl crate::extraction::LanguageExtractor for ScalaExtractor {
         &["scala", "sc"]
     }
 
-    fn language_name(&self) -> &str {
+    fn language_name(&self) -> &'static str {
         "Scala"
     }
 

--- a/src/extraction/swift_extractor.rs
+++ b/src/extraction/swift_extractor.rs
@@ -19,7 +19,7 @@ struct ExtractionState {
     edges: Vec<Edge>,
     unresolved_refs: Vec<UnresolvedRef>,
     errors: Vec<String>,
-    /// Stack of (name, node_id) for building qualified names and parent edges.
+    /// Stack of (name, `node_id`) for building qualified names and parent edges.
     node_stack: Vec<(String, String)>,
     file_path: String,
     source: Vec<u8>,
@@ -169,16 +169,17 @@ impl SwiftExtractor {
 
     /// Extract an import declaration (e.g. `import Foundation`).
     fn visit_import(state: &mut ExtractionState, node: TsNode<'_>) {
-        let name = Self::find_child_by_kind(node, "identifier")
-            .map(|n| state.node_text(n))
-            .unwrap_or_else(|| {
+        let name = Self::find_child_by_kind(node, "identifier").map_or_else(
+            || {
                 // Fallback: get everything after "import "
                 let text = state.node_text(node);
                 text.strip_prefix("import ")
                     .unwrap_or(&text)
                     .trim()
                     .to_string()
-            });
+            },
+            |n| state.node_text(n),
+        );
 
         let start_line = node.start_position().row as u32;
         let end_line = node.end_position().row as u32;
@@ -227,23 +228,22 @@ impl SwiftExtractor {
     // class_declaration (class, struct, enum, extension)
     // ----------------------------------
 
-    /// Dispatch class_declaration based on the `declaration_kind` field.
+    /// Dispatch `class_declaration` based on the `declaration_kind` field.
     ///
     /// tree-sitter-swift uses `class_declaration` for class, struct, enum, and extension.
     /// The first anonymous child carries the keyword: "class", "struct", "enum", or "extension".
     fn visit_class_declaration(state: &mut ExtractionState, node: TsNode<'_>) {
         let decl_kind = Self::declaration_kind_keyword(state, node);
         match decl_kind.as_str() {
-            "class" => Self::visit_class(state, node),
             "struct" => Self::visit_struct(state, node),
             "enum" => Self::visit_enum(state, node),
             "extension" => Self::visit_extension(state, node),
-            _ => Self::visit_class(state, node), // fallback
+            _ => Self::visit_class(state, node),
         }
     }
 
     /// Returns the declaration keyword ("class", "struct", "enum", "extension") for a
-    /// class_declaration node by reading the first child with field "declaration_kind".
+    /// `class_declaration` node by reading the first child with field "`declaration_kind`".
     fn declaration_kind_keyword(state: &ExtractionState, node: TsNode<'_>) -> String {
         // The keyword is stored as the first anonymous child with field name "declaration_kind".
         let mut cursor = node.walk();
@@ -444,7 +444,7 @@ impl SwiftExtractor {
         state.node_stack.pop();
     }
 
-    /// Visit enum body children, extracting enum entries as EnumVariant nodes.
+    /// Visit enum body children, extracting enum entries as `EnumVariant` nodes.
     fn visit_enum_body(state: &mut ExtractionState, body: TsNode<'_>) {
         let mut cursor = body.walk();
         if cursor.goto_first_child() {
@@ -464,7 +464,7 @@ impl SwiftExtractor {
         }
     }
 
-    /// Extract an enum entry as an EnumVariant node.
+    /// Extract an enum entry as an `EnumVariant` node.
     fn visit_enum_entry(state: &mut ExtractionState, node: TsNode<'_>) {
         let name = node
             .child_by_field_name("name")
@@ -527,15 +527,14 @@ impl SwiftExtractor {
     /// Extract an extension declaration.
     fn visit_extension(state: &mut ExtractionState, node: TsNode<'_>) {
         // For extension, the name is in a user_type or type_identifier child with field "name".
-        let name = node
-            .child_by_field_name("name")
-            .map(|n| {
+        let name = node.child_by_field_name("name").map_or_else(
+            || "<anonymous>".to_string(),
+            |n| {
                 // Could be a user_type wrapping a type_identifier.
                 Self::find_child_by_kind(n, "type_identifier")
-                    .map(|ti| state.node_text(ti))
-                    .unwrap_or_else(|| state.node_text(n))
-            })
-            .unwrap_or_else(|| "<anonymous>".to_string());
+                    .map_or_else(|| state.node_text(n), |ti| state.node_text(ti))
+            },
+        );
 
         let docstring = Self::extract_docstring(state, node);
         let signature = Self::extract_first_line_signature(state, node);
@@ -599,8 +598,7 @@ impl SwiftExtractor {
     fn visit_protocol(state: &mut ExtractionState, node: TsNode<'_>) {
         let name = node
             .child_by_field_name("name")
-            .map(|n| state.node_text(n))
-            .unwrap_or_else(|| "<anonymous>".to_string());
+            .map_or_else(|| "<anonymous>".to_string(), |n| state.node_text(n));
 
         let docstring = Self::extract_docstring(state, node);
         let signature = Self::extract_first_line_signature(state, node);
@@ -739,7 +737,7 @@ impl SwiftExtractor {
 
     /// Extract a function or method declaration.
     ///
-    /// If class_depth > 0, it becomes a Method; otherwise a Function.
+    /// If `class_depth` > 0, it becomes a Method; otherwise a Function.
     fn visit_function(state: &mut ExtractionState, node: TsNode<'_>) {
         let name = node
             .child_by_field_name("name")
@@ -993,29 +991,29 @@ impl SwiftExtractor {
     // Helper extraction methods
     // ----------------------------
 
-    /// Extract the type name from a class_declaration node.
+    /// Extract the type name from a `class_declaration` node.
     ///
     /// The name is in a child with field "name", which is a `type_identifier` for
     /// class/struct/enum, or a `user_type` wrapping `type_identifier` for extensions.
     fn extract_type_name(state: &ExtractionState, node: TsNode<'_>) -> String {
-        node.child_by_field_name("name")
-            .map(|n| {
+        node.child_by_field_name("name").map_or_else(
+            || "<anonymous>".to_string(),
+            |n| {
                 // For class/struct/enum, this is a type_identifier directly.
                 // For extension, it may be a user_type wrapping type_identifier.
                 if n.kind() == "user_type" {
                     Self::find_child_by_kind(n, "type_identifier")
-                        .map(|ti| state.node_text(ti))
-                        .unwrap_or_else(|| state.node_text(n))
+                        .map_or_else(|| state.node_text(n), |ti| state.node_text(ti))
                 } else {
                     state.node_text(n)
                 }
-            })
-            .unwrap_or_else(|| "<anonymous>".to_string())
+            },
+        )
     }
 
     /// Extract inheritance specifiers (e.g. `class Foo: Bar`).
     ///
-    /// Creates Extends UnresolvedRef for each inherited type.
+    /// Creates Extends `UnresolvedRef` for each inherited type.
     fn extract_inheritance(state: &mut ExtractionState, node: TsNode<'_>, class_id: &str) {
         let mut cursor = node.walk();
         if cursor.goto_first_child() {
@@ -1026,8 +1024,10 @@ impl SwiftExtractor {
                     // which is a user_type containing the parent type name.
                     if let Some(inherits_from) = child.child_by_field_name("inherits_from") {
                         let base_name = Self::find_child_by_kind(inherits_from, "type_identifier")
-                            .map(|ti| state.node_text(ti))
-                            .unwrap_or_else(|| state.node_text(inherits_from));
+                            .map_or_else(
+                                || state.node_text(inherits_from),
+                                |ti| state.node_text(ti),
+                            );
                         let line = inherits_from.start_position().row as u32;
                         let column = inherits_from.start_position().column as u32;
                         state.unresolved_refs.push(UnresolvedRef {
@@ -1047,9 +1047,9 @@ impl SwiftExtractor {
         }
     }
 
-    /// Extract the property name from a property_declaration.
+    /// Extract the property name from a `property_declaration`.
     ///
-    /// The name is in the `pattern` child (field "name") -> `simple_identifier` (field "bound_identifier").
+    /// The name is in the `pattern` child (field "name") -> `simple_identifier` (field "`bound_identifier`").
     fn extract_property_name(state: &ExtractionState, node: TsNode<'_>) -> String {
         if let Some(pattern) = node.child_by_field_name("name") {
             if let Some(ident) = pattern.child_by_field_name("bound_identifier") {
@@ -1082,11 +1082,8 @@ impl SwiftExtractor {
                     if let Some(vis_mod) = Self::find_child_by_kind(child, "visibility_modifier") {
                         let text = state.node_text(vis_mod);
                         return match text.as_str() {
-                            "private" => Visibility::Private,
-                            "fileprivate" => Visibility::Private,
+                            "private" | "fileprivate" => Visibility::Private,
                             "internal" => Visibility::PubCrate,
-                            "public" => Visibility::Pub,
-                            "open" => Visibility::Pub,
                             _ => Visibility::Pub,
                         };
                     }
@@ -1199,14 +1196,13 @@ impl SwiftExtractor {
         }
     }
 
-    /// Extract the callee name from a call_expression.
+    /// Extract the callee name from a `call_expression`.
     ///
-    /// In Swift, call_expression children are: callee (simple_identifier or navigation_expression)
-    /// followed by call_suffix with value_arguments.
+    /// In Swift, `call_expression` children are: callee (`simple_identifier` or `navigation_expression`)
+    /// followed by `call_suffix` with `value_arguments`.
     fn extract_callee_name(state: &ExtractionState, node: TsNode<'_>) -> Option<String> {
         let first_child = node.named_child(0)?;
         match first_child.kind() {
-            "simple_identifier" => Some(state.node_text(first_child)),
             "navigation_expression" => {
                 // For chained calls like `super.init(...)` or `foo.bar(...)`,
                 // get the suffix (last navigation_suffix child's simple_identifier).
@@ -1382,7 +1378,7 @@ impl SwiftExtractor {
             .to_string()
     }
 
-    /// Build the final ExtractionResult from the accumulated state.
+    /// Build the final `ExtractionResult` from the accumulated state.
     fn build_result(state: ExtractionState, start: Instant) -> ExtractionResult {
         ExtractionResult {
             nodes: state.nodes,
@@ -1399,7 +1395,7 @@ impl crate::extraction::LanguageExtractor for SwiftExtractor {
         &["swift"]
     }
 
-    fn language_name(&self) -> &str {
+    fn language_name(&self) -> &'static str {
         "Swift"
     }
 

--- a/src/extraction/typescript_extractor.rs
+++ b/src/extraction/typescript_extractor.rs
@@ -21,12 +21,12 @@ struct ExtractionState {
     edges: Vec<Edge>,
     unresolved_refs: Vec<UnresolvedRef>,
     errors: Vec<String>,
-    /// Stack of (name, node_id) for building qualified names and parent edges.
+    /// Stack of (name, `node_id`) for building qualified names and parent edges.
     node_stack: Vec<(String, String)>,
     file_path: String,
     source: Vec<u8>,
     timestamp: u64,
-    /// Whether the current declaration is inside an export_statement.
+    /// Whether the current declaration is inside an `export_statement`.
     in_export: bool,
 }
 
@@ -131,7 +131,6 @@ impl TypeScriptExtractor {
     fn parse_source(source: &str, extension: &str) -> Result<Tree, String> {
         let mut parser = Parser::new();
         let (key, label) = match extension {
-            "ts" => ("typescript", "TypeScript"),
             "tsx" => ("tsx", "TSX"),
             "js" | "jsx" => ("javascript", "JavaScript"),
             _ => ("typescript", "TypeScript"),
@@ -183,7 +182,7 @@ impl TypeScriptExtractor {
         }
     }
 
-    /// Visit an export_statement. Sets in_export flag and recurses into the
+    /// Visit an `export_statement`. Sets `in_export` flag and recurses into the
     /// inner declaration.
     fn visit_export_statement(state: &mut ExtractionState, node: TsNode<'_>) {
         let prev_in_export = state.in_export;
@@ -262,15 +261,14 @@ impl TypeScriptExtractor {
     /// Extract a function declaration node.
     fn visit_function(state: &mut ExtractionState, node: TsNode<'_>) {
         let name = Self::find_child_by_kind(node, "identifier")
-            .map(|n| state.node_text(n))
-            .unwrap_or_else(|| "<anonymous>".to_string());
+            .map_or_else(|| "<anonymous>".to_string(), |n| state.node_text(n));
         let visibility = if state.in_export {
             Visibility::Pub
         } else {
             Visibility::Private
         };
         let is_async = Self::has_child_kind(node, "async");
-        let signature = Self::extract_signature(state, node);
+        let signature = Some(Self::extract_signature(state, node));
         let docstring = Self::extract_jsdoc(state, node);
         let start_line = node.start_position().row as u32;
         let end_line = node.end_position().row as u32;
@@ -349,15 +347,14 @@ impl TypeScriptExtractor {
         }
     }
 
-    /// Extract an arrow function from a variable_declarator node.
+    /// Extract an arrow function from a `variable_declarator` node.
     fn visit_arrow_function(
         state: &mut ExtractionState,
         declarator: TsNode<'_>,
         arrow_node: TsNode<'_>,
     ) {
         let name = Self::find_child_by_kind(declarator, "identifier")
-            .map(|n| state.node_text(n))
-            .unwrap_or_else(|| "<anonymous>".to_string());
+            .map_or_else(|| "<anonymous>".to_string(), |n| state.node_text(n));
         let visibility = if state.in_export {
             Visibility::Pub
         } else {
@@ -372,7 +369,7 @@ impl TypeScriptExtractor {
             None
         };
 
-        let signature = Self::extract_arrow_signature(state, declarator);
+        let signature = Some(Self::extract_arrow_signature(state, declarator));
         let start_line = declarator.start_position().row as u32;
         let end_line = arrow_node.end_position().row as u32;
         let start_column = declarator.start_position().column as u32;
@@ -433,8 +430,7 @@ impl TypeScriptExtractor {
     /// Extract a const variable declaration (not an arrow function).
     fn visit_const_variable(state: &mut ExtractionState, declarator: TsNode<'_>) {
         let name = Self::find_child_by_kind(declarator, "identifier")
-            .map(|n| state.node_text(n))
-            .unwrap_or_else(|| "<anonymous>".to_string());
+            .map_or_else(|| "<anonymous>".to_string(), |n| state.node_text(n));
         let visibility = if state.in_export {
             Visibility::Pub
         } else {
@@ -489,15 +485,14 @@ impl TypeScriptExtractor {
         // TS uses type_identifier, JS uses identifier for class names.
         let name = Self::find_child_by_kind(node, "type_identifier")
             .or_else(|| Self::find_child_by_kind(node, "identifier"))
-            .map(|n| state.node_text(n))
-            .unwrap_or_else(|| "<anonymous>".to_string());
+            .map_or_else(|| "<anonymous>".to_string(), |n| state.node_text(n));
         let visibility = if state.in_export {
             Visibility::Pub
         } else {
             Visibility::Private
         };
         let docstring = Self::extract_jsdoc(state, node);
-        let signature = Self::extract_signature(state, node);
+        let signature = Some(Self::extract_signature(state, node));
         let start_line = node.start_position().row as u32;
         let end_line = node.end_position().row as u32;
         let start_column = node.start_position().column as u32;
@@ -572,11 +567,10 @@ impl TypeScriptExtractor {
         }
     }
 
-    /// Extract a method_definition from a class body.
+    /// Extract a `method_definition` from a class body.
     fn visit_method(state: &mut ExtractionState, node: TsNode<'_>) {
         let name = Self::find_child_by_kind(node, "property_identifier")
-            .map(|n| state.node_text(n))
-            .unwrap_or_else(|| "<anonymous>".to_string());
+            .map_or_else(|| "<anonymous>".to_string(), |n| state.node_text(n));
 
         let kind = if name == "constructor" {
             NodeKind::Constructor
@@ -587,7 +581,7 @@ impl TypeScriptExtractor {
         // Check for accessibility_modifier (public/private/protected).
         let visibility = Self::extract_ts_accessibility(state, node);
         let is_async = Self::has_child_kind(node, "async");
-        let signature = Self::extract_signature(state, node);
+        let signature = Some(Self::extract_signature(state, node));
         let docstring = Self::extract_jsdoc(state, node);
         let start_line = node.start_position().row as u32;
         let end_line = node.end_position().row as u32;
@@ -641,11 +635,10 @@ impl TypeScriptExtractor {
         }
     }
 
-    /// Extract a field from a class body (public_field_definition).
+    /// Extract a field from a class body (`public_field_definition`).
     fn visit_field(state: &mut ExtractionState, node: TsNode<'_>) {
         let name = Self::find_child_by_kind(node, "property_identifier")
-            .map(|n| state.node_text(n))
-            .unwrap_or_else(|| "<anonymous>".to_string());
+            .map_or_else(|| "<anonymous>".to_string(), |n| state.node_text(n));
         let visibility = Self::extract_ts_accessibility(state, node);
         let text = state.node_text(node);
         let start_line = node.start_position().row as u32;
@@ -694,15 +687,14 @@ impl TypeScriptExtractor {
     /// Extract an interface declaration node.
     fn visit_interface(state: &mut ExtractionState, node: TsNode<'_>) {
         let name = Self::find_child_by_kind(node, "type_identifier")
-            .map(|n| state.node_text(n))
-            .unwrap_or_else(|| "<anonymous>".to_string());
+            .map_or_else(|| "<anonymous>".to_string(), |n| state.node_text(n));
         let visibility = if state.in_export {
             Visibility::Pub
         } else {
             Visibility::Private
         };
         let docstring = Self::extract_jsdoc(state, node);
-        let signature = Self::extract_signature(state, node);
+        let signature = Some(Self::extract_signature(state, node));
         let start_line = node.start_position().row as u32;
         let end_line = node.end_position().row as u32;
         let start_column = node.start_position().column as u32;
@@ -769,11 +761,10 @@ impl TypeScriptExtractor {
         }
     }
 
-    /// Extract a method_signature from an interface body.
+    /// Extract a `method_signature` from an interface body.
     fn visit_interface_method(state: &mut ExtractionState, node: TsNode<'_>) {
         let name = Self::find_child_by_kind(node, "property_identifier")
-            .map(|n| state.node_text(n))
-            .unwrap_or_else(|| "<anonymous>".to_string());
+            .map_or_else(|| "<anonymous>".to_string(), |n| state.node_text(n));
         let text = state.node_text(node);
         let start_line = node.start_position().row as u32;
         let end_line = node.end_position().row as u32;
@@ -821,8 +812,7 @@ impl TypeScriptExtractor {
     /// Extract an enum declaration node.
     fn visit_enum(state: &mut ExtractionState, node: TsNode<'_>) {
         let name = Self::find_child_by_kind(node, "identifier")
-            .map(|n| state.node_text(n))
-            .unwrap_or_else(|| "<anonymous>".to_string());
+            .map_or_else(|| "<anonymous>".to_string(), |n| state.node_text(n));
         let visibility = if state.in_export {
             Visibility::Pub
         } else {
@@ -946,8 +936,7 @@ impl TypeScriptExtractor {
     /// Extract a type alias declaration.
     fn visit_type_alias(state: &mut ExtractionState, node: TsNode<'_>) {
         let name = Self::find_child_by_kind(node, "type_identifier")
-            .map(|n| state.node_text(n))
-            .unwrap_or_else(|| "<anonymous>".to_string());
+            .map_or_else(|| "<anonymous>".to_string(), |n| state.node_text(n));
         let visibility = if state.in_export {
             Visibility::Pub
         } else {
@@ -1056,11 +1045,10 @@ impl TypeScriptExtractor {
         });
     }
 
-    /// Extract a namespace (internal_module) declaration.
+    /// Extract a namespace (`internal_module`) declaration.
     fn visit_namespace(state: &mut ExtractionState, node: TsNode<'_>) {
         let name = Self::find_child_by_kind(node, "identifier")
-            .map(|n| state.node_text(n))
-            .unwrap_or_else(|| "<anonymous>".to_string());
+            .map_or_else(|| "<anonymous>".to_string(), |n| state.node_text(n));
         let visibility = if state.in_export {
             Visibility::Pub
         } else {
@@ -1244,7 +1232,7 @@ impl TypeScriptExtractor {
         }
     }
 
-    /// Extract the import path from an import_statement.
+    /// Extract the import path from an `import_statement`.
     fn extract_import_path(state: &ExtractionState, node: TsNode<'_>) -> Option<String> {
         // The string child contains the module path.
         if let Some(string_node) = Self::find_child_by_kind(node, "string") {
@@ -1258,7 +1246,7 @@ impl TypeScriptExtractor {
         None
     }
 
-    /// Recursively find call_expression nodes inside a node and create
+    /// Recursively find `call_expression` nodes inside a node and create
     /// unresolved Calls references.
     fn extract_call_sites(state: &mut ExtractionState, node: TsNode<'_>, fn_node_id: &str) {
         let mut cursor = node.walk();
@@ -1309,12 +1297,9 @@ impl TypeScriptExtractor {
         loop {
             let child = cursor.node();
             match child.kind() {
-                // Parameter nodes contain type_annotation children
-                "required_parameter" | "optional_parameter" | "rest_parameter" => {
-                    Self::collect_type_identifiers(state, child, fn_node_id);
-                }
-                // The function's own return type annotation
-                "type_annotation" => {
+                // Parameter nodes contain type_annotation children; also the return type annotation
+                "required_parameter" | "optional_parameter" | "rest_parameter"
+                | "type_annotation" => {
                     Self::collect_type_identifiers(state, child, fn_node_id);
                 }
                 // Formal parameters container
@@ -1374,29 +1359,29 @@ impl TypeScriptExtractor {
     }
 
     /// Extract the function/method signature (everything up to the body `{`).
-    fn extract_signature(state: &ExtractionState, node: TsNode<'_>) -> Option<String> {
+    fn extract_signature(state: &ExtractionState, node: TsNode<'_>) -> String {
         let text = state.node_text(node);
         if let Some(brace_pos) = text.find('{') {
-            Some(text[..brace_pos].trim().to_string())
+            text[..brace_pos].trim().to_string()
         } else {
-            Some(text.trim().to_string())
+            text.trim().to_string()
         }
     }
 
-    /// Extract the signature for an arrow function from its variable_declarator.
-    fn extract_arrow_signature(state: &ExtractionState, declarator: TsNode<'_>) -> Option<String> {
+    /// Extract the signature for an arrow function from its `variable_declarator`.
+    fn extract_arrow_signature(state: &ExtractionState, declarator: TsNode<'_>) -> String {
         let text = state.node_text(declarator);
         // For arrow functions, the signature is "name = (params) => ..."
         // We want everything up to the arrow body.
         if let Some(arrow_pos) = text.find("=>") {
-            Some(text[..arrow_pos + 2].trim().to_string())
+            text[..arrow_pos + 2].trim().to_string()
         } else {
-            Some(text.trim().to_string())
+            text.trim().to_string()
         }
     }
 
-    /// Extract JSDoc docstrings from preceding comment nodes.
-    /// Only picks up `/** ... */` style comments (JSDoc).
+    /// Extract `JSDoc` docstrings from preceding comment nodes.
+    /// Only picks up `/** ... */` style comments (`JSDoc`).
     fn extract_jsdoc(state: &ExtractionState, node: TsNode<'_>) -> Option<String> {
         // In TS, we also need to check the parent if this is inside an export_statement.
         let mut target = node;
@@ -1418,7 +1403,7 @@ impl TypeScriptExtractor {
         None
     }
 
-    /// Clean JSDoc comment markers.
+    /// Clean `JSDoc` comment markers.
     fn clean_jsdoc(comment: &str) -> String {
         let trimmed = comment.trim();
         if trimmed.starts_with("/**") && trimmed.ends_with("*/") {
@@ -1445,7 +1430,6 @@ impl TypeScriptExtractor {
         if let Some(modifier) = Self::find_child_by_kind(node, "accessibility_modifier") {
             let text = state.node_text(modifier);
             match text.as_str() {
-                "public" => Visibility::Pub,
                 "private" => Visibility::Private,
                 "protected" => Visibility::PubSuper,
                 _ => Visibility::Pub,
@@ -1489,7 +1473,7 @@ impl TypeScriptExtractor {
         None
     }
 
-    /// Build the final ExtractionResult from the accumulated state.
+    /// Build the final `ExtractionResult` from the accumulated state.
     fn build_result(state: ExtractionState, start: Instant) -> ExtractionResult {
         ExtractionResult {
             nodes: state.nodes,
@@ -1506,7 +1490,7 @@ impl crate::extraction::LanguageExtractor for TypeScriptExtractor {
         &["ts", "tsx", "js", "jsx"]
     }
 
-    fn language_name(&self) -> &str {
+    fn language_name(&self) -> &'static str {
         "TypeScript"
     }
 

--- a/src/extraction/vbnet_extractor.rs
+++ b/src/extraction/vbnet_extractor.rs
@@ -49,7 +49,7 @@ struct ExtractionState {
     edges: Vec<Edge>,
     unresolved_refs: Vec<UnresolvedRef>,
     errors: Vec<String>,
-    /// Stack of (name, node_id) for building qualified names and parent edges.
+    /// Stack of (name, `node_id`) for building qualified names and parent edges.
     node_stack: Vec<(String, String)>,
     file_path: String,
     source: Vec<u8>,
@@ -189,7 +189,7 @@ impl VbNetExtractor {
         }
     }
 
-    /// Visit a type_declaration node and dispatch to the inner block type.
+    /// Visit a `type_declaration` node and dispatch to the inner block type.
     fn visit_type_declaration(state: &mut ExtractionState, node: TsNode<'_>) {
         // Collect docstring from preceding comment siblings.
         let docstring = Self::extract_xml_docstring(state, node);
@@ -293,17 +293,17 @@ impl VbNetExtractor {
 
     /// Extract an imports statement as a Use node.
     fn visit_imports(state: &mut ExtractionState, node: TsNode<'_>) {
-        let path = node
-            .child_by_field_name("namespace")
-            .map(|n| state.node_text(n))
-            .unwrap_or_else(|| {
+        let path = node.child_by_field_name("namespace").map_or_else(
+            || {
                 let text = state.node_text(node);
                 text.trim()
                     .strip_prefix("Imports ")
                     .unwrap_or(&text)
                     .trim()
                     .to_string()
-            });
+            },
+            |n| state.node_text(n),
+        );
 
         let start_line = node.start_position().row as u32;
         let end_line = node.end_position().row as u32;
@@ -358,7 +358,7 @@ impl VbNetExtractor {
         });
     }
 
-    /// Extract a class_block declaration.
+    /// Extract a `class_block` declaration.
     fn visit_class(state: &mut ExtractionState, node: TsNode<'_>, docstring: Option<String>) {
         let name =
             Self::extract_block_name(state, node).unwrap_or_else(|| "<anonymous>".to_string());
@@ -375,7 +375,7 @@ impl VbNetExtractor {
         };
 
         let id = generate_node_id(&state.file_path, &kind, &name, start_line);
-        let signature = Self::extract_block_signature(state, node, "Class");
+        let signature = Some(Self::extract_block_signature(state, node, "Class"));
 
         let graph_node = Node {
             id: id.clone(),
@@ -428,7 +428,7 @@ impl VbNetExtractor {
         state.node_stack.pop();
     }
 
-    /// Extract a structure_block declaration.
+    /// Extract a `structure_block` declaration.
     fn visit_struct(state: &mut ExtractionState, node: TsNode<'_>, docstring: Option<String>) {
         let name =
             Self::extract_block_name(state, node).unwrap_or_else(|| "<anonymous>".to_string());
@@ -438,7 +438,7 @@ impl VbNetExtractor {
         let end_column = node.end_position().column as u32;
         let qualified_name = format!("{}::{}", state.qualified_prefix(), name);
         let id = generate_node_id(&state.file_path, &NodeKind::Struct, &name, start_line);
-        let signature = Self::extract_block_signature(state, node, "Structure");
+        let signature = Some(Self::extract_block_signature(state, node, "Structure"));
 
         let graph_node = Node {
             id: id.clone(),
@@ -483,7 +483,7 @@ impl VbNetExtractor {
         state.node_stack.pop();
     }
 
-    /// Extract an interface_block declaration.
+    /// Extract an `interface_block` declaration.
     fn visit_interface(state: &mut ExtractionState, node: TsNode<'_>, docstring: Option<String>) {
         let name =
             Self::extract_block_name(state, node).unwrap_or_else(|| "<anonymous>".to_string());
@@ -493,7 +493,7 @@ impl VbNetExtractor {
         let end_column = node.end_position().column as u32;
         let qualified_name = format!("{}::{}", state.qualified_prefix(), name);
         let id = generate_node_id(&state.file_path, &NodeKind::Interface, &name, start_line);
-        let signature = Self::extract_block_signature(state, node, "Interface");
+        let signature = Some(Self::extract_block_signature(state, node, "Interface"));
 
         let graph_node = Node {
             id: id.clone(),
@@ -538,7 +538,7 @@ impl VbNetExtractor {
         state.node_stack.pop();
     }
 
-    /// Extract an enum_block declaration with its members.
+    /// Extract an `enum_block` declaration with its members.
     fn visit_enum(state: &mut ExtractionState, node: TsNode<'_>, docstring: Option<String>) {
         let name =
             Self::extract_block_name(state, node).unwrap_or_else(|| "<anonymous>".to_string());
@@ -559,7 +559,7 @@ impl VbNetExtractor {
             end_line,
             start_column,
             end_column,
-            signature: Some(format!("Enum {}", name)),
+            signature: Some(format!("Enum {name}")),
             docstring,
             visibility: Visibility::Pub,
             is_async: false,
@@ -590,7 +590,7 @@ impl VbNetExtractor {
         state.node_stack.pop();
     }
 
-    /// Extract a module_block declaration.
+    /// Extract a `module_block` declaration.
     fn visit_module(state: &mut ExtractionState, node: TsNode<'_>, docstring: Option<String>) {
         let name =
             Self::extract_block_name(state, node).unwrap_or_else(|| "<anonymous>".to_string());
@@ -600,7 +600,7 @@ impl VbNetExtractor {
         let end_column = node.end_position().column as u32;
         let qualified_name = format!("{}::{}", state.qualified_prefix(), name);
         let id = generate_node_id(&state.file_path, &NodeKind::Module, &name, start_line);
-        let signature = Self::extract_block_signature(state, node, "Module");
+        let signature = Some(Self::extract_block_signature(state, node, "Module"));
 
         let graph_node = Node {
             id: id.clone(),
@@ -645,7 +645,7 @@ impl VbNetExtractor {
         state.node_stack.pop();
     }
 
-    /// Visit the children of a block node (class_block, structure_block, etc.),
+    /// Visit the children of a block node (`class_block`, `structure_block`, etc.),
     /// dispatching to the appropriate handler for each child.
     fn visit_block_children(state: &mut ExtractionState, node: TsNode<'_>) {
         let mut cursor = node.walk();
@@ -797,9 +797,9 @@ impl VbNetExtractor {
         // Extract type from as_clause
         let type_str = Self::extract_as_clause_type(state, node);
         let sig = if let Some(t) = &type_str {
-            format!("Property {} As {}", name, t)
+            format!("Property {name} As {t}")
         } else {
-            format!("Property {}", name)
+            format!("Property {name}")
         };
 
         let graph_node = Node {
@@ -859,10 +859,8 @@ impl VbNetExtractor {
             loop {
                 let child = cursor.node();
                 if child.kind() == "variable_declarator" {
-                    let field_name = child
-                        .child_by_field_name("name")
-                        .map(|n| state.node_text(n))
-                        .unwrap_or_else(|| {
+                    let field_name = child.child_by_field_name("name").map_or_else(
+                        || {
                             // Try direct identifier child
                             let mut inner = child.walk();
                             if inner.goto_first_child() {
@@ -877,7 +875,9 @@ impl VbNetExtractor {
                                 }
                             }
                             state.node_text(child)
-                        });
+                        },
+                        |n| state.node_text(n),
+                    );
 
                     // Skip field names that look like mis-parsed Inherits/Implements
                     if field_name == "Inherits" || field_name.starts_with("erializable") {
@@ -938,7 +938,7 @@ impl VbNetExtractor {
         }
     }
 
-    /// Extract enum members from an enum_block.
+    /// Extract enum members from an `enum_block`.
     fn extract_enum_members(state: &mut ExtractionState, node: TsNode<'_>) {
         let mut cursor = node.walk();
         if cursor.goto_first_child() {
@@ -954,12 +954,10 @@ impl VbNetExtractor {
         }
     }
 
-    /// Extract a single enum member as an EnumVariant node.
+    /// Extract a single enum member as an `EnumVariant` node.
     fn extract_single_enum_member(state: &mut ExtractionState, node: TsNode<'_>) {
-        let name = node
-            .child_by_field_name("name")
-            .map(|n| state.node_text(n))
-            .unwrap_or_else(|| {
+        let name = node.child_by_field_name("name").map_or_else(
+            || {
                 // Fallback: try identifier child
                 let mut cursor = node.walk();
                 if cursor.goto_first_child() {
@@ -974,7 +972,9 @@ impl VbNetExtractor {
                     }
                 }
                 "<anonymous>".to_string()
-            });
+            },
+            |n| state.node_text(n),
+        );
         let start_line = node.start_position().row as u32;
         let end_line = node.end_position().row as u32;
         let start_column = node.start_position().column as u32;
@@ -1022,7 +1022,7 @@ impl VbNetExtractor {
     // Helper extraction methods
     // ----------------------------
 
-    /// Extract the name from a block node (class_block, etc.) via the first identifier child.
+    /// Extract the name from a block node (`class_block`, etc.) via the first identifier child.
     fn extract_block_name(state: &ExtractionState, node: TsNode<'_>) -> Option<String> {
         // Block nodes in VB.NET grammar use `name` field
         if let Some(name_node) = node.child_by_field_name("name") {
@@ -1066,22 +1066,18 @@ impl VbNetExtractor {
     }
 
     /// Extract a simple block signature like "Class Foo" or "Module Bar".
-    fn extract_block_signature(
-        state: &ExtractionState,
-        node: TsNode<'_>,
-        keyword: &str,
-    ) -> Option<String> {
+    fn extract_block_signature(state: &ExtractionState, node: TsNode<'_>, keyword: &str) -> String {
         let text = state.node_text(node);
         // Take the first line which contains the declaration keyword and name.
         let first_line = text.lines().next().unwrap_or("").trim();
         if first_line.is_empty() {
-            Some(format!(
+            format!(
                 "{} {}",
                 keyword,
                 Self::extract_block_name(state, node).unwrap_or_default()
-            ))
+            )
         } else {
-            Some(first_line.to_string())
+            first_line.to_string()
         }
     }
 
@@ -1091,7 +1087,7 @@ impl VbNetExtractor {
         text.lines().next().map(|l| l.trim().to_string())
     }
 
-    /// Extract the type from an as_clause child.
+    /// Extract the type from an `as_clause` child.
     fn extract_as_clause_type(state: &ExtractionState, node: TsNode<'_>) -> Option<String> {
         let mut cursor = node.walk();
         if cursor.goto_first_child() {
@@ -1162,7 +1158,7 @@ impl VbNetExtractor {
     }
 
     /// Extract Inherits and Implements references from the text of a class block.
-    /// The VB.NET tree-sitter grammar mis-parses these as field_declaration/ERROR,
+    /// The VB.NET tree-sitter grammar mis-parses these as `field_declaration/ERROR`,
     /// so we do text-based extraction from the full block text.
     fn extract_inherits_implements(state: &mut ExtractionState, node: TsNode<'_>, class_id: &str) {
         let text = state.node_text(node);
@@ -1320,7 +1316,7 @@ impl VbNetExtractor {
     // -----------------------------------------------------------------------
 
     /// Extract VB.NET attributes from a node's children (for methods,
-    /// constructors, properties) and create AnnotationUsage nodes and
+    /// constructors, properties) and create `AnnotationUsage` nodes and
     /// Annotates edges.
     ///
     /// VB.NET attributes appear as `attribute_block` children containing
@@ -1345,7 +1341,7 @@ impl VbNetExtractor {
     }
 
     /// Extract VB.NET attributes from previous siblings (for classes, structs,
-    /// etc. where attribute_block appears before the type_declaration).
+    /// etc. where `attribute_block` appears before the `type_declaration`).
     fn extract_annotations_from_prev_siblings(
         state: &mut ExtractionState,
         node: TsNode<'_>,
@@ -1363,7 +1359,7 @@ impl VbNetExtractor {
         }
     }
 
-    /// Walk an attribute_block node to create AnnotationUsage nodes.
+    /// Walk an `attribute_block` node to create `AnnotationUsage` nodes.
     fn extract_annotations_from_block(
         state: &mut ExtractionState,
         attr_block: TsNode<'_>,
@@ -1457,7 +1453,7 @@ impl VbNetExtractor {
         text.split('(').next().unwrap_or(&text).trim().to_string()
     }
 
-    /// Build the final ExtractionResult from the accumulated state.
+    /// Build the final `ExtractionResult` from the accumulated state.
     fn build_result(state: ExtractionState, start: Instant) -> ExtractionResult {
         ExtractionResult {
             nodes: state.nodes,
@@ -1474,7 +1470,7 @@ impl crate::extraction::LanguageExtractor for VbNetExtractor {
         &["vb"]
     }
 
-    fn language_name(&self) -> &str {
+    fn language_name(&self) -> &'static str {
         "VB.NET"
     }
 

--- a/src/extraction/zig_extractor.rs
+++ b/src/extraction/zig_extractor.rs
@@ -19,7 +19,7 @@ struct ExtractionState {
     edges: Vec<Edge>,
     unresolved_refs: Vec<UnresolvedRef>,
     errors: Vec<String>,
-    /// Stack of (name, node_id) for building qualified names and parent edges.
+    /// Stack of (name, `node_id`) for building qualified names and parent edges.
     node_stack: Vec<(String, String)>,
     file_path: String,
     source: Vec<u8>,
@@ -163,16 +163,15 @@ impl ZigExtractor {
     // variable_declaration
     // ----------------------------------
 
-    /// Visit a variable_declaration node.
+    /// Visit a `variable_declaration` node.
     ///
     /// In Zig, `const X = struct { ... }`, `const X = enum { ... }`, `const X = @import("...")`,
-    /// and plain `const X: type = value` are all variable_declaration nodes.
+    /// and plain `const X: type = value` are all `variable_declaration` nodes.
     /// We dispatch based on the value child.
     fn visit_variable_declaration(state: &mut ExtractionState, node: TsNode<'_>) {
         // Get the name from the first identifier child.
         let name = Self::find_child_by_kind(node, "identifier")
-            .map(|n| state.node_text(n))
-            .unwrap_or_else(|| "<anonymous>".to_string());
+            .map_or_else(|| "<anonymous>".to_string(), |n| state.node_text(n));
 
         // Check what the value is: struct, enum, union, @import, or plain const.
         // The value is typically the last named child that is not the type annotation.
@@ -210,10 +209,10 @@ impl ZigExtractor {
         Self::visit_const(state, node, &name);
     }
 
-    /// Find the "value" child of a variable_declaration.
+    /// Find the "value" child of a `variable_declaration`.
     ///
     /// In tree-sitter-zig, the value part is the last significant named child
-    /// (struct_declaration, enum_declaration, builtin_function, integer, identifier, etc.).
+    /// (`struct_declaration`, `enum_declaration`, `builtin_function`, integer, identifier, etc.).
     fn find_value_child<'a>(node: TsNode<'a>) -> Option<TsNode<'a>> {
         let mut cursor = node.walk();
         let mut last_named: Option<TsNode<'a>> = None;
@@ -235,11 +234,10 @@ impl ZigExtractor {
         last_named
     }
 
-    /// Check if a builtin_function node is @import.
+    /// Check if a `builtin_function` node is @import.
     fn is_import_call(state: &ExtractionState, node: TsNode<'_>) -> bool {
         Self::find_child_by_kind(node, "builtin_identifier")
-            .map(|n| state.node_text(n) == "@import")
-            .unwrap_or(false)
+            .is_some_and(|n| state.node_text(n) == "@import")
     }
 
     // ----------------------------------
@@ -300,7 +298,7 @@ impl ZigExtractor {
         }
     }
 
-    /// Extract the module name from an @import builtin_function node.
+    /// Extract the module name from an @import `builtin_function` node.
     ///
     /// Looks for the string child inside the arguments: `@import("std")` -> `"std"`.
     fn extract_import_module(state: &ExtractionState, builtin_node: TsNode<'_>) -> Option<String> {
@@ -379,7 +377,7 @@ impl ZigExtractor {
         state.node_stack.pop();
     }
 
-    /// Visit children of a struct_declaration to extract fields and methods.
+    /// Visit children of a `struct_declaration` to extract fields and methods.
     fn visit_struct_body(state: &mut ExtractionState, struct_node: TsNode<'_>) {
         let mut cursor = struct_node.walk();
         if cursor.goto_first_child() {
@@ -458,7 +456,7 @@ impl ZigExtractor {
         state.node_stack.pop();
     }
 
-    /// Visit children of an enum_declaration to extract variants.
+    /// Visit children of an `enum_declaration` to extract variants.
     fn visit_enum_body(state: &mut ExtractionState, enum_node: TsNode<'_>) {
         let mut cursor = enum_node.walk();
         if cursor.goto_first_child() {
@@ -474,12 +472,11 @@ impl ZigExtractor {
         }
     }
 
-    /// Extract an enum variant from a container_field inside an enum.
+    /// Extract an enum variant from a `container_field` inside an enum.
     fn visit_enum_variant(state: &mut ExtractionState, node: TsNode<'_>) {
         let name = node
             .child_by_field_name("name")
-            .map(|n| state.node_text(n))
-            .unwrap_or_else(|| "<anonymous>".to_string());
+            .map_or_else(|| "<anonymous>".to_string(), |n| state.node_text(n));
 
         let start_line = node.start_position().row as u32;
         let end_line = node.end_position().row as u32;
@@ -579,12 +576,11 @@ impl ZigExtractor {
     // Field
     // ----------------------------------
 
-    /// Extract a field from a container_field inside a struct.
+    /// Extract a field from a `container_field` inside a struct.
     fn visit_field(state: &mut ExtractionState, node: TsNode<'_>) {
         let name = node
             .child_by_field_name("name")
-            .map(|n| state.node_text(n))
-            .unwrap_or_else(|| "<anonymous>".to_string());
+            .map_or_else(|| "<anonymous>".to_string(), |n| state.node_text(n));
 
         let docstring = Self::extract_docstring(state, node);
         let start_line = node.start_position().row as u32;
@@ -640,8 +636,7 @@ impl ZigExtractor {
     fn visit_function(state: &mut ExtractionState, node: TsNode<'_>) {
         let name = node
             .child_by_field_name("name")
-            .map(|n| state.node_text(n))
-            .unwrap_or_else(|| "<anonymous>".to_string());
+            .map_or_else(|| "<anonymous>".to_string(), |n| state.node_text(n));
 
         let is_pub = Self::has_pub_keyword(state, node);
         let visibility = if is_pub {
@@ -713,8 +708,7 @@ impl ZigExtractor {
         // The test name is in a string child.
         let name = Self::find_child_by_kind(node, "string")
             .and_then(|s| Self::find_child_by_kind(s, "string_content"))
-            .map(|n| state.node_text(n))
-            .unwrap_or_else(|| "<anonymous test>".to_string());
+            .map_or_else(|| "<anonymous test>".to_string(), |n| state.node_text(n));
 
         let start_line = node.start_position().row as u32;
         let end_line = node.end_position().row as u32;
@@ -775,7 +769,7 @@ impl ZigExtractor {
     // Helper extraction methods
     // ----------------------------
 
-    /// Check if a function_declaration node has the `pub` keyword.
+    /// Check if a `function_declaration` node has the `pub` keyword.
     ///
     /// In tree-sitter-zig, `pub fn` has an anonymous "pub" child before "fn".
     fn has_pub_keyword(state: &ExtractionState, node: TsNode<'_>) -> bool {
@@ -903,16 +897,10 @@ impl ZigExtractor {
     /// For chained calls like `std.debug.print`, returns the full chain.
     fn extract_callee_name(state: &ExtractionState, node: TsNode<'_>) -> String {
         match node.kind() {
-            "identifier" => state.node_text(node),
-            "field_expression" => {
-                // Get the full chain: e.g. "std.debug.print" or "self.connected"
-                state.node_text(node)
-            }
             "builtin_function" => {
                 // @sqrt, @as, etc.
                 Self::find_child_by_kind(node, "builtin_identifier")
-                    .map(|n| state.node_text(n))
-                    .unwrap_or_else(|| state.node_text(node))
+                    .map_or_else(|| state.node_text(node), |n| state.node_text(n))
             }
             _ => state.node_text(node),
         }
@@ -935,7 +923,7 @@ impl ZigExtractor {
         None
     }
 
-    /// Build the final ExtractionResult from the accumulated state.
+    /// Build the final `ExtractionResult` from the accumulated state.
     fn build_result(state: ExtractionState, start: Instant) -> ExtractionResult {
         ExtractionResult {
             nodes: state.nodes,
@@ -952,7 +940,7 @@ impl crate::extraction::LanguageExtractor for ZigExtractor {
         &["zig"]
     }
 
-    fn language_name(&self) -> &str {
+    fn language_name(&self) -> &'static str {
         "Zig"
     }
 

--- a/src/global_db.rs
+++ b/src/global_db.rs
@@ -1,4 +1,4 @@
-//! User-level database that tracks all TokenSave projects and their saved tokens.
+//! User-level database that tracks all `TokenSave` projects and their saved tokens.
 //!
 //! Stored at `~/.tokensave/global.db`, this DB holds one row per project with
 //! the project's DB path and its cumulative tokens-saved count. All operations
@@ -9,7 +9,7 @@ use std::path::{Path, PathBuf};
 
 use libsql::{params, Builder, Connection, Database as LibsqlDatabase};
 
-/// User-level database tracking all TokenSave projects.
+/// User-level database tracking all `TokenSave` projects.
 pub struct GlobalDb {
     conn: Connection,
     _db: LibsqlDatabase,
@@ -93,19 +93,18 @@ impl GlobalDb {
             .await;
     }
 
-    /// Returns the stored tokens_saved count for a specific project, or 0 if not found.
+    /// Returns the stored `tokens_saved` count for a specific project, or 0 if not found.
     pub async fn get_project_tokens(&self, project_path: &Path) -> u64 {
         let path_str = project_path.to_string_lossy().to_string();
-        let mut rows = match self
+        let Ok(mut rows) = self
             .conn
             .query(
                 "SELECT tokens_saved FROM projects WHERE path = ?1",
                 params![path_str],
             )
             .await
-        {
-            Ok(r) => r,
-            Err(_) => return 0,
+        else {
+            return 0;
         };
         match rows.next().await {
             Ok(Some(row)) => row.get::<i64>(0).unwrap_or(0) as u64,
@@ -113,7 +112,7 @@ impl GlobalDb {
         }
     }
 
-    /// Returns the sum of tokens_saved across all tracked projects.
+    /// Returns the sum of `tokens_saved` across all tracked projects.
     pub async fn global_tokens_saved(&self) -> Option<u64> {
         let mut rows = self
             .conn
@@ -127,9 +126,8 @@ impl GlobalDb {
 
     /// Returns all tracked project paths.
     pub async fn list_project_paths(&self) -> Vec<String> {
-        let mut rows = match self.conn.query("SELECT path FROM projects", ()).await {
-            Ok(r) => r,
-            Err(_) => return Vec::new(),
+        let Ok(mut rows) = self.conn.query("SELECT path FROM projects", ()).await else {
+            return Vec::new();
         };
         let mut paths = Vec::new();
         while let Ok(Some(row)) = rows.next().await {
@@ -167,8 +165,7 @@ impl GlobalDb {
                 ],
             )
             .await
-            .map(|n| n > 0)
-            .unwrap_or(false)
+            .is_ok_and(|n| n > 0)
     }
 
     /// Total cost in USD since a given unix timestamp.
@@ -199,7 +196,7 @@ impl GlobalDb {
         Some(row.get::<i64>(0).unwrap_or(0) as u64)
     }
 
-    /// Token breakdown (input, output, cache_read) since a given timestamp.
+    /// Token breakdown (input, output, `cache_read`) since a given timestamp.
     pub async fn token_breakdown_since(&self, since: u64) -> Option<(u64, u64, u64)> {
         let mut rows = self
             .conn
@@ -223,7 +220,7 @@ impl GlobalDb {
     /// Cost grouped by model since a given timestamp.
     /// Returns `(model, cost, total_tokens)`.
     pub async fn cost_by_model_since(&self, since: u64) -> Vec<(String, f64, u64)> {
-        let mut rows = match self
+        let Ok(mut rows) = self
             .conn
             .query(
                 "SELECT model, SUM(cost_usd), SUM(input_tokens + output_tokens)
@@ -232,9 +229,8 @@ impl GlobalDb {
                 params![since as i64],
             )
             .await
-        {
-            Ok(r) => r,
-            Err(_) => return Vec::new(),
+        else {
+            return Vec::new();
         };
         let mut out = Vec::new();
         while let Ok(Some(row)) = rows.next().await {
@@ -249,7 +245,7 @@ impl GlobalDb {
     /// Cost grouped by category since a given timestamp.
     /// Returns `(category, cost, turn_count)`.
     pub async fn cost_by_category_since(&self, since: u64) -> Vec<(String, f64, u64)> {
-        let mut rows = match self
+        let Ok(mut rows) = self
             .conn
             .query(
                 "SELECT category, SUM(cost_usd), COUNT(*)
@@ -258,9 +254,8 @@ impl GlobalDb {
                 params![since as i64],
             )
             .await
-        {
-            Ok(r) => r,
-            Err(_) => return Vec::new(),
+        else {
+            return Vec::new();
         };
         let mut out = Vec::new();
         while let Ok(Some(row)) = rows.next().await {

--- a/src/graph/queries.rs
+++ b/src/graph/queries.rs
@@ -73,7 +73,8 @@ impl<'a> GraphQueryManager<'a> {
             return Ok(Vec::new());
         }
 
-        let placeholders: Vec<String> = (1..=candidate_ids.len()).map(|i| format!("?{i}")).collect();
+        let placeholders: Vec<String> =
+            (1..=candidate_ids.len()).map(|i| format!("?{i}")).collect();
         let sql = format!(
             "SELECT target FROM edges WHERE target IN ({}) LIMIT 1",
             placeholders.join(", ")
@@ -92,7 +93,8 @@ impl<'a> GraphQueryManager<'a> {
                 operation: "find_dead_code".to_string(),
             })?;
 
-        let mut nodes_with_incoming: std::collections::HashSet<String> = std::collections::HashSet::new();
+        let mut nodes_with_incoming: std::collections::HashSet<String> =
+            std::collections::HashSet::new();
         while let Some(row) = rows.next().await.map_err(|e| TokenSaveError::Database {
             message: format!("failed to read row: {e}"),
             operation: "find_dead_code".to_string(),
@@ -102,10 +104,13 @@ impl<'a> GraphQueryManager<'a> {
             }
         }
 
-        let candidate_set: std::collections::HashSet<String> = candidate_ids.iter().cloned().collect();
+        let candidate_set: std::collections::HashSet<String> =
+            candidate_ids.iter().cloned().collect();
         let dead: Vec<Node> = nodes
             .into_iter()
-            .filter(|node| candidate_set.contains(&node.id) && !nodes_with_incoming.contains(&node.id))
+            .filter(|node| {
+                candidate_set.contains(&node.id) && !nodes_with_incoming.contains(&node.id)
+            })
             .collect();
 
         Ok(dead)

--- a/src/graph/queries.rs
+++ b/src/graph/queries.rs
@@ -335,7 +335,7 @@ impl<'a> GraphQueryManager<'a> {
             // Take the first parent in the containment hierarchy.
             match incoming.first() {
                 Some(edge) => {
-                    current_id = edge.source.clone();
+                    current_id.clone_from(&edge.source);
                     depth += 1;
                 }
                 None => break,

--- a/src/graph/queries.rs
+++ b/src/graph/queries.rs
@@ -100,7 +100,8 @@ impl<'a> GraphQueryManager<'a> {
         let kind_filter = if kinds.is_empty() {
             String::new()
         } else {
-            let kind_strs: Vec<String> = kinds.iter().map(|k| format!("'{}'", k.as_str())).collect();
+            let kind_strs: Vec<String> =
+                kinds.iter().map(|k| format!("'{}'", k.as_str())).collect();
             format!(" AND kind IN ({})", kind_strs.join(", "))
         };
 
@@ -117,15 +118,15 @@ impl<'a> GraphQueryManager<'a> {
              AND NOT EXISTS (SELECT 1 FROM edges WHERE target = nodes.id)"
         );
 
-        let mut rows = self
-            .db
-            .conn()
-            .query(&sql, ())
-            .await
-            .map_err(|e| TokenSaveError::Database {
-                message: format!("failed to find dead code: {e}"),
-                operation: "find_dead_code".to_string(),
-            })?;
+        let mut rows =
+            self.db
+                .conn()
+                .query(&sql, ())
+                .await
+                .map_err(|e| TokenSaveError::Database {
+                    message: format!("failed to find dead code: {e}"),
+                    operation: "find_dead_code".to_string(),
+                })?;
 
         let mut dead = Vec::new();
         while let Some(row) = rows.next().await.map_err(|e| TokenSaveError::Database {

--- a/src/graph/queries.rs
+++ b/src/graph/queries.rs
@@ -27,6 +27,61 @@ pub struct GraphQueryManager<'a> {
     db: &'a Database,
 }
 
+fn row_to_node_dead_code(row: &libsql::Row) -> std::result::Result<Node, libsql::Error> {
+    let kind_str = get_string_lossy(row, 1)?;
+    let vis_str = get_string_lossy(row, 11)?;
+    let is_async_int = row.get::<i64>(12)?;
+
+    Ok(Node {
+        id: get_string_lossy(row, 0)?,
+        kind: NodeKind::from_str(&kind_str).unwrap_or(NodeKind::Function),
+        name: get_string_lossy(row, 2)?,
+        qualified_name: get_string_lossy(row, 3)?,
+        file_path: get_string_lossy(row, 4)?,
+        start_line: row.get::<u32>(5)?,
+        end_line: row.get::<u32>(6)?,
+        start_column: row.get::<u32>(7)?,
+        end_column: row.get::<u32>(8)?,
+        signature: get_opt_string_lossy(row, 10)?,
+        docstring: get_opt_string_lossy(row, 9)?,
+        visibility: Visibility::from_str(&vis_str).unwrap_or_default(),
+        is_async: is_async_int != 0,
+        branches: row.get::<u32>(13)?,
+        loops: row.get::<u32>(14)?,
+        returns: row.get::<u32>(15)?,
+        max_nesting: row.get::<u32>(16)?,
+        unsafe_blocks: row.get::<u32>(17)?,
+        unchecked_calls: row.get::<u32>(18)?,
+        assertions: row.get::<u32>(19)?,
+        updated_at: row.get::<u64>(20)?,
+    })
+}
+
+fn get_string_lossy(row: &libsql::Row, idx: i32) -> std::result::Result<String, libsql::Error> {
+    let val = row.get::<libsql::Value>(idx)?;
+    match val {
+        libsql::Value::Text(s) => Ok(s),
+        libsql::Value::Blob(bytes) => Ok(String::from_utf8_lossy(&bytes).into_owned()),
+        libsql::Value::Null => Ok(String::new()),
+        libsql::Value::Integer(i) => Ok(i.to_string()),
+        libsql::Value::Real(f) => Ok(f.to_string()),
+    }
+}
+
+fn get_opt_string_lossy(
+    row: &libsql::Row,
+    idx: i32,
+) -> std::result::Result<Option<String>, libsql::Error> {
+    let val = row.get::<libsql::Value>(idx)?;
+    match val {
+        libsql::Value::Text(s) => Ok(Some(s)),
+        libsql::Value::Blob(bytes) => Ok(Some(String::from_utf8_lossy(&bytes).into_owned())),
+        libsql::Value::Null => Ok(None),
+        libsql::Value::Integer(i) => Ok(Some(i.to_string())),
+        libsql::Value::Real(f) => Ok(Some(f.to_string())),
+    }
+}
+
 impl<'a> GraphQueryManager<'a> {
     /// Creates a new `GraphQueryManager` backed by the given database.
     pub fn new(db: &'a Database) -> Self {
@@ -42,76 +97,44 @@ impl<'a> GraphQueryManager<'a> {
     ///
     /// If `kinds` is non-empty, only nodes of the specified kinds are checked.
     pub async fn find_dead_code(&self, kinds: &[NodeKind]) -> Result<Vec<Node>> {
-        let nodes = if kinds.is_empty() {
-            self.db.get_all_nodes().await?
+        let kind_filter = if kinds.is_empty() {
+            String::new()
         } else {
-            let mut all = Vec::new();
-            for kind in kinds {
-                all.extend(self.db.get_nodes_by_kind(kind.clone()).await?);
-            }
-            all
+            let kind_strs: Vec<String> = kinds.iter().map(|k| format!("'{}'", k.as_str())).collect();
+            format!(" AND kind IN ({})", kind_strs.join(", "))
         };
 
-        let candidate_ids: Vec<String> = nodes
-            .iter()
-            .filter(|node| {
-                if node.name == "main" {
-                    return false;
-                }
-                if node.name.starts_with("test") {
-                    return false;
-                }
-                if node.visibility == Visibility::Pub {
-                    return false;
-                }
-                true
-            })
-            .map(|n| n.id.clone())
-            .collect();
-
-        if candidate_ids.is_empty() {
-            return Ok(Vec::new());
-        }
-
-        let placeholders: Vec<String> =
-            (1..=candidate_ids.len()).map(|i| format!("?{i}")).collect();
         let sql = format!(
-            "SELECT target FROM edges WHERE target IN ({}) LIMIT 1",
-            placeholders.join(", ")
+            "SELECT id, kind, name, qualified_name, file_path, start_line, end_line,
+                    start_column, end_column, docstring, signature, visibility,
+                    is_async, branches, loops, returns, max_nesting, unsafe_blocks,
+                    unchecked_calls, assertions, updated_at
+             FROM nodes
+             WHERE name != 'main'
+             AND name NOT LIKE 'test%'
+             AND visibility != 'public'
+             {kind_filter}
+             AND NOT EXISTS (SELECT 1 FROM edges WHERE target = nodes.id)"
         );
-        let param_values: Vec<libsql::Value> = candidate_ids
-            .iter()
-            .map(|id| libsql::Value::Text(id.clone()))
-            .collect();
+
         let mut rows = self
             .db
             .conn()
-            .query(&sql, libsql::params_from_iter(param_values))
+            .query(&sql, ())
             .await
             .map_err(|e| TokenSaveError::Database {
-                message: format!("failed to find nodes with incoming edges: {e}"),
+                message: format!("failed to find dead code: {e}"),
                 operation: "find_dead_code".to_string(),
             })?;
 
-        let mut nodes_with_incoming: std::collections::HashSet<String> =
-            std::collections::HashSet::new();
+        let mut dead = Vec::new();
         while let Some(row) = rows.next().await.map_err(|e| TokenSaveError::Database {
             message: format!("failed to read row: {e}"),
             operation: "find_dead_code".to_string(),
         })? {
-            if let Ok(id) = row.get::<String>(0) {
-                nodes_with_incoming.insert(id);
-            }
+            let node = row_to_node_dead_code(&row)?;
+            dead.push(node);
         }
-
-        let candidate_set: std::collections::HashSet<String> =
-            candidate_ids.iter().cloned().collect();
-        let dead: Vec<Node> = nodes
-            .into_iter()
-            .filter(|node| {
-                candidate_set.contains(&node.id) && !nodes_with_incoming.contains(&node.id)
-            })
-            .collect();
 
         Ok(dead)
     }

--- a/src/graph/traversal.rs
+++ b/src/graph/traversal.rs
@@ -45,7 +45,7 @@ impl<'a> GraphTraverser<'a> {
         // Optionally include the start node.
         if let Some(start_node) = self.db.get_node_by_id(start_id).await? {
             visited.insert(start_id.to_string());
-            if opts.include_start && self.node_matches_filter(&start_node, opts) {
+            if opts.include_start && Self::node_matches_filter(&start_node, opts) {
                 roots.push(start_id.to_string());
                 result_nodes.push(start_node);
             }
@@ -75,7 +75,7 @@ impl<'a> GraphTraverser<'a> {
 
             let neighbor_ids: Vec<String> = edges
                 .iter()
-                .map(|edge| self.neighbor_id(edge, &current_id, &opts.direction))
+                .map(|edge| Self::neighbor_id(edge, &current_id, &opts.direction))
                 .filter(|id| !visited.contains(id))
                 .collect();
 
@@ -90,7 +90,7 @@ impl<'a> GraphTraverser<'a> {
                 .collect();
 
             for edge in edges {
-                let neighbor_id = self.neighbor_id(&edge, &current_id, &opts.direction);
+                let neighbor_id = Self::neighbor_id(&edge, &current_id, &opts.direction);
 
                 if visited.contains(&neighbor_id) {
                     continue;
@@ -102,7 +102,7 @@ impl<'a> GraphTraverser<'a> {
 
                 visited.insert(neighbor_id.clone());
 
-                if self.node_matches_filter(neighbor_node, opts) {
+                if Self::node_matches_filter(neighbor_node, opts) {
                     if opts.direction == TraversalDirection::Incoming
                         && is_container_kind(&neighbor_node.kind)
                     {
@@ -114,7 +114,7 @@ impl<'a> GraphTraverser<'a> {
                             )
                             .await?;
                         for child_edge in children {
-                            let child_id = self.neighbor_id(
+                            let child_id = Self::neighbor_id(
                                 &child_edge,
                                 &neighbor_id,
                                 &TraversalDirection::Outgoing,
@@ -172,7 +172,7 @@ impl<'a> GraphTraverser<'a> {
 
         if let Some(start_node) = self.db.get_node_by_id(start_id).await? {
             visited.insert(start_id.to_string());
-            if opts.include_start && self.node_matches_filter(&start_node, opts) {
+            if opts.include_start && Self::node_matches_filter(&start_node, opts) {
                 roots.push(start_id.to_string());
                 result_nodes.push(start_node);
             }
@@ -204,7 +204,7 @@ impl<'a> GraphTraverser<'a> {
 
             let neighbor_ids: Vec<String> = edges
                 .iter()
-                .map(|edge| self.neighbor_id(edge, &current_id, &opts.direction))
+                .map(|edge| Self::neighbor_id(edge, &current_id, &opts.direction))
                 .filter(|id| !visited.contains(id))
                 .collect();
 
@@ -219,7 +219,7 @@ impl<'a> GraphTraverser<'a> {
                 .collect();
 
             for edge in edges {
-                let neighbor_id = self.neighbor_id(&edge, &current_id, &opts.direction);
+                let neighbor_id = Self::neighbor_id(&edge, &current_id, &opts.direction);
 
                 if visited.contains(&neighbor_id) {
                     continue;
@@ -231,7 +231,7 @@ impl<'a> GraphTraverser<'a> {
 
                 visited.insert(neighbor_id.clone());
 
-                if self.node_matches_filter(neighbor_node, opts) {
+                if Self::node_matches_filter(neighbor_node, opts) {
                     result_nodes.push(neighbor_node.clone());
                     result_edges.push(edge.clone());
                     stack.push((neighbor_id, depth + 1));
@@ -610,7 +610,7 @@ impl<'a> GraphTraverser<'a> {
     /// For outgoing: the neighbor is `edge.target`.
     /// For incoming: the neighbor is `edge.source`.
     /// For both: whichever end is not `current_id`.
-    fn neighbor_id(&self, edge: &Edge, current_id: &str, direction: &TraversalDirection) -> String {
+    fn neighbor_id(edge: &Edge, current_id: &str, direction: &TraversalDirection) -> String {
         match direction {
             TraversalDirection::Outgoing => edge.target.clone(),
             TraversalDirection::Incoming => edge.source.clone(),
@@ -625,7 +625,7 @@ impl<'a> GraphTraverser<'a> {
     }
 
     /// Checks whether a node passes the optional `node_kinds` filter.
-    fn node_matches_filter(&self, node: &Node, opts: &TraversalOptions) -> bool {
+    fn node_matches_filter(node: &Node, opts: &TraversalOptions) -> bool {
         if let Some(ref kinds) = opts.node_kinds {
             if !kinds.is_empty() {
                 return kinds.contains(&node.kind);

--- a/src/hooks.rs
+++ b/src/hooks.rs
@@ -4,7 +4,7 @@
 //! tool calls, redirect exploration work to tokensave MCP tools, and
 //! track per-session token savings.
 
-/// PreToolUse hook handler for Claude Code's Agent tool matcher.
+/// `PreToolUse` hook handler for Claude Code's Agent tool matcher.
 ///
 /// Reads the `TOOL_INPUT` environment variable (JSON), inspects the
 /// `subagent_type` and `prompt` fields, and prints a JSON decision to
@@ -14,11 +14,11 @@ pub fn hook_pre_tool_use() {
     let tool_input = std::env::var("TOOL_INPUT").unwrap_or_default();
     let decision = evaluate_hook_decision(&tool_input);
     if !decision.is_empty() {
-        println!("{}", decision);
+        println!("{decision}");
     }
 }
 
-/// Pure decision logic for the PreToolUse hook.
+/// Pure decision logic for the `PreToolUse` hook.
 ///
 /// Takes the raw `TOOL_INPUT` JSON string and returns the JSON decision
 /// string to print to stdout.

--- a/src/main.rs
+++ b/src/main.rs
@@ -283,6 +283,9 @@ enum Commands {
         /// Remove autostart service
         #[arg(long)]
         disable_autostart: bool,
+        /// Override debounce duration (e.g. "2s", "15s", "1m"). Overrides config.
+        #[arg(long)]
+        debounce: Option<String>,
     },
     /// Token cost summary from Claude Code sessions
     Cost {
@@ -1180,6 +1183,7 @@ async fn run(cli: Cli) -> tokensave::errors::Result<()> {
             status,
             enable_autostart,
             disable_autostart,
+            debounce,
         } => {
             if stop {
                 tokensave::daemon::stop()?;
@@ -1191,7 +1195,7 @@ async fn run(cli: Cli) -> tokensave::errors::Result<()> {
             } else if disable_autostart {
                 tokensave::daemon::disable_autostart()?;
             } else {
-                let upgraded = tokensave::daemon::run(foreground).await?;
+                let upgraded = tokensave::daemon::run(foreground, debounce).await?;
                 if upgraded {
                     // Exit with non-zero code so the service manager (launchd
                     // KeepAlive / systemd Restart=on-failure / Windows SCM

--- a/src/main.rs
+++ b/src/main.rs
@@ -418,7 +418,7 @@ async fn run(cli: Cli) -> tokensave::errors::Result<()> {
                         let ctx = tokensave::agents::InstallContext {
                             home: home.clone(),
                             tokensave_bin: bin.clone(),
-                            tool_permissions: tokensave::agents::EXPECTED_TOOL_PERMS,
+                            tool_permissions: tokensave::agents::expected_tool_perms(),
                         };
                         if ag.install(&ctx).is_err() {
                             all_ok = false;
@@ -928,7 +928,7 @@ async fn run(cli: Cli) -> tokensave::errors::Result<()> {
                 let ctx = tokensave::agents::InstallContext {
                     home: home.clone(),
                     tokensave_bin: tokensave_bin.clone(),
-                    tool_permissions: tokensave::agents::EXPECTED_TOOL_PERMS,
+                    tool_permissions: tokensave::agents::expected_tool_perms(),
                 };
                 ag.install(&ctx)?;
                 if !user_cfg.installed_agents.contains(&id) {
@@ -947,7 +947,7 @@ async fn run(cli: Cli) -> tokensave::errors::Result<()> {
                     let ctx = tokensave::agents::InstallContext {
                         home: home.clone(),
                         tokensave_bin: tokensave_bin.clone(),
-                        tool_permissions: tokensave::agents::EXPECTED_TOOL_PERMS,
+                        tool_permissions: tokensave::agents::expected_tool_perms(),
                     };
                     ag.uninstall(&ctx)?;
                     removed_names.push(ag.name().to_string());
@@ -958,7 +958,7 @@ async fn run(cli: Cli) -> tokensave::errors::Result<()> {
                     let ctx = tokensave::agents::InstallContext {
                         home: home.clone(),
                         tokensave_bin: tokensave_bin.clone(),
-                        tool_permissions: tokensave::agents::EXPECTED_TOOL_PERMS,
+                        tool_permissions: tokensave::agents::expected_tool_perms(),
                     };
                     ag.install(&ctx)?;
                     installed_names.push(ag.name().to_string());
@@ -1015,7 +1015,7 @@ async fn run(cli: Cli) -> tokensave::errors::Result<()> {
                     let ctx = tokensave::agents::InstallContext {
                         home: home.clone(),
                         tokensave_bin: tokensave_bin.clone(),
-                        tool_permissions: tokensave::agents::EXPECTED_TOOL_PERMS,
+                        tool_permissions: tokensave::agents::expected_tool_perms(),
                     };
                     ag.install(&ctx)?;
                 }
@@ -1038,7 +1038,7 @@ async fn run(cli: Cli) -> tokensave::errors::Result<()> {
                 let ctx = tokensave::agents::InstallContext {
                     home,
                     tokensave_bin: String::new(),
-                    tool_permissions: tokensave::agents::EXPECTED_TOOL_PERMS,
+                    tool_permissions: tokensave::agents::expected_tool_perms(),
                 };
                 ag.uninstall(&ctx)?;
                 user_cfg.installed_agents.retain(|a| a != &id);
@@ -1049,7 +1049,7 @@ async fn run(cli: Cli) -> tokensave::errors::Result<()> {
                         let ctx = tokensave::agents::InstallContext {
                             home: home.clone(),
                             tokensave_bin: String::new(),
-                            tool_permissions: tokensave::agents::EXPECTED_TOOL_PERMS,
+                            tool_permissions: tokensave::agents::expected_tool_perms(),
                         };
                         ag.uninstall(&ctx).ok();
                     }

--- a/src/main.rs
+++ b/src/main.rs
@@ -860,12 +860,10 @@ async fn run(cli: Cli) -> tokensave::errors::Result<()> {
             let mut changed: Vec<String> = files;
             if stdin {
                 let stdin_handle = io::stdin();
-                for line in stdin_handle.lock().lines() {
-                    if let Ok(line) = line {
-                        let trimmed = line.trim().to_string();
-                        if !trimmed.is_empty() {
-                            changed.push(trimmed);
-                        }
+                for line in stdin_handle.lock().lines().map_while(Result::ok) {
+                    let trimmed = line.trim().to_string();
+                    if !trimmed.is_empty() {
+                        changed.push(trimmed);
                     }
                 }
             }

--- a/src/mcp/server.rs
+++ b/src/mcp/server.rs
@@ -797,20 +797,30 @@ impl McpServer {
                 }
 
                 // Check per-file staleness for files touched by this tool call.
+                // If stale files exist, attempt an incremental sync first to keep
+                // the index up-to-date before returning the response.
                 if !result.touched_files.is_empty() {
                     let stale_files = self.cg.check_file_staleness(&result.touched_files).await;
                     if !stale_files.is_empty() {
-                        let warning = format!(
-                            "WARNING: STALE INDEX — {} file(s) modified since last sync: {}. Run `tokensave sync` to update.",
-                            stale_files.len(),
-                            stale_files.join(", ")
-                        );
-                        if let Some(content) = result
-                            .value
-                            .get_mut("content")
-                            .and_then(|c| c.as_array_mut())
-                        {
-                            content.insert(0, json!({"type": "text", "text": &warning}));
+                        // Try to sync before responding. If sync fails (e.g., lock
+                        // held by another process), we still warn the user.
+                        let still_stale = match self.cg.sync_if_stale(&stale_files).await {
+                            Ok(false) => false,        // Sync completed and files are no longer stale
+                            Ok(true) | Err(_) => true, // Files still stale or sync failed
+                        };
+                        if still_stale {
+                            let warning = format!(
+                                "WARNING: STALE INDEX — {} file(s) modified since last sync: {}. Run `tokensave sync` to update.",
+                                stale_files.len(),
+                                stale_files.join(", ")
+                            );
+                            if let Some(content) = result
+                                .value
+                                .get_mut("content")
+                                .and_then(|c| c.as_array_mut())
+                            {
+                                content.insert(0, json!({"type": "text", "text": &warning}));
+                            }
                         }
                     }
                 }

--- a/src/mcp/server.rs
+++ b/src/mcp/server.rs
@@ -38,7 +38,7 @@ impl ServerStats {
 }
 
 /// Cache duration for version checks (15 minutes).
-const VERSION_CHECK_INTERVAL: Duration = Duration::from_secs(900);
+const VERSION_CHECK_INTERVAL: Duration = Duration::from_mins(15);
 
 /// Cached result of a latest-version check against GitHub releases.
 struct VersionCheckState {
@@ -52,7 +52,7 @@ pub struct McpServer {
     cg: TokenSave,
     stats: ServerStats,
     tool_call_counts: std::sync::Mutex<HashMap<String, u64>>,
-    /// Approximate token count per indexed file (file_path -> tokens).
+    /// Approximate token count per indexed file (`file_path` -> tokens).
     file_token_map: std::sync::Mutex<HashMap<String, u64>>,
     /// Running total of tokens saved by serving from the graph.
     tokens_saved: AtomicU64,
@@ -117,9 +117,8 @@ impl McpServer {
             "accumulate_tokens_saved received empty file path"
         );
         let delta = {
-            let map = match self.file_token_map.lock() {
-                Ok(m) => m,
-                Err(_) => return 0,
+            let Ok(map) = self.file_token_map.lock() else {
+                return 0;
             };
             let mut total: u64 = 0;
             for path in file_paths {
@@ -219,7 +218,7 @@ impl McpServer {
 
         // Update cache regardless of fetch outcome so we don't retry immediately.
         if let Ok(mut cache) = self.version_cache.lock() {
-            cache.latest = latest.clone();
+            cache.latest.clone_from(&latest);
             cache.checked_at = Some(Instant::now());
         }
 
@@ -289,7 +288,7 @@ impl McpServer {
                 Err(e) => Some(JsonRpcResponse::error(
                     Value::Null,
                     ErrorCode::ParseError,
-                    format!("failed to parse JSON-RPC request: {}", e),
+                    format!("failed to parse JSON-RPC request: {e}"),
                 )),
             };
 
@@ -302,7 +301,7 @@ impl McpServer {
                     .unwrap_or_default();
                 for notification in notifications {
                     if let Ok(s) = serde_json::to_string(&notification) {
-                        let _ = transport.write_line(&format!("{}\n", s)).await;
+                        let _ = transport.write_line(&format!("{s}\n")).await;
                         let _ = transport.flush().await;
                     }
                 }
@@ -313,17 +312,17 @@ impl McpServer {
                 let json_line = match serde_json::to_string(&resp) {
                     Ok(s) => s,
                     Err(e) => {
-                        eprintln!("failed to serialize response: {}", e);
+                        eprintln!("failed to serialize response: {e}");
                         continue;
                     }
                 };
-                let output = format!("{}\n", json_line);
+                let output = format!("{json_line}\n");
                 if let Err(e) = transport.write_line(&output).await {
-                    eprintln!("failed to write response: {}", e);
+                    eprintln!("failed to write response: {e}");
                     break;
                 }
                 if let Err(e) = transport.flush().await {
-                    eprintln!("failed to flush stdout: {}", e);
+                    eprintln!("failed to flush stdout: {e}");
                     break;
                 }
             }
@@ -396,7 +395,7 @@ impl McpServer {
         let id = request.id.clone();
 
         let result = match request.method.as_str() {
-            "initialize" => Some(self.handle_initialize(id)),
+            "initialize" => Some(Self::handle_initialize(id)),
             "initialized" => {
                 // Notification - no response required
                 None
@@ -406,9 +405,12 @@ impl McpServer {
                 None
             }
             "tools/list" => Some(self.handle_tools_list(id).await),
-            "tools/call" => Some(self.handle_tools_call(id, &request.params).await),
-            "resources/list" => Some(self.handle_resources_list(id)),
-            "resources/read" => Some(self.handle_resources_read(id, &request.params).await),
+            "tools/call" => Some(self.handle_tools_call(id, request.params.as_ref()).await),
+            "resources/list" => Some(Self::handle_resources_list(id)),
+            "resources/read" => Some(
+                self.handle_resources_read(id, request.params.as_ref())
+                    .await,
+            ),
             "ping" => Some(JsonRpcResponse::success(id, json!({}))),
             _ => Some(JsonRpcResponse::error(
                 id,
@@ -428,7 +430,7 @@ impl McpServer {
     }
 
     /// Handles the `initialize` method, returning server capabilities.
-    fn handle_initialize(&self, id: Value) -> JsonRpcResponse {
+    fn handle_initialize(id: Value) -> JsonRpcResponse {
         JsonRpcResponse::success(
             id,
             json!({
@@ -456,14 +458,14 @@ impl McpServer {
 
     /// Handles the `tools/list` method, returning all available tool definitions.
     async fn handle_tools_list(&self, id: Value) -> JsonRpcResponse {
-        let node_count = self.cg.get_stats().await.map(|s| s.node_count).unwrap_or(0);
+        let node_count = self.cg.get_stats().await.map_or(0, |s| s.node_count);
         let budget = explore_call_budget(node_count);
         let tools = get_tool_definitions_with_budget(node_count, budget);
         JsonRpcResponse::success(id, json!({ "tools": tools }))
     }
 
     /// Handles the `resources/list` method, returning available resources.
-    fn handle_resources_list(&self, id: Value) -> JsonRpcResponse {
+    fn handle_resources_list(id: Value) -> JsonRpcResponse {
         JsonRpcResponse::success(
             id,
             json!({
@@ -498,21 +500,15 @@ impl McpServer {
     }
 
     /// Handles the `resources/read` method, returning resource contents.
-    async fn handle_resources_read(&self, id: Value, params: &Option<Value>) -> JsonRpcResponse {
-        let uri = params
-            .as_ref()
-            .and_then(|p| p.get("uri"))
-            .and_then(|v| v.as_str());
+    async fn handle_resources_read(&self, id: Value, params: Option<&Value>) -> JsonRpcResponse {
+        let uri = params.and_then(|p| p.get("uri")).and_then(|v| v.as_str());
 
-        let uri = match uri {
-            Some(u) => u,
-            None => {
-                return JsonRpcResponse::error(
-                    id,
-                    ErrorCode::InvalidParams,
-                    "missing 'uri' in resources/read params".to_string(),
-                );
-            }
+        let Some(uri) = uri else {
+            return JsonRpcResponse::error(
+                id,
+                ErrorCode::InvalidParams,
+                "missing 'uri' in resources/read params".to_string(),
+            );
         };
 
         match uri {
@@ -523,7 +519,7 @@ impl McpServer {
             _ => JsonRpcResponse::error(
                 id,
                 ErrorCode::InvalidParams,
-                format!("unknown resource URI: {}", uri),
+                format!("unknown resource URI: {uri}"),
             ),
         }
     }
@@ -547,7 +543,7 @@ impl McpServer {
             Err(e) => JsonRpcResponse::error(
                 id,
                 ErrorCode::InternalError,
-                format!("failed to read graph stats: {}", e),
+                format!("failed to read graph stats: {e}"),
             ),
         }
     }
@@ -560,12 +556,8 @@ impl McpServer {
                 let mut groups: std::collections::BTreeMap<String, Vec<String>> =
                     std::collections::BTreeMap::new();
                 for f in &files {
-                    let dir = f
-                        .path
-                        .rfind('/')
-                        .map(|i| &f.path[..i])
-                        .unwrap_or(".")
-                        .to_string();
+                    let dir = f.path.rfind('/').map_or(".", |i| &f.path[..i]).to_string();
+                    #[allow(clippy::map_unwrap_or)]
                     let name = f
                         .path
                         .rfind('/')
@@ -581,7 +573,7 @@ impl McpServer {
                 for (dir, entries) in &groups {
                     lines.push(format!("\n{}/ ({} files)", dir, entries.len()));
                     for entry in entries {
-                        lines.push(format!("  {}", entry));
+                        lines.push(format!("  {entry}"));
                     }
                 }
                 let text = lines.join("\n");
@@ -599,7 +591,7 @@ impl McpServer {
             Err(e) => JsonRpcResponse::error(
                 id,
                 ErrorCode::InternalError,
-                format!("failed to read file list: {}", e),
+                format!("failed to read file list: {e}"),
             ),
         }
     }
@@ -612,7 +604,7 @@ impl McpServer {
                 return JsonRpcResponse::error(
                     id,
                     ErrorCode::InternalError,
-                    format!("failed to read graph stats: {}", e),
+                    format!("failed to read graph stats: {e}"),
                 );
             }
         };
@@ -630,7 +622,7 @@ impl McpServer {
             let mut langs: Vec<_> = stats.files_by_language.iter().collect();
             langs.sort_by(|a, b| b.1.cmp(a.1));
             for (lang, count) in &langs {
-                lines.push(format!("  {} ({} files)", lang, count));
+                lines.push(format!("  {lang} ({count} files)"));
             }
         }
 
@@ -640,7 +632,7 @@ impl McpServer {
             let mut kinds: Vec<_> = stats.nodes_by_kind.iter().collect();
             kinds.sort_by(|a, b| b.1.cmp(a.1));
             for (kind, count) in kinds.iter().take(10) {
-                lines.push(format!("  {} ({})", kind, count));
+                lines.push(format!("  {kind} ({count})"));
             }
         }
 
@@ -667,7 +659,7 @@ impl McpServer {
                 .iter()
                 .map(|(name, entry)| {
                     let db_path = tokensave_dir.join(&entry.db_file);
-                    let size_bytes = db_path.metadata().map(|m| m.len()).unwrap_or(0);
+                    let size_bytes = db_path.metadata().map_or(0, |m| m.len());
                     json!({
                         "name": name,
                         "db_file": entry.db_file,
@@ -700,37 +692,31 @@ impl McpServer {
     }
 
     /// Handles the `tools/call` method, dispatching to the appropriate tool handler.
-    async fn handle_tools_call(&self, id: Value, params: &Option<Value>) -> JsonRpcResponse {
+    async fn handle_tools_call(&self, id: Value, params: Option<&Value>) -> JsonRpcResponse {
         debug_assert!(
             !id.is_null(),
             "handle_tools_call called with null request id"
         );
-        let params = match params {
-            Some(p) => p,
-            None => {
-                return JsonRpcResponse::error(
-                    id,
-                    ErrorCode::InvalidParams,
-                    "missing params for tools/call".to_string(),
-                );
-            }
+        let Some(params) = params else {
+            return JsonRpcResponse::error(
+                id,
+                ErrorCode::InvalidParams,
+                "missing params for tools/call".to_string(),
+            );
         };
 
-        let tool_name = match params.get("name").and_then(|v| v.as_str()) {
-            Some(name) => name,
-            None => {
-                return JsonRpcResponse::error(
-                    id,
-                    ErrorCode::InvalidParams,
-                    "missing 'name' in tools/call params".to_string(),
-                );
-            }
+        let Some(tool_name) = params.get("name").and_then(|v| v.as_str()) else {
+            return JsonRpcResponse::error(
+                id,
+                ErrorCode::InvalidParams,
+                "missing 'name' in tools/call params".to_string(),
+            );
         };
 
         let arguments = params.get("arguments").cloned().unwrap_or(json!({}));
 
         self.stats.tool_calls.fetch_add(1, Ordering::Relaxed);
-        eprintln!("[tokensave] tool call: {}", tool_name);
+        eprintln!("[tokensave] tool call: {tool_name}");
         if let Ok(mut counts) = self.tool_call_counts.lock() {
             *counts.entry(tool_name.to_string()).or_insert(0) += 1;
         }
@@ -766,15 +752,14 @@ impl McpServer {
                     .value
                     .get("content")
                     .and_then(|c| c.as_array())
-                    .map(|arr| {
+                    .map_or(0, |arr| {
                         let total_chars: usize = arr
                             .iter()
                             .filter_map(|item| item.get("text").and_then(|t| t.as_str()))
-                            .map(|text| text.len())
+                            .map(str::len)
                             .sum();
                         (total_chars / 4) as u64
-                    })
-                    .unwrap_or(0);
+                    });
 
                 // Append per-call token savings to the response content.
                 if raw_file_tokens > 0 {
@@ -859,8 +844,7 @@ impl McpServer {
                             )
                         } else {
                             format!(
-                                "WARNING: Index last synced {}h {}m ago. Run `tokensave sync` to update.",
-                                hours, mins
+                                "WARNING: Index last synced {hours}h {mins}m ago. Run `tokensave sync` to update."
                             )
                         };
                         if let Some(content) = result
@@ -878,7 +862,7 @@ impl McpServer {
             Err(e) => JsonRpcResponse::error(
                 id,
                 ErrorCode::InternalError,
-                format!("tool execution failed: {}", e),
+                format!("tool execution failed: {e}"),
             ),
         }
     }

--- a/src/mcp/tools/definitions.rs
+++ b/src/mcp/tools/definitions.rs
@@ -54,19 +54,18 @@ pub fn explore_call_budget(total_nodes: u64) -> u8 {
     }
 }
 
-/// Generates the tokensave_context description with a dynamic call budget.
+/// Generates the `tokensave_context` description with a dynamic call budget.
 pub fn context_description(node_count: u64, budget: u8) -> String {
     format!(
         "Build an AI-ready context for a task description. Returns relevant symbols, \
          relationships, and optionally code snippets.\n\n\
-         CALL BUDGET: {} calls maximum for this project ({} nodes). \
-         Stop after {} calls. If the question is not fully answered, synthesise \
-         from what you have — do not exceed the budget.",
-        budget, node_count, budget
+         CALL BUDGET: {budget} calls maximum for this project ({node_count} nodes). \
+         Stop after {budget} calls. If the question is not fully answered, synthesise \
+         from what you have — do not exceed the budget."
     )
 }
 
-/// Returns tool definitions with a dynamic call budget for tokensave_context.
+/// Returns tool definitions with a dynamic call budget for `tokensave_context`.
 pub fn get_tool_definitions_with_budget(node_count: u64, budget: u8) -> Vec<ToolDefinition> {
     let mut defs = get_tool_definitions();
     // Replace the context tool's description with the budgeted version

--- a/src/mcp/tools/definitions.rs
+++ b/src/mcp/tools/definitions.rs
@@ -118,6 +118,10 @@ pub fn get_tool_definitions() -> Vec<ToolDefinition> {
         def_branch_search(),
         def_branch_diff(),
         def_branch_list(),
+        def_str_replace(),
+        def_multi_str_replace(),
+        def_insert_at(),
+        def_ast_grep_rewrite(),
     ];
     debug_assert!(
         !definitions.is_empty(),
@@ -961,6 +965,132 @@ fn def_branch_list() -> ToolDefinition {
             "properties": {}
         }),
     )
+}
+
+fn def_str_replace() -> ToolDefinition {
+    ToolDefinition {
+        name: "tokensave_str_replace".to_string(),
+        description: "Replace a unique string in a file with new content. Fails if the old string is not found or matches more than once. This is the safest edit primitive — use this instead of sed/awk.".to_string(),
+        input_schema: json!({
+            "type": "object",
+            "properties": {
+                "path": {
+                    "type": "string",
+                    "description": "Absolute or project-relative file path"
+                },
+                "old_str": {
+                    "type": "string",
+                    "description": "Exact string to find and replace. Must match exactly once in the file."
+                },
+                "new_str": {
+                    "type": "string",
+                    "description": "Replacement string"
+                }
+            },
+            "required": ["path", "old_str", "new_str"]
+        }),
+        annotations: Some(json!({
+            "readOnlyHint": false,
+            "title": "Edit File"
+        })),
+        meta: None,
+    }
+}
+
+fn def_multi_str_replace() -> ToolDefinition {
+    ToolDefinition {
+        name: "tokensave_multi_str_replace".to_string(),
+        description: "Apply multiple string replacements atomically in a single file. All replacements must match exactly once. If any replacement fails (0 or >1 matches), the entire operation is aborted and no changes are made.".to_string(),
+        input_schema: json!({
+            "type": "object",
+            "properties": {
+                "path": {
+                    "type": "string",
+                    "description": "Absolute or project-relative file path"
+                },
+                "replacements": {
+                    "type": "array",
+                    "description": "Array of [old_str, new_str] pairs to replace",
+                    "items": {
+                        "type": "array",
+                        "items": {"type": "string"},
+                        "minItems": 2,
+                        "maxItems": 2
+                    }
+                }
+            },
+            "required": ["path", "replacements"]
+        }),
+        annotations: Some(json!({
+            "readOnlyHint": false,
+            "title": "Multi-Edit File"
+        })),
+        meta: None,
+    }
+}
+
+fn def_insert_at() -> ToolDefinition {
+    ToolDefinition {
+        name: "tokensave_insert_at".to_string(),
+        description: "Insert content before or after a unique anchor in a file. The anchor can be a unique string or a 1-indexed line number. Fails if the anchor matches more than one line.".to_string(),
+        input_schema: json!({
+            "type": "object",
+            "properties": {
+                "path": {
+                    "type": "string",
+                    "description": "Absolute or project-relative file path"
+                },
+                "anchor": {
+                    "type": "string",
+                    "description": "Unique string or line number (1-indexed) to insert at"
+                },
+                "content": {
+                    "type": "string",
+                    "description": "Content to insert"
+                },
+                "before": {
+                    "type": "boolean",
+                    "description": "If true, insert before the anchor line; if false, insert after (default: false)"
+                }
+            },
+            "required": ["path", "anchor", "content"]
+        }),
+        annotations: Some(json!({
+            "readOnlyHint": false,
+            "title": "Insert Into File"
+        })),
+        meta: None,
+    }
+}
+
+fn def_ast_grep_rewrite() -> ToolDefinition {
+    ToolDefinition {
+        name: "tokensave_ast_grep_rewrite".to_string(),
+        description: "Perform structural code rewrite using ast-grep. The pattern and rewrite use ast-grep's SGPattern syntax. Fails if ast-grep is not installed.".to_string(),
+        input_schema: json!({
+            "type": "object",
+            "properties": {
+                "path": {
+                    "type": "string",
+                    "description": "Absolute or project-relative file path"
+                },
+                "pattern": {
+                    "type": "string",
+                    "description": "ast-grep search pattern (SGPattern syntax)"
+                },
+                "rewrite": {
+                    "type": "string",
+                    "description": "ast-grep rewrite rule"
+                }
+            },
+            "required": ["path", "pattern", "rewrite"]
+        }),
+        annotations: Some(json!({
+            "readOnlyHint": false,
+            "title": "AST Structural Rewrite"
+        })),
+        meta: None,
+    }
 }
 
 #[cfg(test)]

--- a/src/mcp/tools/handlers.rs
+++ b/src/mcp/tools/handlers.rs
@@ -5,6 +5,7 @@
 //! formats the result.
 
 use std::collections::{HashMap, HashSet};
+use std::fmt::Write as _;
 
 use serde_json::{json, Value};
 
@@ -116,13 +117,13 @@ pub async fn handle_tool_call(
         "tokensave_type_hierarchy" => handle_type_hierarchy(cg, args).await,
         "tokensave_branch_search" => handle_branch_search(cg, args).await,
         "tokensave_branch_diff" => handle_branch_diff(cg, args).await,
-        "tokensave_branch_list" => handle_branch_list(cg).await,
+        "tokensave_branch_list" => Ok(handle_branch_list(cg)),
         "tokensave_str_replace" => handle_str_replace(cg, args).await,
         "tokensave_multi_str_replace" => handle_multi_str_replace(cg, args).await,
         "tokensave_insert_at" => handle_insert_at(cg, args).await,
         "tokensave_ast_grep_rewrite" => handle_ast_grep_rewrite(cg, args).await,
         _ => Err(TokenSaveError::Config {
-            message: format!("unknown tool: {}", tool_name),
+            message: format!("unknown tool: {tool_name}"),
         }),
     }
 }
@@ -170,9 +171,8 @@ async fn handle_search(
 
     let limit = args
         .get("limit")
-        .and_then(|v| v.as_u64())
-        .map(|v| v.min(500) as usize)
-        .unwrap_or(10);
+        .and_then(serde_json::Value::as_u64)
+        .map_or(10, |v| v.min(500) as usize);
 
     let results = cg.search(query, limit).await?;
     let results = filter_by_scope(results, scope_prefix, |r| &r.node.file_path);
@@ -218,20 +218,18 @@ async fn handle_context(
 
     let max_nodes = args
         .get("max_nodes")
-        .and_then(|v| v.as_u64())
-        .map(|v| v.min(100) as usize)
-        .unwrap_or(20);
+        .and_then(serde_json::Value::as_u64)
+        .map_or(20, |v| v.min(100) as usize);
 
     let include_code = args
         .get("include_code")
-        .and_then(|v| v.as_bool())
+        .and_then(serde_json::Value::as_bool)
         .unwrap_or(false);
 
     let max_code_blocks = args
         .get("max_code_blocks")
-        .and_then(|v| v.as_u64())
-        .map(|v| v.min(20) as usize)
-        .unwrap_or(5);
+        .and_then(serde_json::Value::as_u64)
+        .map_or(5, |v| v.min(20) as usize);
 
     let mode = args
         .get("mode")
@@ -260,12 +258,12 @@ async fn handle_context(
 
     let merge_adjacent = args
         .get("merge_adjacent")
-        .and_then(|v| v.as_bool())
+        .and_then(serde_json::Value::as_bool)
         .unwrap_or(false);
 
     let max_per_file: Option<usize> = args
         .get("max_per_file")
-        .and_then(|v| v.as_u64())
+        .and_then(serde_json::Value::as_u64)
         .map(|v| v as usize)
         .or(Some((max_nodes / 3).max(3)));
 
@@ -273,8 +271,8 @@ async fn handle_context(
 
     let options = BuildContextOptions {
         max_nodes,
-        include_code,
         max_code_blocks,
+        include_code,
         extra_keywords,
         exclude_node_ids,
         merge_adjacent,
@@ -290,7 +288,12 @@ async fn handle_context(
             .nodes
             .iter()
             .map(|n| n.file_path.as_str())
-            .chain(context.related_files.iter().map(|s| s.as_str())),
+            .chain(
+                context
+                    .related_files
+                    .iter()
+                    .map(std::string::String::as_str),
+            ),
     );
     let mut output = format_context_as_markdown(&context);
 
@@ -307,14 +310,15 @@ async fn handle_context(
                     .iter()
                     .filter(|(_, e)| matches!(e.kind, crate::types::EdgeKind::Implements))
                     .count();
-                output.push_str(&format!(
-                    "- **{}** ({}) - {}:{} ({} implementors)\n",
+                let _ = writeln!(
+                    output,
+                    "- **{}** ({}) - {}:{} ({} implementors)",
                     node.name,
                     node.kind.as_str(),
                     node.file_path,
                     node.start_line,
                     impl_count,
-                ));
+                );
                 found_extension = true;
             }
         }
@@ -351,17 +355,18 @@ async fn handle_context(
                 let mut sorted: Vec<_> = test_files.into_iter().collect();
                 sorted.sort();
                 for tf in &sorted {
-                    output.push_str(&format!("- {}\n", tf));
+                    let _ = writeln!(output, "- {tf}");
                 }
             }
         }
     }
 
     if !context.seen_node_ids.is_empty() {
-        output.push_str(&format!(
+        let _ = write!(
+            output,
             "\nseen_node_ids: {}\n",
             serde_json::to_string(&context.seen_node_ids).unwrap_or_default()
-        ));
+        );
     }
 
     Ok(ToolResult {
@@ -378,9 +383,8 @@ async fn handle_callers(cg: &TokenSave, args: Value) -> Result<ToolResult> {
 
     let max_depth = args
         .get("max_depth")
-        .and_then(|v| v.as_u64())
-        .map(|v| v.min(10) as usize)
-        .unwrap_or(3);
+        .and_then(serde_json::Value::as_u64)
+        .map_or(3, |v| v.min(10) as usize);
 
     let results = cg.get_callers(node_id, max_depth).await?;
 
@@ -415,9 +419,8 @@ async fn handle_callees(cg: &TokenSave, args: Value) -> Result<ToolResult> {
 
     let max_depth = args
         .get("max_depth")
-        .and_then(|v| v.as_u64())
-        .map(|v| v.min(10) as usize)
-        .unwrap_or(3);
+        .and_then(serde_json::Value::as_u64)
+        .map_or(3, |v| v.min(10) as usize);
 
     let results = cg.get_callees(node_id, max_depth).await?;
 
@@ -452,9 +455,8 @@ async fn handle_impact(cg: &TokenSave, args: Value) -> Result<ToolResult> {
 
     let max_depth = args
         .get("max_depth")
-        .and_then(|v| v.as_u64())
-        .map(|v| v.min(10) as usize)
-        .unwrap_or(3);
+        .and_then(serde_json::Value::as_u64)
+        .map_or(3, |v| v.min(10) as usize);
 
     let subgraph = cg.get_impact_radius(node_id, max_depth).await?;
 
@@ -613,7 +615,7 @@ async fn handle_files(
         let prefix = if dir.ends_with('/') {
             dir.to_string()
         } else {
-            format!("{}/", dir)
+            format!("{dir}/")
         };
         files.retain(|f| f.path.starts_with(&prefix) || f.path == dir);
     }
@@ -644,12 +646,8 @@ async fn handle_files(
         let mut groups: std::collections::BTreeMap<String, Vec<String>> =
             std::collections::BTreeMap::new();
         for f in &files {
-            let dir = f
-                .path
-                .rfind('/')
-                .map(|i| &f.path[..i])
-                .unwrap_or(".")
-                .to_string();
+            let dir = f.path.rfind('/').map_or(".", |i| &f.path[..i]).to_string();
+            #[allow(clippy::map_unwrap_or)]
             let name = f
                 .path
                 .rfind('/')
@@ -665,7 +663,7 @@ async fn handle_files(
         for (dir, entries) in &groups {
             lines.push(format!("\n{}/ ({} files)", dir, entries.len()));
             for entry in entries {
-                lines.push(format!("  {}", entry));
+                lines.push(format!("  {entry}"));
             }
         }
         lines.join("\n")
@@ -686,7 +684,7 @@ async fn handle_affected(cg: &TokenSave, args: Value) -> Result<ToolResult> {
         .and_then(|v| v.as_array())
         .map(|arr| {
             arr.iter()
-                .filter_map(|v| v.as_str().map(|s| s.to_string()))
+                .filter_map(|v| v.as_str().map(std::string::ToString::to_string))
                 .collect()
         })
         .ok_or_else(|| TokenSaveError::Config {
@@ -695,9 +693,8 @@ async fn handle_affected(cg: &TokenSave, args: Value) -> Result<ToolResult> {
 
     let max_depth = args
         .get("depth")
-        .and_then(|v| v.as_u64())
-        .map(|v| v.min(10) as usize)
-        .unwrap_or(5);
+        .and_then(serde_json::Value::as_u64)
+        .map_or(5, |v| v.min(10) as usize);
 
     let custom_filter = args.get("filter").and_then(|v| v.as_str());
     let custom_glob = custom_filter.and_then(|p| glob::Pattern::new(p).ok());
@@ -765,15 +762,14 @@ async fn handle_dead_code(
     args: Value,
     scope_prefix: Option<&str>,
 ) -> Result<ToolResult> {
-    let kinds: Vec<NodeKind> = args
-        .get("kinds")
-        .and_then(|v| v.as_array())
-        .map(|arr| {
+    let kinds: Vec<NodeKind> = args.get("kinds").and_then(|v| v.as_array()).map_or_else(
+        || vec![NodeKind::Function, NodeKind::Method],
+        |arr| {
             arr.iter()
                 .filter_map(|v| v.as_str().and_then(NodeKind::from_str))
                 .collect()
-        })
-        .unwrap_or_else(|| vec![NodeKind::Function, NodeKind::Method]);
+        },
+    );
 
     let dead = cg.find_dead_code(&kinds).await?;
     let dead = filter_by_scope(dead, scope_prefix, |n| &n.file_path);
@@ -819,7 +815,7 @@ async fn handle_diff_context(cg: &TokenSave, args: Value) -> Result<ToolResult> 
         .and_then(|v| v.as_array())
         .map(|arr| {
             arr.iter()
-                .filter_map(|v| v.as_str().map(|s| s.to_string()))
+                .filter_map(|v| v.as_str().map(std::string::ToString::to_string))
                 .collect()
         })
         .ok_or_else(|| TokenSaveError::Config {
@@ -828,9 +824,8 @@ async fn handle_diff_context(cg: &TokenSave, args: Value) -> Result<ToolResult> 
 
     let depth = args
         .get("depth")
-        .and_then(|v| v.as_u64())
-        .map(|v| v.min(10) as usize)
-        .unwrap_or(2);
+        .and_then(serde_json::Value::as_u64)
+        .map_or(2, |v| v.min(10) as usize);
 
     let mut modified_symbols: Vec<Value> = Vec::new();
     let mut impacted_symbols: Vec<Value> = Vec::new();
@@ -902,8 +897,8 @@ async fn handle_diff_context(cg: &TokenSave, args: Value) -> Result<ToolResult> 
     let touched_files = unique_file_paths(
         all_touched_files
             .iter()
-            .map(|s| s.as_str())
-            .chain(files.iter().map(|s| s.as_str())),
+            .map(std::string::String::as_str)
+            .chain(files.iter().map(std::string::String::as_str)),
     );
 
     let output = json!({
@@ -939,7 +934,7 @@ async fn handle_module_api(
     let prefix = if path.ends_with('/') {
         path.to_string()
     } else {
-        format!("{}/", path)
+        format!("{path}/")
     };
 
     let mut pub_nodes: Vec<&crate::types::Node> = all_nodes
@@ -1015,9 +1010,8 @@ async fn handle_hotspots(
 ) -> Result<ToolResult> {
     let limit = args
         .get("limit")
-        .and_then(|v| v.as_u64())
-        .map(|v| v.min(100) as usize)
-        .unwrap_or(10);
+        .and_then(serde_json::Value::as_u64)
+        .map_or(10, |v| v.min(100) as usize);
     debug_assert!(limit > 0, "handle_hotspots limit must be positive");
 
     let all_edges = cg.get_all_edges().await?;
@@ -1070,7 +1064,7 @@ async fn handle_hotspots(
         touched.retain(|f| f.starts_with(&with_slash) || f == prefix);
     }
 
-    let touched_files = unique_file_paths(touched.iter().map(|s| s.as_str()));
+    let touched_files = unique_file_paths(touched.iter().map(std::string::String::as_str));
 
     let output = json!({
         "hotspot_count": items.len(),
@@ -1101,9 +1095,8 @@ async fn handle_similar(cg: &TokenSave, args: Value) -> Result<ToolResult> {
 
     let limit = args
         .get("limit")
-        .and_then(|v| v.as_u64())
-        .map(|v| v.min(100) as usize)
-        .unwrap_or(10);
+        .and_then(serde_json::Value::as_u64)
+        .map_or(10, |v| v.min(100) as usize);
 
     // Use FTS search first
     let mut results = cg.search(symbol, limit).await?;
@@ -1228,7 +1221,7 @@ async fn handle_rename_preview(cg: &TokenSave, args: Value) -> Result<ToolResult
         }
     }
 
-    let touched_files = unique_file_paths(touched.iter().map(|s| s.as_str()));
+    let touched_files = unique_file_paths(touched.iter().map(std::string::String::as_str));
 
     let output = json!({
         "node": node_info,
@@ -1296,7 +1289,7 @@ async fn handle_unused_imports(
         }
     }
 
-    let touched_files = unique_file_paths(touched.iter().map(|s| s.as_str()));
+    let touched_files = unique_file_paths(touched.iter().map(std::string::String::as_str));
 
     let output = json!({
         "unused_import_count": unused.len(),
@@ -1318,8 +1311,8 @@ async fn handle_rank(
     args: Value,
     scope_prefix: Option<&str>,
 ) -> Result<ToolResult> {
-    debug_assert!(args.is_object(), "handle_rank expects an object argument");
     use crate::types::EdgeKind;
+    debug_assert!(args.is_object(), "handle_rank expects an object argument");
 
     let edge_kind_str = args
         .get("edge_kind")
@@ -1330,8 +1323,7 @@ async fn handle_rank(
 
     let edge_kind = EdgeKind::from_str(edge_kind_str).ok_or_else(|| TokenSaveError::Config {
         message: format!(
-            "invalid edge_kind '{}'. Valid values: implements, extends, calls, uses, contains, annotates, derives_macro",
-            edge_kind_str
+            "invalid edge_kind '{edge_kind_str}'. Valid values: implements, extends, calls, uses, contains, annotates, derives_macro"
         ),
     })?;
 
@@ -1346,8 +1338,7 @@ async fn handle_rank(
         _ => {
             return Err(TokenSaveError::Config {
                 message: format!(
-                    "invalid direction '{}'. Valid values: incoming, outgoing",
-                    direction
+                    "invalid direction '{direction}'. Valid values: incoming, outgoing"
                 ),
             });
         }
@@ -1360,9 +1351,8 @@ async fn handle_rank(
 
     let limit = args
         .get("limit")
-        .and_then(|v| v.as_u64())
-        .map(|v| v.min(100) as usize)
-        .unwrap_or(10);
+        .and_then(serde_json::Value::as_u64)
+        .map_or(10, |v| v.min(100) as usize);
 
     let path_prefix = effective_path(&args, scope_prefix);
 
@@ -1416,9 +1406,8 @@ async fn handle_largest(
 
     let limit = args
         .get("limit")
-        .and_then(|v| v.as_u64())
-        .map(|v| v.min(100) as usize)
-        .unwrap_or(10);
+        .and_then(serde_json::Value::as_u64)
+        .map_or(10, |v| v.min(100) as usize);
 
     let path_prefix = effective_path(&args, scope_prefix);
 
@@ -1474,19 +1463,15 @@ async fn handle_coupling(
         "fan_out" => false,
         _ => {
             return Err(TokenSaveError::Config {
-                message: format!(
-                    "invalid direction '{}'. Valid values: fan_in, fan_out",
-                    direction
-                ),
+                message: format!("invalid direction '{direction}'. Valid values: fan_in, fan_out"),
             });
         }
     };
 
     let limit = args
         .get("limit")
-        .and_then(|v| v.as_u64())
-        .map(|v| v.min(100) as usize)
-        .unwrap_or(10);
+        .and_then(serde_json::Value::as_u64)
+        .map_or(10, |v| v.min(100) as usize);
 
     let path_prefix = effective_path(&args, scope_prefix);
 
@@ -1525,9 +1510,8 @@ async fn handle_inheritance_depth(
 ) -> Result<ToolResult> {
     let limit = args
         .get("limit")
-        .and_then(|v| v.as_u64())
-        .map(|v| v.min(100) as usize)
-        .unwrap_or(10);
+        .and_then(serde_json::Value::as_u64)
+        .map_or(10, |v| v.min(100) as usize);
 
     let path_prefix = effective_path(&args, scope_prefix);
 
@@ -1576,7 +1560,7 @@ async fn handle_distribution(
     let path_prefix = effective_path(&args, scope_prefix);
     let summary = args
         .get("summary")
-        .and_then(|v| v.as_bool())
+        .and_then(serde_json::Value::as_bool)
         .unwrap_or(false);
 
     let results = cg.get_node_distribution(path_prefix).await?;
@@ -1607,7 +1591,7 @@ async fn handle_distribution(
         let mut current_file = String::new();
         for (file, kind, count) in &results {
             if *file != current_file {
-                current_file = file.clone();
+                current_file.clone_from(file);
                 by_file.push((file.clone(), Vec::new()));
             }
             if let Some(last) = by_file.last_mut() {
@@ -1648,9 +1632,8 @@ async fn handle_recursion(
 ) -> Result<ToolResult> {
     let limit = args
         .get("limit")
-        .and_then(|v| v.as_u64())
-        .map(|v| v.min(100) as usize)
-        .unwrap_or(10);
+        .and_then(serde_json::Value::as_u64)
+        .map_or(10, |v| v.min(100) as usize);
     let path_prefix = effective_path(&args, scope_prefix);
 
     debug_assert!(limit > 0, "handle_recursion limit must be positive");
@@ -1752,7 +1735,7 @@ async fn handle_recursion(
         }));
     }
 
-    let touched_files = unique_file_paths(touched.iter().map(|s| s.as_str()));
+    let touched_files = unique_file_paths(touched.iter().map(std::string::String::as_str));
 
     let output = json!({
         "cycle_count": cycle_items.len(),
@@ -1781,9 +1764,8 @@ async fn handle_complexity(
 
     let limit = args
         .get("limit")
-        .and_then(|v| v.as_u64())
-        .map(|v| v.min(100) as usize)
-        .unwrap_or(10);
+        .and_then(serde_json::Value::as_u64)
+        .map_or(10, |v| v.min(100) as usize);
 
     let path_prefix = effective_path(&args, scope_prefix);
 
@@ -1845,9 +1827,8 @@ async fn handle_doc_coverage(
 
     let limit = args
         .get("limit")
-        .and_then(|v| v.as_u64())
-        .map(|v| v.min(500) as usize)
-        .unwrap_or(50);
+        .and_then(serde_json::Value::as_u64)
+        .map_or(50, |v| v.min(500) as usize);
 
     let results = cg
         .get_undocumented_public_symbols(path_prefix, limit)
@@ -1906,9 +1887,8 @@ async fn handle_god_class(
 ) -> Result<ToolResult> {
     let limit = args
         .get("limit")
-        .and_then(|v| v.as_u64())
-        .map(|v| v.min(100) as usize)
-        .unwrap_or(10);
+        .and_then(serde_json::Value::as_u64)
+        .map_or(10, |v| v.min(100) as usize);
 
     let path_prefix = effective_path(&args, scope_prefix);
 
@@ -2088,15 +2068,19 @@ async fn handle_port_status(cg: &TokenSave, args: Value) -> Result<ToolResult> {
             message: "missing required parameter: target_dir".to_string(),
         })?;
 
-    let kind_strs: Vec<String> = args
-        .get("kinds")
-        .and_then(|v| v.as_array())
-        .map(|arr| {
-            arr.iter()
-                .filter_map(|v| v.as_str().map(|s| s.to_string()))
+    let kind_strs: Vec<String> = args.get("kinds").and_then(|v| v.as_array()).map_or_else(
+        || {
+            PORT_DEFAULT_KINDS
+                .iter()
+                .map(std::string::ToString::to_string)
                 .collect()
-        })
-        .unwrap_or_else(|| PORT_DEFAULT_KINDS.iter().map(|s| s.to_string()).collect());
+        },
+        |arr| {
+            arr.iter()
+                .filter_map(|v| v.as_str().map(std::string::ToString::to_string))
+                .collect()
+        },
+    );
 
     let kinds: Vec<NodeKind> = kind_strs
         .iter()
@@ -2224,21 +2208,24 @@ async fn handle_port_order(cg: &TokenSave, args: Value) -> Result<ToolResult> {
             message: "missing required parameter: source_dir".to_string(),
         })?;
 
-    let kind_strs: Vec<String> = args
-        .get("kinds")
-        .and_then(|v| v.as_array())
-        .map(|arr| {
-            arr.iter()
-                .filter_map(|v| v.as_str().map(|s| s.to_string()))
+    let kind_strs: Vec<String> = args.get("kinds").and_then(|v| v.as_array()).map_or_else(
+        || {
+            PORT_DEFAULT_KINDS
+                .iter()
+                .map(std::string::ToString::to_string)
                 .collect()
-        })
-        .unwrap_or_else(|| PORT_DEFAULT_KINDS.iter().map(|s| s.to_string()).collect());
+        },
+        |arr| {
+            arr.iter()
+                .filter_map(|v| v.as_str().map(std::string::ToString::to_string))
+                .collect()
+        },
+    );
 
     let limit = args
         .get("limit")
-        .and_then(|v| v.as_u64())
-        .map(|v| v.min(500) as usize)
-        .unwrap_or(50);
+        .and_then(serde_json::Value::as_u64)
+        .map_or(50, |v| v.min(500) as usize);
 
     let kinds: Vec<NodeKind> = kind_strs
         .iter()
@@ -2278,7 +2265,7 @@ async fn handle_port_order(cg: &TokenSave, args: Value) -> Result<ToolResult> {
     let node_ids: Vec<String> = nodes.iter().map(|n| n.id.clone()).collect();
     let node_map: HashMap<&str, &crate::types::Node> =
         nodes.iter().map(|n| (n.id.as_str(), n)).collect();
-    let id_set: HashSet<&str> = node_ids.iter().map(|s| s.as_str()).collect();
+    let id_set: HashSet<&str> = node_ids.iter().map(std::string::String::as_str).collect();
 
     // Get internal edges (dependency edges between these nodes)
     let edges = cg.get_internal_edges(&node_ids).await?;
@@ -2391,7 +2378,7 @@ async fn handle_port_order(cg: &TokenSave, args: Value) -> Result<ToolResult> {
     // Detect cycles: any unsorted nodes form cycles
     let cycle_node_ids: Vec<&str> = node_ids
         .iter()
-        .map(|s| s.as_str())
+        .map(std::string::String::as_str)
         .filter(|id| !sorted_set.contains(id))
         .collect();
 
@@ -2639,7 +2626,7 @@ fn git_recent_commits(
             .to_string();
         commits.push(subject);
 
-        let parent_id = commit.parent_ids().next().map(|id| id.detach());
+        let parent_id = commit.parent_ids().next().map(gix::Id::detach);
         match parent_id {
             Some(pid) => current_id = pid,
             None => break,
@@ -2692,7 +2679,7 @@ fn git_commit_log(
         let short_id = format!("{:.7}", commit.id);
         commits.push(json!({"hash": short_id, "subject": subject}));
 
-        let parent_id = commit.parent_ids().next().map(|id| id.detach());
+        let parent_id = commit.parent_ids().next().map(gix::Id::detach);
         match parent_id {
             Some(pid) => current_id = pid,
             None => break,
@@ -2708,22 +2695,19 @@ fn classify_file_role(path: &str) -> &'static str {
         return "test";
     }
     let lower = path.to_lowercase();
+    let ext = std::path::Path::new(&lower)
+        .extension()
+        .and_then(|e| e.to_str());
     // Config files
-    if lower.ends_with(".toml")
-        || lower.ends_with(".yaml")
-        || lower.ends_with(".yml")
-        || lower.ends_with(".json")
-        || lower.ends_with(".lock")
-        || lower.ends_with(".ini")
-        || lower.ends_with(".cfg")
-        || lower.contains("config")
+    if matches!(
+        ext,
+        Some("toml" | "yaml" | "yml" | "json" | "lock" | "ini" | "cfg")
+    ) || lower.contains("config")
     {
         return "config";
     }
     // Documentation
-    if lower.ends_with(".md")
-        || lower.ends_with(".rst")
-        || lower.ends_with(".txt")
+    if matches!(ext, Some("md" | "rst" | "txt"))
         || lower.starts_with("docs/")
         || lower.starts_with("doc/")
     {
@@ -2736,7 +2720,7 @@ fn classify_file_role(path: &str) -> &'static str {
 async fn handle_commit_context(cg: &TokenSave, args: Value) -> Result<ToolResult> {
     let staged_only = args
         .get("staged_only")
-        .and_then(|v| v.as_bool())
+        .and_then(serde_json::Value::as_bool)
         .unwrap_or(false);
 
     let changed_files = match git_changed_files(cg.project_root(), staged_only) {
@@ -2785,7 +2769,7 @@ async fn handle_commit_context(cg: &TokenSave, args: Value) -> Result<ToolResult
 
     let recent_commits = git_recent_commits(cg.project_root(), 5).unwrap_or_default();
 
-    let total_symbols: usize = symbols_by_role.values().map(|v| v.len()).sum();
+    let total_symbols: usize = symbols_by_role.values().map(std::vec::Vec::len).sum();
     let output = json!({
         "changed_files": file_roles,
         "symbols_by_role": symbols_by_role,
@@ -2855,6 +2839,7 @@ async fn handle_pr_context(cg: &TokenSave, args: Value) -> Result<ToolResult> {
                 // Track impacted modules
                 for (caller, _) in &callers {
                     if !changed_files.contains(&caller.file_path) {
+                        #[allow(clippy::map_unwrap_or)]
                         let dir = caller
                             .file_path
                             .rfind('/')
@@ -3117,15 +3102,14 @@ async fn handle_type_hierarchy(cg: &TokenSave, args: Value) -> Result<ToolResult
     let node_id = require_node_id(&args)?;
     let max_depth = args
         .get("max_depth")
-        .and_then(|v| v.as_u64())
-        .map(|v| v.min(10) as usize)
-        .unwrap_or(5);
+        .and_then(serde_json::Value::as_u64)
+        .map_or(5, |v| v.min(10) as usize);
 
     let root = cg
         .get_node(node_id)
         .await?
         .ok_or_else(|| TokenSaveError::Config {
-            message: format!("node not found: {}", node_id),
+            message: format!("node not found: {node_id}"),
         })?;
 
     let mut output = format!(
@@ -3140,7 +3124,7 @@ async fn handle_type_hierarchy(cg: &TokenSave, args: Value) -> Result<ToolResult
     // Recursively build the hierarchy
     build_type_tree(cg, &root.id, max_depth, 0, &mut output, &mut all_files).await;
 
-    let touched_files = unique_file_paths(all_files.iter().map(|s| s.as_str()));
+    let touched_files = unique_file_paths(all_files.iter().map(std::string::String::as_str));
     Ok(ToolResult {
         value: json!({"content": [{"type": "text", "text": truncate_response(&output)}]}),
         touched_files,
@@ -3172,15 +3156,16 @@ fn build_type_tree<'a>(
                 continue;
             }
             if let Ok(Some(child)) = cg.get_node(&edge.source).await {
-                output.push_str(&format!(
-                    "{}|- {} {} ({}) -- {}:{}\n",
+                let _ = writeln!(
+                    output,
+                    "{}|- {} {} ({}) -- {}:{}",
                     pad,
                     edge.kind.as_str(),
                     child.name,
                     child.kind.as_str(),
                     child.file_path,
                     child.start_line,
-                ));
+                );
                 all_files.push(child.file_path.clone());
                 build_type_tree(cg, &child.id, max_depth, depth + 1, output, all_files).await;
             }
@@ -3191,7 +3176,7 @@ fn build_type_tree<'a>(
 // ── Cross-branch tools ─────────────────────────────────────────────────
 
 /// Handles `tokensave_branch_list` tool calls.
-async fn handle_branch_list(cg: &TokenSave) -> Result<ToolResult> {
+fn handle_branch_list(cg: &TokenSave) -> ToolResult {
     let tokensave_dir = crate::config::get_tokensave_dir(cg.project_root());
     let current = cg.active_branch();
 
@@ -3202,7 +3187,7 @@ async fn handle_branch_list(cg: &TokenSave) -> Result<ToolResult> {
             .iter()
             .map(|(name, entry)| {
                 let db_path = tokensave_dir.join(&entry.db_file);
-                let size_bytes = db_path.metadata().map(|m| m.len()).unwrap_or(0);
+                let size_bytes = db_path.metadata().map_or(0, |m| m.len());
                 json!({
                     "name": name,
                     "parent": entry.parent,
@@ -3223,12 +3208,12 @@ async fn handle_branch_list(cg: &TokenSave) -> Result<ToolResult> {
     });
 
     let output = serde_json::to_string_pretty(&result).unwrap_or_default();
-    Ok(ToolResult {
+    ToolResult {
         value: json!({
             "content": [{ "type": "text", "text": truncate_response(&output) }]
         }),
         touched_files: vec![],
-    })
+    }
 }
 
 /// Handles `tokensave_branch_search` tool calls.
@@ -3247,9 +3232,8 @@ async fn handle_branch_search(cg: &TokenSave, args: Value) -> Result<ToolResult>
             })?;
     let limit = args
         .get("limit")
-        .and_then(|v| v.as_u64())
-        .map(|v| v.min(500) as usize)
-        .unwrap_or(10);
+        .and_then(serde_json::Value::as_u64)
+        .map_or(10, |v| v.min(500) as usize);
 
     let branch_cg = TokenSave::open_branch(cg.project_root(), branch).await?;
     let results = branch_cg.search(query, limit).await?;
@@ -3442,7 +3426,7 @@ async fn handle_branch_diff(cg: &TokenSave, args: Value) -> Result<ToolResult> {
     });
 
     let output = serde_json::to_string_pretty(&result).unwrap_or_default();
-    let touched_files = unique_file_paths(touched.iter().map(|s| s.as_str()));
+    let touched_files = unique_file_paths(touched.iter().map(std::string::String::as_str));
     Ok(ToolResult {
         value: json!({
             "content": [{ "type": "text", "text": truncate_response(&output) }]
@@ -3551,7 +3535,7 @@ async fn handle_insert_at(cg: &TokenSave, args: Value) -> Result<ToolResult> {
 
     let before = args
         .get("before")
-        .and_then(|v| v.as_bool())
+        .and_then(serde_json::Value::as_bool)
         .unwrap_or(false);
 
     let result = cg.insert_at(path, anchor, content, before).await?;

--- a/src/mcp/tools/handlers.rs
+++ b/src/mcp/tools/handlers.rs
@@ -3535,12 +3535,12 @@ async fn handle_insert_at(cg: &TokenSave, args: Value) -> Result<ToolResult> {
             message: "missing required parameter: path".to_string(),
         })?;
 
-    let anchor = args
-        .get("anchor")
-        .and_then(|v| v.as_str())
-        .ok_or_else(|| TokenSaveError::Config {
-            message: "missing required parameter: anchor".to_string(),
-        })?;
+    let anchor =
+        args.get("anchor")
+            .and_then(|v| v.as_str())
+            .ok_or_else(|| TokenSaveError::Config {
+                message: "missing required parameter: anchor".to_string(),
+            })?;
 
     let content = args
         .get("content")

--- a/src/mcp/tools/handlers.rs
+++ b/src/mcp/tools/handlers.rs
@@ -117,6 +117,10 @@ pub async fn handle_tool_call(
         "tokensave_branch_search" => handle_branch_search(cg, args).await,
         "tokensave_branch_diff" => handle_branch_diff(cg, args).await,
         "tokensave_branch_list" => handle_branch_list(cg).await,
+        "tokensave_str_replace" => handle_str_replace(cg, args).await,
+        "tokensave_multi_str_replace" => handle_multi_str_replace(cg, args).await,
+        "tokensave_insert_at" => handle_insert_at(cg, args).await,
+        "tokensave_ast_grep_rewrite" => handle_ast_grep_rewrite(cg, args).await,
         _ => Err(TokenSaveError::Config {
             message: format!("unknown tool: {}", tool_name),
         }),
@@ -3447,6 +3451,155 @@ async fn handle_branch_diff(cg: &TokenSave, args: Value) -> Result<ToolResult> {
     })
 }
 
+async fn handle_str_replace(cg: &TokenSave, args: Value) -> Result<ToolResult> {
+    let path = args
+        .get("path")
+        .and_then(|v| v.as_str())
+        .ok_or_else(|| TokenSaveError::Config {
+            message: "missing required parameter: path".to_string(),
+        })?;
+
+    let old_str = args
+        .get("old_str")
+        .and_then(|v| v.as_str())
+        .ok_or_else(|| TokenSaveError::Config {
+            message: "missing required parameter: old_str".to_string(),
+        })?;
+
+    let new_str = args
+        .get("new_str")
+        .and_then(|v| v.as_str())
+        .ok_or_else(|| TokenSaveError::Config {
+            message: "missing required parameter: new_str".to_string(),
+        })?;
+
+    let result = cg.str_replace(path, old_str, new_str).await?;
+    let touched_files = vec![result.file_path.clone()];
+    Ok(ToolResult {
+        value: json!({
+            "content": [{ "type": "text", "text": serde_json::to_string_pretty(&result).unwrap_or_default() }]
+        }),
+        touched_files,
+    })
+}
+
+async fn handle_multi_str_replace(cg: &TokenSave, args: Value) -> Result<ToolResult> {
+    let path = args
+        .get("path")
+        .and_then(|v| v.as_str())
+        .ok_or_else(|| TokenSaveError::Config {
+            message: "missing required parameter: path".to_string(),
+        })?;
+
+    let replacements = args
+        .get("replacements")
+        .and_then(|v| v.as_array())
+        .ok_or_else(|| TokenSaveError::Config {
+            message: "missing required parameter: replacements".to_string(),
+        })?;
+
+    let parsed_replacements: Vec<(&str, &str)> = replacements
+        .iter()
+        .filter_map(|pair| {
+            let arr = pair.as_array()?;
+            if arr.len() != 2 {
+                return None;
+            }
+            let old = arr[0].as_str()?;
+            let new = arr[1].as_str()?;
+            Some((old, new))
+        })
+        .collect();
+
+    if parsed_replacements.len() != replacements.len() {
+        return Err(TokenSaveError::Config {
+            message: "each replacement must be an array of exactly 2 strings".to_string(),
+        });
+    }
+
+    let result = cg.multi_str_replace(path, &parsed_replacements).await?;
+    let touched_files = vec![result.file_path.clone()];
+    Ok(ToolResult {
+        value: json!({
+            "content": [{ "type": "text", "text": serde_json::to_string_pretty(&result).unwrap_or_default() }]
+        }),
+        touched_files,
+    })
+}
+
+async fn handle_insert_at(cg: &TokenSave, args: Value) -> Result<ToolResult> {
+    let path = args
+        .get("path")
+        .and_then(|v| v.as_str())
+        .ok_or_else(|| TokenSaveError::Config {
+            message: "missing required parameter: path".to_string(),
+        })?;
+
+    let anchor = args
+        .get("anchor")
+        .and_then(|v| v.as_str())
+        .ok_or_else(|| TokenSaveError::Config {
+            message: "missing required parameter: anchor".to_string(),
+        })?;
+
+    let content = args
+        .get("content")
+        .and_then(|v| v.as_str())
+        .ok_or_else(|| TokenSaveError::Config {
+            message: "missing required parameter: content".to_string(),
+        })?;
+
+    let before = args
+        .get("before")
+        .and_then(|v| v.as_bool())
+        .unwrap_or(false);
+
+    let result = cg.insert_at(path, anchor, content, before).await?;
+    let touched_files = vec![result.file_path.clone()];
+    Ok(ToolResult {
+        value: json!({
+            "content": [{ "type": "text", "text": serde_json::to_string_pretty(&result).unwrap_or_default() }]
+        }),
+        touched_files,
+    })
+}
+
+async fn handle_ast_grep_rewrite(cg: &TokenSave, args: Value) -> Result<ToolResult> {
+    let path = args
+        .get("path")
+        .and_then(|v| v.as_str())
+        .ok_or_else(|| TokenSaveError::Config {
+            message: "missing required parameter: path".to_string(),
+        })?;
+
+    let pattern = args
+        .get("pattern")
+        .and_then(|v| v.as_str())
+        .ok_or_else(|| TokenSaveError::Config {
+            message: "missing required parameter: pattern".to_string(),
+        })?;
+
+    let rewrite = args
+        .get("rewrite")
+        .and_then(|v| v.as_str())
+        .ok_or_else(|| TokenSaveError::Config {
+            message: "missing required parameter: rewrite".to_string(),
+        })?;
+
+    let result = cg.ast_grep_rewrite(path, pattern, rewrite).await?;
+    let touched_files = if result.success {
+        vec![result.file_path.clone()]
+    } else {
+        vec![]
+    };
+    Ok(ToolResult {
+        value: json!({
+            "content": [{ "type": "text", "text": serde_json::to_string_pretty(&result).unwrap_or_default() }]
+        }),
+        touched_files,
+    })
+}
+
 #[cfg(test)]
 #[allow(clippy::unwrap_used, clippy::expect_used)]
 mod tests {
@@ -3456,7 +3609,7 @@ mod tests {
     #[test]
     fn test_tool_definitions_complete() {
         let tools = get_tool_definitions();
-        assert_eq!(tools.len(), 37);
+        assert_eq!(tools.len(), 41);
 
         let tool_names: Vec<&str> = tools.iter().map(|t| t.name.as_str()).collect();
         assert!(tool_names.contains(&"tokensave_search"));
@@ -3496,6 +3649,10 @@ mod tests {
         assert!(tool_names.contains(&"tokensave_branch_search"));
         assert!(tool_names.contains(&"tokensave_branch_diff"));
         assert!(tool_names.contains(&"tokensave_branch_list"));
+        assert!(tool_names.contains(&"tokensave_str_replace"));
+        assert!(tool_names.contains(&"tokensave_multi_str_replace"));
+        assert!(tool_names.contains(&"tokensave_insert_at"));
+        assert!(tool_names.contains(&"tokensave_ast_grep_rewrite"));
     }
 
     #[test]
@@ -3512,16 +3669,30 @@ mod tests {
     #[test]
     fn test_tool_definitions_have_annotations() {
         let tools = get_tool_definitions();
+        let write_tools = [
+            "tokensave_str_replace",
+            "tokensave_multi_str_replace",
+            "tokensave_insert_at",
+            "tokensave_ast_grep_rewrite",
+        ];
         for tool in &tools {
             let ann = tool
                 .annotations
                 .as_ref()
                 .unwrap_or_else(|| panic!("{} missing annotations", tool.name));
-            assert_eq!(
-                ann["readOnlyHint"], true,
-                "{} missing readOnlyHint",
-                tool.name
-            );
+            if write_tools.contains(&tool.name.as_str()) {
+                assert_eq!(
+                    ann["readOnlyHint"], false,
+                    "{} should have readOnlyHint=false",
+                    tool.name
+                );
+            } else {
+                assert_eq!(
+                    ann["readOnlyHint"], true,
+                    "{} missing readOnlyHint",
+                    tool.name
+                );
+            }
             assert!(
                 ann["title"].is_string(),
                 "{} missing title annotation",

--- a/src/monitor.rs
+++ b/src/monitor.rs
@@ -512,8 +512,11 @@ fn monitor_loop(
         for entry in entries.iter() {
             let project = &entry.project;
             let method = &entry.tool_name;
-            *grouped.entry(project.clone()).or_default().entry(method.clone()).or_default() +=
-                entry.delta;
+            *grouped
+                .entry(project.clone())
+                .or_default()
+                .entry(method.clone())
+                .or_default() += entry.delta;
         }
 
         let mut projects: Vec<String> = grouped.keys().cloned().collect();
@@ -523,7 +526,9 @@ fn monitor_loop(
         let mut grand_total: u64 = 0;
 
         for project in &projects {
-            let Some(methods) = grouped.get(project) else { continue };
+            let Some(methods) = grouped.get(project) else {
+                continue;
+            };
             let mut method_lines: Vec<String> = methods.keys().cloned().collect();
             method_lines.sort();
 

--- a/src/monitor.rs
+++ b/src/monitor.rs
@@ -505,32 +505,49 @@ fn monitor_loop(
             write!(stdout, "\r{}\r\n", sep)?;
         }
 
-        // ── Log entries (most recent at bottom of log area) ──
-        let visible: Vec<&MonitorEntry> = entries
-            .iter()
-            .rev()
-            .take(log_lines)
-            .collect::<Vec<_>>()
-            .into_iter()
-            .rev()
-            .collect();
-        let blank_lines = log_lines.saturating_sub(visible.len());
+        // ── Grouped log entries ──
+        use std::collections::HashMap;
+
+        let mut grouped: HashMap<String, HashMap<String, u64>> = HashMap::new();
+        for entry in entries.iter() {
+            let project = &entry.project;
+            let method = &entry.tool_name;
+            *grouped.entry(project.clone()).or_default().entry(method.clone()).or_default() +=
+                entry.delta;
+        }
+
+        let mut projects: Vec<String> = grouped.keys().cloned().collect();
+        projects.sort();
+
+        let mut all_lines: Vec<String> = Vec::new();
+        let mut grand_total: u64 = 0;
+
+        for project in &projects {
+            let Some(methods) = grouped.get(project) else { continue };
+            let mut method_lines: Vec<String> = methods.keys().cloned().collect();
+            method_lines.sort();
+
+            let project_total: u64 = methods.values().sum::<u64>();
+            grand_total += project_total;
+
+            all_lines.push(format!("{} ({})", project, format_number(project_total)));
+            for method in &method_lines {
+                let delta = *methods.get(method).unwrap_or(&0);
+                all_lines.push(format!("  {}  {}", method, format_number(delta)));
+            }
+        }
+        all_lines.push(format!("TOTAL  {}", format_number(grand_total)));
+
+        let visible_lines: Vec<&String> = all_lines.iter().rev().take(log_lines).collect();
+        let blank_lines = log_lines.saturating_sub(visible_lines.len());
 
         for _ in 0..blank_lines {
             write!(stdout, "\r{}\r\n", " ".repeat(w))?;
         }
 
-        for entry in &visible {
-            let label = entry.label();
-            let delta_str = format_number(entry.delta);
-            let padding = w.saturating_sub(label.len() + delta_str.len() + 2);
-            write!(
-                stdout,
-                "\r{}{}{}\r\n",
-                label,
-                " ".repeat(padding),
-                delta_str
-            )?;
+        for line in visible_lines.into_iter().rev() {
+            let padding = w.saturating_sub(line.len());
+            write!(stdout, "\r{}{}\r\n", line, " ".repeat(padding))?;
         }
 
         // ── Footer ──

--- a/src/monitor.rs
+++ b/src/monitor.rs
@@ -6,9 +6,11 @@
 //!
 //! Entry format is generic: each entry carries a **prefix** (tool suite
 //! name, e.g. "tokensave"), a **project** (folder name), and a
-//! **tool_name** (the specific MCP call).
+//! **`tool_name`** (the specific MCP call).
 
 use std::path::{Path, PathBuf};
+
+use fs2::FileExt;
 
 // ── Layout constants ────────────────────────────────────────────────
 const HEADER_SIZE: usize = 32;
@@ -118,7 +120,6 @@ fn write_entry_inner(
         .open(mmap_path)?;
 
     // Exclusive lock for concurrent writer safety.
-    use fs2::FileExt;
     file.lock_exclusive()?;
 
     let len = file.metadata()?.len() as usize;
@@ -270,6 +271,10 @@ use std::io::Write;
 
 /// Run the monitor TUI. Blocks until Ctrl+C.
 pub fn run() -> std::io::Result<()> {
+    use crossterm::{
+        cursor, execute, terminal,
+        terminal::{EnterAlternateScreen, LeaveAlternateScreen},
+    };
     let dir = global_tokensave_dir().ok_or_else(|| {
         std::io::Error::new(
             std::io::ErrorKind::NotFound,
@@ -287,7 +292,6 @@ pub fn run() -> std::io::Result<()> {
         .truncate(false)
         .open(&lock_path)?;
 
-    use fs2::FileExt;
     if lock_file.try_lock_exclusive().is_err() {
         eprintln!("Monitor already running.");
         return Ok(());
@@ -323,10 +327,6 @@ pub fn run() -> std::io::Result<()> {
     }
 
     // Enter raw mode + alternate screen.
-    use crossterm::{
-        cursor, execute, terminal,
-        terminal::{EnterAlternateScreen, LeaveAlternateScreen},
-    };
     let mut stdout = std::io::stdout();
     terminal::enable_raw_mode()?;
     execute!(stdout, EnterAlternateScreen, cursor::Hide)?;
@@ -363,7 +363,9 @@ impl CostCache {
             efficiency_pct: 0.0,
             top_model: String::new(),
             top_model_cost: 0.0,
-            last_refresh: std::time::Instant::now() - std::time::Duration::from_secs(999),
+            last_refresh: std::time::Instant::now()
+                .checked_sub(std::time::Duration::from_secs(999))
+                .unwrap_or_else(std::time::Instant::now),
         }
     }
 
@@ -373,7 +375,7 @@ impl CostCache {
 }
 
 /// Refresh cost data from the global DB. Best-effort, non-blocking.
-/// Uses a tokio runtime because GlobalDb is async.
+/// Uses a tokio runtime because `GlobalDb` is async.
 fn refresh_cost_cache(cache: &mut CostCache) {
     let future = async {
         let Some(gdb) = crate::global_db::GlobalDb::open().await else {
@@ -404,7 +406,7 @@ fn refresh_cost_cache(cache: &mut CostCache) {
 
         let models = gdb.cost_by_model_since(today_start).await;
         if let Some((model, cost, _)) = models.first() {
-            cache.top_model = model.clone();
+            cache.top_model.clone_from(model);
             cache.top_model_cost = *cost;
         }
     };
@@ -422,6 +424,7 @@ fn monitor_loop(
     stdout: &mut std::io::Stdout,
 ) -> std::io::Result<()> {
     use crossterm::{cursor, event, execute, terminal};
+    use std::collections::HashMap;
 
     let mut cost_cache = CostCache::new();
 
@@ -502,12 +505,10 @@ fn monitor_loop(
                 line2,
                 " ".repeat(w.saturating_sub(line2.len()))
             )?;
-            write!(stdout, "\r{}\r\n", sep)?;
+            write!(stdout, "\r{sep}\r\n")?;
         }
 
         // ── Grouped log entries ──
-        use std::collections::HashMap;
-
         let mut grouped: HashMap<String, HashMap<String, u64>> = HashMap::new();
         for entry in entries.iter() {
             let project = &entry.project;
@@ -561,12 +562,12 @@ fn monitor_loop(
         let total_str = format_number(total_saved);
         let label = "TokenSave Monitor";
         let suffix = "saved tokens";
-        let footer_content = format!("{}  {} {}", label, total_str, suffix);
+        let footer_content = format!("{label}  {total_str} {suffix}");
         let footer_padding = w.saturating_sub(footer_content.len());
         let hint = "Ctrl+R reset | Ctrl+C quit";
         let hint_padding = w.saturating_sub(hint.len());
 
-        write!(stdout, "\r{}\r\n", sep)?;
+        write!(stdout, "\r{sep}\r\n")?;
         write!(
             stdout,
             "\r{}{}\r\n",
@@ -574,7 +575,7 @@ fn monitor_loop(
             footer_content
         )?;
         write!(stdout, "\r{}{}\r\n", " ".repeat(hint_padding), hint)?;
-        write!(stdout, "\r{}", sep)?;
+        write!(stdout, "\r{sep}")?;
 
         stdout.flush()?;
     }

--- a/src/project_watcher.rs
+++ b/src/project_watcher.rs
@@ -93,11 +93,11 @@ impl ProjectWatcher {
         loop {
             let sleep_dur = match deadline {
                 Some(d) => d.saturating_duration_since(Instant::now()),
-                None => Duration::from_secs(3600),
+                None => Duration::from_hours(1),
             };
 
             tokio::select! {
-                _ = cancel.cancelled() => {
+                () = cancel.cancelled() => {
                     if deadline.is_some() {
                         sync_project(&self.project_root).await;
                     }
@@ -106,7 +106,7 @@ impl ProjectWatcher {
                 Some(()) = self.rx.recv() => {
                     deadline = Some(Instant::now() + self.debounce);
                 }
-                _ = tokio::time::sleep(sleep_dur), if deadline.is_some() => {
+                () = tokio::time::sleep(sleep_dur), if deadline.is_some() => {
                     deadline = None;
                     sync_project(&self.project_root).await;
                 }

--- a/src/resolution/resolver.rs
+++ b/src/resolution/resolver.rs
@@ -61,7 +61,7 @@ pub struct ReferenceResolver<'a> {
     qualified_name_cache: HashMap<String, Vec<Node>>,
     /// Suffix index: maps every `::suffix` of a qualified name to the full
     /// qualified name(s). Enables O(1) suffix lookups instead of scanning
-    /// the entire qualified_name_cache.
+    /// the entire `qualified_name_cache`.
     suffix_cache: HashMap<String, Vec<String>>,
     /// All known symbol names (short + qualified + suffixes) for pre-filtering.
     known_names: HashSet<String>,
@@ -278,7 +278,7 @@ impl<'a> ReferenceResolver<'a> {
         }
 
         // Multiple candidates -- score them and pick the best.
-        let best = self.find_best_match(uref, candidates)?;
+        let best = Self::find_best_match(uref, candidates)?;
 
         Some(ResolvedRef {
             original: uref.clone(),
@@ -296,8 +296,8 @@ impl<'a> ReferenceResolver<'a> {
     /// - Same language: +50, cross-language: -80
     /// - Exported / pub visibility: +10
     /// - Callable kind (function/method) when the ref kind is `Calls`: +25
-    /// - Line proximity (same file only): +20 - (line_distance / 10)
-    fn find_best_match(&self, uref: &UnresolvedRef, candidates: &[Node]) -> Option<Node> {
+    /// - Line proximity (same file only): +20 - (`line_distance` / 10)
+    fn find_best_match(uref: &UnresolvedRef, candidates: &[Node]) -> Option<Node> {
         if candidates.is_empty() {
             return None;
         }

--- a/src/sync.rs
+++ b/src/sync.rs
@@ -88,8 +88,10 @@ pub async fn find_new_files(db: &Database, current_files: &[String]) -> Result<V
 /// Find files that are in the database but no longer exist on disk.
 pub async fn find_removed_files(db: &Database, current_files: &[String]) -> Result<Vec<String>> {
     let all_db_files = db.get_all_files().await?;
-    let current_set: std::collections::HashSet<&str> =
-        current_files.iter().map(|s| s.as_str()).collect();
+    let current_set: std::collections::HashSet<&str> = current_files
+        .iter()
+        .map(std::string::String::as_str)
+        .collect();
     let mut removed = Vec::new();
     for file_record in &all_db_files {
         if !current_set.contains(file_record.path.as_str()) {

--- a/src/tokensave.rs
+++ b/src/tokensave.rs
@@ -1127,16 +1127,16 @@ impl TokenSave {
     /// Re-indexes a single file after an edit.
     async fn reindex_file(&self, file_path: &str) -> Result<()> {
         let abs_path = self.absolute_path(file_path);
-        let source = std::fs::read_to_string(&abs_path).map_err(|e| {
-            TokenSaveError::Config {
-                message: format!("failed to read file {file_path}: {e}"),
-            }
+        let source = std::fs::read_to_string(&abs_path).map_err(|e| TokenSaveError::Config {
+            message: format!("failed to read file {file_path}: {e}"),
         })?;
 
-        let extractor = self.registry.extractor_for_file(file_path)
-            .ok_or_else(|| TokenSaveError::Config {
-                message: format!("unsupported file type: {file_path}"),
-            })?;
+        let extractor =
+            self.registry
+                .extractor_for_file(file_path)
+                .ok_or_else(|| TokenSaveError::Config {
+                    message: format!("unsupported file type: {file_path}"),
+                })?;
 
         let mut result = extractor.extract(file_path, &source);
         result.sanitize();
@@ -1149,7 +1149,9 @@ impl TokenSave {
         self.db.insert_nodes(&result.nodes).await?;
         self.db.insert_edges(&result.edges).await?;
         if !result.unresolved_refs.is_empty() {
-            self.db.insert_unresolved_refs(&result.unresolved_refs).await?;
+            self.db
+                .insert_unresolved_refs(&result.unresolved_refs)
+                .await?;
         }
 
         let file_record = FileRecord {
@@ -1167,44 +1169,53 @@ impl TokenSave {
 
     /// Performs a single string replacement.
     /// Fails if `old_str` is not found or matches more than once.
-    pub async fn str_replace(&self, path: &str, old_str: &str, new_str: &str) -> Result<EditResult> {
-        let rel_path = self.resolve_path(path).ok_or_else(|| TokenSaveError::Config {
-            message: "path is not within the project".to_string(),
-        })?;
+    pub async fn str_replace(
+        &self,
+        path: &str,
+        old_str: &str,
+        new_str: &str,
+    ) -> Result<EditResult> {
+        let rel_path = self
+            .resolve_path(path)
+            .ok_or_else(|| TokenSaveError::Config {
+                message: "path is not within the project".to_string(),
+            })?;
 
         let abs_path = self.absolute_path(&rel_path);
-        let source = std::fs::read_to_string(&abs_path).map_err(|e| {
-            TokenSaveError::Config {
-                message: format!("failed to read {path}: {e}"),
-            }
+        let source = std::fs::read_to_string(&abs_path).map_err(|e| TokenSaveError::Config {
+            message: format!("failed to read {path}: {e}"),
         })?;
 
         let matches: Vec<_> = source.match_indices(old_str).collect();
         match matches.len() {
-            0 => return Ok(EditResult {
-                success: false,
-                file_path: rel_path.clone(),
-                matched_str: old_str.to_string(),
-                new_str: new_str.to_string(),
-                message: format!("old_str not found in {path}"),
-            }),
+            0 => {
+                return Ok(EditResult {
+                    success: false,
+                    file_path: rel_path.clone(),
+                    matched_str: old_str.to_string(),
+                    new_str: new_str.to_string(),
+                    message: format!("old_str not found in {path}"),
+                })
+            }
             1 => {}
-            n => return Ok(EditResult {
-                success: false,
-                file_path: rel_path.clone(),
-                matched_str: old_str.to_string(),
-                new_str: new_str.to_string(),
-                message: format!("old_str matches {n} times, must match exactly once"),
-            }),
+            n => {
+                return Ok(EditResult {
+                    success: false,
+                    file_path: rel_path.clone(),
+                    matched_str: old_str.to_string(),
+                    new_str: new_str.to_string(),
+                    message: format!("old_str matches {n} times, must match exactly once"),
+                })
+            }
         }
 
         let modified = source.replacen(old_str, new_str, 1);
 
-        tokio::fs::write(&abs_path, &modified).await.map_err(|e| {
-            TokenSaveError::Config {
+        tokio::fs::write(&abs_path, &modified)
+            .await
+            .map_err(|e| TokenSaveError::Config {
                 message: format!("failed to write {path}: {e}"),
-            }
-        })?;
+            })?;
 
         self.reindex_file(&rel_path).await?;
 
@@ -1224,15 +1235,15 @@ impl TokenSave {
         path: &str,
         replacements: &[(&str, &str)],
     ) -> Result<MultiEditResult> {
-        let rel_path = self.resolve_path(path).ok_or_else(|| TokenSaveError::Config {
-            message: "path is not within the project".to_string(),
-        })?;
+        let rel_path = self
+            .resolve_path(path)
+            .ok_or_else(|| TokenSaveError::Config {
+                message: "path is not within the project".to_string(),
+            })?;
 
         let abs_path = self.absolute_path(&rel_path);
-        let source = std::fs::read_to_string(&abs_path).map_err(|e| {
-            TokenSaveError::Config {
-                message: format!("failed to read {path}: {e}"),
-            }
+        let source = std::fs::read_to_string(&abs_path).map_err(|e| TokenSaveError::Config {
+            message: format!("failed to read {path}: {e}"),
         })?;
 
         for (old, _) in replacements {
@@ -1256,11 +1267,11 @@ impl TokenSave {
             modified = modified.replacen(old, new, 1);
         }
 
-        tokio::fs::write(&abs_path, &modified).await.map_err(|e| {
-            TokenSaveError::Config {
+        tokio::fs::write(&abs_path, &modified)
+            .await
+            .map_err(|e| TokenSaveError::Config {
                 message: format!("failed to write {path}: {e}"),
-            }
-        })?;
+            })?;
 
         self.reindex_file(&rel_path).await?;
 
@@ -1281,15 +1292,15 @@ impl TokenSave {
         content: &str,
         before: bool,
     ) -> Result<InsertResult> {
-        let rel_path = self.resolve_path(path).ok_or_else(|| TokenSaveError::Config {
-            message: "path is not within the project".to_string(),
-        })?;
+        let rel_path = self
+            .resolve_path(path)
+            .ok_or_else(|| TokenSaveError::Config {
+                message: "path is not within the project".to_string(),
+            })?;
 
         let abs_path = self.absolute_path(&rel_path);
-        let source = std::fs::read_to_string(&abs_path).map_err(|e| {
-            TokenSaveError::Config {
-                message: format!("failed to read {path}: {e}"),
-            }
+        let source = std::fs::read_to_string(&abs_path).map_err(|e| TokenSaveError::Config {
+            message: format!("failed to read {path}: {e}"),
         })?;
 
         let lines: Vec<&str> = source.lines().collect();
@@ -1305,7 +1316,10 @@ impl TokenSave {
                     anchor_line: line_num as u32,
                     content: content.to_string(),
                     before,
-                    message: format!("line number {line_num} out of range (file has {} lines)", lines.len()),
+                    message: format!(
+                        "line number {line_num} out of range (file has {} lines)",
+                        lines.len()
+                    ),
                 });
             }
             line_num - 1
@@ -1334,7 +1348,10 @@ impl TokenSave {
                     anchor_line: matching_lines.len() as u32,
                     content: content.to_string(),
                     before,
-                    message: format!("anchor '{anchor}' matches {} lines, must match exactly one", matching_lines.len()),
+                    message: format!(
+                        "anchor '{anchor}' matches {} lines, must match exactly one",
+                        matching_lines.len()
+                    ),
                 });
             }
             matching_lines[0]
@@ -1346,11 +1363,11 @@ impl TokenSave {
         new_lines.extend_from_slice(&lines[insert_idx..]);
         let modified = new_lines.join("\n");
 
-        tokio::fs::write(&abs_path, &modified).await.map_err(|e| {
-            TokenSaveError::Config {
+        tokio::fs::write(&abs_path, &modified)
+            .await
+            .map_err(|e| TokenSaveError::Config {
                 message: format!("failed to write {path}: {e}"),
-            }
-        })?;
+            })?;
 
         self.reindex_file(&rel_path).await?;
 
@@ -1373,15 +1390,15 @@ impl TokenSave {
     ) -> Result<AstGrepResult> {
         use std::process::Command;
 
-        let rel_path = self.resolve_path(path).ok_or_else(|| TokenSaveError::Config {
-            message: "path is not within the project".to_string(),
-        })?;
+        let rel_path = self
+            .resolve_path(path)
+            .ok_or_else(|| TokenSaveError::Config {
+                message: "path is not within the project".to_string(),
+            })?;
 
         let abs_path = self.absolute_path(&rel_path);
 
-        let check_output = Command::new("ast-grep")
-            .args(["--version"])
-            .output();
+        let check_output = Command::new("ast-grep").args(["--version"]).output();
 
         if check_output.is_err() {
             return Ok(AstGrepResult {
@@ -1389,12 +1406,21 @@ impl TokenSave {
                 file_path: rel_path.clone(),
                 pattern: pattern.to_string(),
                 rewrite: rewrite.to_string(),
-                message: "ast-grep is not installed. Install with: cargo install ast-grep".to_string(),
+                message: "ast-grep is not installed. Install with: cargo install ast-grep"
+                    .to_string(),
             });
         }
 
         let output = Command::new("ast-grep")
-            .args(["run", "-p", pattern, "-r", rewrite, "-d", abs_path.to_string_lossy().as_ref()])
+            .args([
+                "run",
+                "-p",
+                pattern,
+                "-r",
+                rewrite,
+                "-d",
+                abs_path.to_string_lossy().as_ref(),
+            ])
             .output()
             .map_err(|e| TokenSaveError::Config {
                 message: format!("failed to run ast-grep: {e}"),

--- a/src/tokensave.rs
+++ b/src/tokensave.rs
@@ -1105,6 +1105,322 @@ impl TokenSave {
         }
         Some(rel_str)
     }
+
+    /// Resolves a path to a relative path string.
+    /// If the path is already relative, returns it as-is.
+    /// If absolute, strips the project_root prefix.
+    fn resolve_path(&self, path: &str) -> Option<String> {
+        let path = Path::new(path);
+        if path.is_absolute() {
+            let relative = path.strip_prefix(&self.project_root).ok()?;
+            Some(relative.to_string_lossy().replace('\\', "/"))
+        } else {
+            Some(path.to_string_lossy().replace('\\', "/"))
+        }
+    }
+
+    /// Gets the absolute path for a relative path.
+    fn absolute_path(&self, relative_path: &str) -> PathBuf {
+        self.project_root.join(relative_path)
+    }
+
+    /// Re-indexes a single file after an edit.
+    async fn reindex_file(&self, file_path: &str) -> Result<()> {
+        let abs_path = self.absolute_path(file_path);
+        let source = std::fs::read_to_string(&abs_path).map_err(|e| {
+            TokenSaveError::Config {
+                message: format!("failed to read file {file_path}: {e}"),
+            }
+        })?;
+
+        let extractor = self.registry.extractor_for_file(file_path)
+            .ok_or_else(|| TokenSaveError::Config {
+                message: format!("unsupported file type: {file_path}"),
+            })?;
+
+        let mut result = extractor.extract(file_path, &source);
+        result.sanitize();
+
+        let hash = sync::content_hash(&source);
+        let size = source.len() as u64;
+        let mtime = sync::file_stat(&abs_path).map_or_else(current_timestamp, |(m, _)| m);
+
+        self.db.delete_nodes_by_file(file_path).await?;
+        self.db.insert_nodes(&result.nodes).await?;
+        self.db.insert_edges(&result.edges).await?;
+        if !result.unresolved_refs.is_empty() {
+            self.db.insert_unresolved_refs(&result.unresolved_refs).await?;
+        }
+
+        let file_record = FileRecord {
+            path: file_path.to_string(),
+            content_hash: hash,
+            size,
+            modified_at: mtime,
+            indexed_at: current_timestamp(),
+            node_count: result.nodes.len() as u32,
+        };
+        self.db.upsert_file(&file_record).await?;
+
+        Ok(())
+    }
+
+    /// Performs a single string replacement.
+    /// Fails if `old_str` is not found or matches more than once.
+    pub async fn str_replace(&self, path: &str, old_str: &str, new_str: &str) -> Result<EditResult> {
+        let rel_path = self.resolve_path(path).ok_or_else(|| TokenSaveError::Config {
+            message: "path is not within the project".to_string(),
+        })?;
+
+        let abs_path = self.absolute_path(&rel_path);
+        let source = std::fs::read_to_string(&abs_path).map_err(|e| {
+            TokenSaveError::Config {
+                message: format!("failed to read {path}: {e}"),
+            }
+        })?;
+
+        let matches: Vec<_> = source.match_indices(old_str).collect();
+        match matches.len() {
+            0 => return Ok(EditResult {
+                success: false,
+                file_path: rel_path.clone(),
+                matched_str: old_str.to_string(),
+                new_str: new_str.to_string(),
+                message: format!("old_str not found in {path}"),
+            }),
+            1 => {}
+            n => return Ok(EditResult {
+                success: false,
+                file_path: rel_path.clone(),
+                matched_str: old_str.to_string(),
+                new_str: new_str.to_string(),
+                message: format!("old_str matches {n} times, must match exactly once"),
+            }),
+        }
+
+        let modified = source.replacen(old_str, new_str, 1);
+
+        tokio::fs::write(&abs_path, &modified).await.map_err(|e| {
+            TokenSaveError::Config {
+                message: format!("failed to write {path}: {e}"),
+            }
+        })?;
+
+        self.reindex_file(&rel_path).await?;
+
+        Ok(EditResult {
+            success: true,
+            file_path: rel_path,
+            matched_str: old_str.to_string(),
+            new_str: new_str.to_string(),
+            message: "replacement successful".to_string(),
+        })
+    }
+
+    /// Applies multiple string replacements atomically.
+    /// Fails if any `old_str` doesn't match exactly once.
+    pub async fn multi_str_replace(
+        &self,
+        path: &str,
+        replacements: &[(&str, &str)],
+    ) -> Result<MultiEditResult> {
+        let rel_path = self.resolve_path(path).ok_or_else(|| TokenSaveError::Config {
+            message: "path is not within the project".to_string(),
+        })?;
+
+        let abs_path = self.absolute_path(&rel_path);
+        let source = std::fs::read_to_string(&abs_path).map_err(|e| {
+            TokenSaveError::Config {
+                message: format!("failed to read {path}: {e}"),
+            }
+        })?;
+
+        for (old, _) in replacements {
+            let count = source.matches(old).count();
+            if count != 1 {
+                return Ok(MultiEditResult {
+                    success: false,
+                    file_path: rel_path.clone(),
+                    applied_count: 0,
+                    message: format!(
+                        "replacement '{}' matches {} times, must match exactly once",
+                        if old.len() > 20 { &old[..20] } else { old },
+                        count
+                    ),
+                });
+            }
+        }
+
+        let mut modified = source;
+        for (old, new) in replacements {
+            modified = modified.replacen(old, new, 1);
+        }
+
+        tokio::fs::write(&abs_path, &modified).await.map_err(|e| {
+            TokenSaveError::Config {
+                message: format!("failed to write {path}: {e}"),
+            }
+        })?;
+
+        self.reindex_file(&rel_path).await?;
+
+        Ok(MultiEditResult {
+            success: true,
+            file_path: rel_path,
+            applied_count: replacements.len(),
+            message: format!("applied {} replacements", replacements.len()),
+        })
+    }
+
+    /// Inserts content before or after a unique anchor.
+    /// Anchor can be a string or 1-indexed line number.
+    pub async fn insert_at(
+        &self,
+        path: &str,
+        anchor: &str,
+        content: &str,
+        before: bool,
+    ) -> Result<InsertResult> {
+        let rel_path = self.resolve_path(path).ok_or_else(|| TokenSaveError::Config {
+            message: "path is not within the project".to_string(),
+        })?;
+
+        let abs_path = self.absolute_path(&rel_path);
+        let source = std::fs::read_to_string(&abs_path).map_err(|e| {
+            TokenSaveError::Config {
+                message: format!("failed to read {path}: {e}"),
+            }
+        })?;
+
+        let lines: Vec<&str> = source.lines().collect();
+
+        let anchor_line = if anchor.chars().all(|c| c.is_ascii_digit()) {
+            let line_num: usize = anchor.parse().map_err(|_| TokenSaveError::Config {
+                message: format!("invalid line number: {anchor}"),
+            })?;
+            if line_num == 0 || line_num > lines.len() {
+                return Ok(InsertResult {
+                    success: false,
+                    file_path: rel_path.clone(),
+                    anchor_line: line_num as u32,
+                    content: content.to_string(),
+                    before,
+                    message: format!("line number {line_num} out of range (file has {} lines)", lines.len()),
+                });
+            }
+            line_num - 1
+        } else {
+            let matching_lines: Vec<usize> = lines
+                .iter()
+                .enumerate()
+                .filter(|(_, line)| line.contains(&anchor[..anchor.len().min(100)]))
+                .map(|(i, _)| i)
+                .collect();
+
+            if matching_lines.is_empty() {
+                return Ok(InsertResult {
+                    success: false,
+                    file_path: rel_path.clone(),
+                    anchor_line: 0,
+                    content: content.to_string(),
+                    before,
+                    message: format!("anchor '{anchor}' not found"),
+                });
+            }
+            if matching_lines.len() > 1 {
+                return Ok(InsertResult {
+                    success: false,
+                    file_path: rel_path.clone(),
+                    anchor_line: matching_lines.len() as u32,
+                    content: content.to_string(),
+                    before,
+                    message: format!("anchor '{anchor}' matches {} lines, must match exactly one", matching_lines.len()),
+                });
+            }
+            matching_lines[0]
+        };
+
+        let insert_idx = if before { anchor_line } else { anchor_line + 1 };
+        let mut new_lines: Vec<&str> = lines[..insert_idx].to_vec();
+        new_lines.push(content);
+        new_lines.extend_from_slice(&lines[insert_idx..]);
+        let modified = new_lines.join("\n");
+
+        tokio::fs::write(&abs_path, &modified).await.map_err(|e| {
+            TokenSaveError::Config {
+                message: format!("failed to write {path}: {e}"),
+            }
+        })?;
+
+        self.reindex_file(&rel_path).await?;
+
+        Ok(InsertResult {
+            success: true,
+            file_path: rel_path,
+            anchor_line: (anchor_line + 1) as u32,
+            content: content.to_string(),
+            before,
+            message: format!("inserted at line {}", anchor_line + 1),
+        })
+    }
+
+    /// Performs structural rewrite using ast-grep CLI.
+    pub async fn ast_grep_rewrite(
+        &self,
+        path: &str,
+        pattern: &str,
+        rewrite: &str,
+    ) -> Result<AstGrepResult> {
+        use std::process::Command;
+
+        let rel_path = self.resolve_path(path).ok_or_else(|| TokenSaveError::Config {
+            message: "path is not within the project".to_string(),
+        })?;
+
+        let abs_path = self.absolute_path(&rel_path);
+
+        let check_output = Command::new("ast-grep")
+            .args(["--version"])
+            .output();
+
+        if check_output.is_err() {
+            return Ok(AstGrepResult {
+                success: false,
+                file_path: rel_path.clone(),
+                pattern: pattern.to_string(),
+                rewrite: rewrite.to_string(),
+                message: "ast-grep is not installed. Install with: cargo install ast-grep".to_string(),
+            });
+        }
+
+        let output = Command::new("ast-grep")
+            .args(["run", "-p", pattern, "-r", rewrite, "-d", abs_path.to_string_lossy().as_ref()])
+            .output()
+            .map_err(|e| TokenSaveError::Config {
+                message: format!("failed to run ast-grep: {e}"),
+            })?;
+
+        if !output.status.success() {
+            let stderr = String::from_utf8_lossy(&output.stderr);
+            return Ok(AstGrepResult {
+                success: false,
+                file_path: rel_path.clone(),
+                pattern: pattern.to_string(),
+                rewrite: rewrite.to_string(),
+                message: format!("ast-grep failed: {stderr}"),
+            });
+        }
+
+        self.reindex_file(&rel_path).await?;
+
+        Ok(AstGrepResult {
+            success: true,
+            file_path: rel_path,
+            pattern: pattern.to_string(),
+            rewrite: rewrite.to_string(),
+            message: "ast-grep rewrite completed".to_string(),
+        })
+    }
 }
 
 // ---------------------------------------------------------------------------

--- a/src/tokensave.rs
+++ b/src/tokensave.rs
@@ -706,6 +706,131 @@ impl TokenSave {
         self.sync_with_progress_verbose(on_progress, |_| {}).await
     }
 
+    /// Sync only the specified files if they are stale, then recheck.
+    ///
+    /// Returns `Ok(false)` if all files are now in sync after the call.
+    /// Returns `Ok(true)` if files are still stale after sync (either sync
+    /// didn't update these specific files, or sync failed to acquire lock).
+    /// Returns `Err` on sync failure.
+    pub async fn sync_if_stale(&self, stale_files: &[String]) -> Result<bool> {
+        if stale_files.is_empty() {
+            return Ok(false);
+        }
+
+        // Quick check: are these files still stale before we even try to sync?
+        let still_stale_before = self.check_file_staleness(stale_files).await;
+        if still_stale_before.is_empty() {
+            return Ok(false);
+        }
+
+        // Try to acquire sync lock and do an incremental sync.
+        // The full sync will pick up any changed files, including our stale ones.
+        let Ok(lock) = try_acquire_sync_lock(&self.project_root) else {
+            // Another sync is in progress (likely daemon) — let caller warn
+            return Ok(true);
+        };
+
+        // Do a minimal sync focused on changed files
+        let result = self.sync_single_files(stale_files).await;
+
+        // Release lock
+        drop(lock);
+
+        match result {
+            Ok(()) => {
+                // Recheck if our files are still stale
+                let still_stale_after = self.check_file_staleness(stale_files).await;
+                Ok(!still_stale_after.is_empty())
+            }
+            Err(_) => Ok(true), // Sync failed — warn caller
+        }
+    }
+
+    /// Index/reexamine the given file paths, updating their graph nodes and edges.
+    /// This is a focused, single-shot operation used by `sync_if_stale`.
+    async fn sync_single_files(&self, file_paths: &[String]) -> Result<()> {
+        use crate::sync as sync_mod;
+
+        let project_root = &self.project_root;
+        let registry = &self.registry;
+
+        // Read and hash the files
+        let mut hash_map: HashMap<String, String> = HashMap::new();
+        let mut stat_map: HashMap<String, (i64, u64)> = HashMap::new();
+
+        for path in file_paths {
+            let abs_path = project_root.join(path);
+            if let Some((mtime, size)) = sync_mod::file_stat(&abs_path) {
+                stat_map.insert(path.clone(), (mtime, size));
+            }
+            if let Ok(source) = sync_mod::read_source_file(&abs_path) {
+                let hash = sync_mod::content_hash(&source);
+                hash_map.insert(path.clone(), hash);
+            }
+        }
+
+        // Extract graph data from the files in parallel
+        let sync_extractions: Vec<_> = file_paths
+            .par_iter()
+            .filter_map(|file_path| {
+                let abs_path = project_root.join(file_path);
+                let source = sync_mod::read_source_file(&abs_path).ok()?;
+                let extractor = registry.extractor_for_file(file_path)?;
+                let mut result = extractor.extract(file_path, &source);
+                result.sanitize();
+                let hash = sync_mod::content_hash(&source);
+                let size = source.len() as u64;
+                let mtime = stat_map
+                    .get(file_path)
+                    .copied()
+                    .map_or_else(current_timestamp, |(m, _)| m);
+                Some((file_path.clone(), result, hash, size, mtime))
+            })
+            .collect();
+
+        // Insert into database
+        for (file_path, result, hash, size, mtime) in &sync_extractions {
+            self.db.delete_nodes_by_file(file_path).await?;
+            self.db.insert_nodes(&result.nodes).await?;
+            self.db.insert_edges(&result.edges).await?;
+            if !result.unresolved_refs.is_empty() {
+                self.db
+                    .insert_unresolved_refs(&result.unresolved_refs)
+                    .await?;
+            }
+
+            let file_record = FileRecord {
+                path: (*file_path).clone(),
+                content_hash: (*hash).clone(),
+                size: *size,
+                modified_at: *mtime,
+                indexed_at: current_timestamp(),
+                node_count: result.nodes.len() as u32,
+            };
+            self.db.upsert_file(&file_record).await?;
+        }
+
+        // Resolve references for any new/changed unresolved refs
+        if !file_paths.is_empty() {
+            let resolver = ReferenceResolver::new(&self.db).await;
+            let unresolved = self.db.get_unresolved_refs().await?;
+            if !unresolved.is_empty() {
+                let resolution = resolver.resolve_all(&unresolved);
+                let edges = resolver.create_edges(&resolution.resolved);
+                if !edges.is_empty() {
+                    self.db.insert_edges(&edges).await?;
+                }
+            }
+        }
+
+        self.db
+            .set_metadata("last_sync_at", &current_timestamp().to_string())
+            .await?;
+
+        clear_dirty_sentinel(&self.project_root);
+        Ok(())
+    }
+
     /// Like `sync()`, but calls `on_progress` with a description and the
     /// current step for each phase of work, and `on_verbose` after each phase
     /// completes with a diagnostic summary line (count + timing).

--- a/src/tokensave.rs
+++ b/src/tokensave.rs
@@ -29,7 +29,7 @@ pub struct TokenSave {
     registry: LanguageRegistry,
     /// The active git branch (None if detached HEAD or not a git repo).
     active_branch: Option<String>,
-    /// The branch whose DB is actually being served (may differ from active_branch on fallback).
+    /// The branch whose DB is actually being served (may differ from `active_branch` on fallback).
     serving_branch: Option<String>,
     /// Set when serving from a fallback (ancestor) DB instead of the exact branch.
     fallback_warning: Option<String>,
@@ -81,10 +81,10 @@ pub fn current_timestamp() -> i64 {
 // ---------------------------------------------------------------------------
 
 impl TokenSave {
-    /// Initializes a new TokenSave project at the given root.
+    /// Initializes a new `TokenSave` project at the given root.
     ///
     /// Creates the `.tokensave` directory, writes a default configuration,
-    /// and initializes a fresh SQLite database.
+    /// and initializes a fresh `SQLite` database.
     pub async fn init(project_root: &Path) -> Result<Self> {
         let config = TokenSaveConfig {
             root_dir: project_root.to_string_lossy().to_string(),
@@ -115,7 +115,7 @@ impl TokenSave {
         })
     }
 
-    /// Opens an existing TokenSave project at the given root.
+    /// Opens an existing `TokenSave` project at the given root.
     ///
     /// If branch metadata exists, resolves the current git branch and opens
     /// the corresponding DB. Falls back to the nearest tracked ancestor DB
@@ -338,7 +338,7 @@ impl TokenSave {
         Some(meta.branches.keys().cloned().collect())
     }
 
-    /// Returns `true` if a TokenSave project has been initialized at the given root.
+    /// Returns `true` if a `TokenSave` project has been initialized at the given root.
     pub fn is_initialized(project_root: &Path) -> bool {
         get_tokensave_dir(project_root)
             .join("tokensave.db")
@@ -431,6 +431,7 @@ impl Drop for SyncLockGuard {
 /// error. Stale lockfiles (dead PID or unreadable content) are reclaimed
 /// automatically.
 fn try_acquire_sync_lock(project_root: &Path) -> Result<SyncLockGuard> {
+    use std::io::Write;
     let lock_path = get_tokensave_dir(project_root).join("sync.lock");
     let pid = std::process::id();
 
@@ -441,7 +442,6 @@ fn try_acquire_sync_lock(project_root: &Path) -> Result<SyncLockGuard> {
         .open(&lock_path)
     {
         Ok(mut f) => {
-            use std::io::Write;
             let _ = write!(f, "{pid}");
             return Ok(SyncLockGuard { path: lock_path });
         }
@@ -478,7 +478,6 @@ fn try_acquire_sync_lock(project_root: &Path) -> Result<SyncLockGuard> {
         .map_err(|e| TokenSaveError::SyncLock {
             message: format!("could not reclaim lockfile: {e}"),
         })?;
-    use std::io::Write;
     let _ = write!(f, "{pid}");
     Ok(SyncLockGuard { path: lock_path })
 }
@@ -492,8 +491,7 @@ fn is_pid_alive(pid: u32) -> bool {
             .stdout(std::process::Stdio::null())
             .stderr(std::process::Stdio::null())
             .status()
-            .map(|s| s.success())
-            .unwrap_or(false)
+            .is_ok_and(|s| s.success())
     }
     #[cfg(windows)]
     {
@@ -570,7 +568,7 @@ impl TokenSave {
 
         // 2. Scan for source files
         let phase_start = Instant::now();
-        let files = self.scan_files()?;
+        let files = self.scan_files();
         let total = files.len();
         on_verbose(&format!(
             "scanned {} files in {:.1}s",
@@ -739,7 +737,7 @@ impl TokenSave {
 
         on_progress(0, 0, "scanning files");
         let phase_start = Instant::now();
-        let current_files = self.scan_files()?;
+        let current_files = self.scan_files();
         on_verbose(&format!(
             "scanned {} files in {:.1}s",
             current_files.len(),
@@ -845,12 +843,12 @@ impl TokenSave {
         for path in &stat_changed {
             if let Some(new_hash) = hash_map.get(path) {
                 if let Some(record) = db_map.get(path) {
-                    if record.content_hash != *new_hash {
-                        stale.push(path.clone());
-                    } else {
+                    if record.content_hash == *new_hash {
                         // mtime changed but content identical (e.g. touch) —
                         // update stored mtime so we skip it next time
                         mtime_only_changed.push(path.clone());
+                    } else {
+                        stale.push(path.clone());
                     }
                 }
             }
@@ -987,7 +985,7 @@ impl TokenSave {
     ///
     /// Supported extensions are derived from the `LanguageRegistry` so that
     /// adding a new extractor automatically picks up its files.
-    fn scan_files(&self) -> Result<Vec<String>> {
+    fn scan_files(&self) -> Vec<String> {
         debug_assert!(
             self.project_root.is_dir(),
             "scan_files: project_root is not a directory"
@@ -999,7 +997,7 @@ impl TokenSave {
         );
 
         if self.config.git_ignore {
-            let files = self.scan_files_with_gitignore(&supported_exts)?;
+            let files = self.scan_files_with_gitignore(&supported_exts);
             if files.is_empty() {
                 // The project directory may be gitignored by a parent repo,
                 // causing the ignore-aware walker to skip everything. Fall
@@ -1008,7 +1006,7 @@ impl TokenSave {
                     .follow_links(true)
                     .max_depth(2)
                     .into_iter()
-                    .filter_map(|e| e.ok())
+                    .filter_map(std::result::Result::ok)
                     .any(|e| {
                         e.file_type().is_file()
                             && e.path()
@@ -1021,14 +1019,14 @@ impl TokenSave {
                     return self.scan_files_walkdir(&supported_exts);
                 }
             }
-            Ok(files)
+            files
         } else {
             self.scan_files_walkdir(&supported_exts)
         }
     }
 
     /// Walk using `walkdir`, skipping hidden directories and `target/`.
-    fn scan_files_walkdir(&self, supported_exts: &[&str]) -> Result<Vec<String>> {
+    fn scan_files_walkdir(&self, supported_exts: &[&str]) -> Vec<String> {
         let mut files = Vec::new();
         for entry in WalkDir::new(&self.project_root)
             .follow_links(true)
@@ -1041,10 +1039,7 @@ impl TokenSave {
                 !name.starts_with('.') && name != "target"
             })
         {
-            let entry = match entry {
-                Ok(e) => e,
-                Err(_) => continue,
-            };
+            let Ok(entry) = entry else { continue };
             if !entry.file_type().is_file() {
                 continue;
             }
@@ -1052,12 +1047,12 @@ impl TokenSave {
                 files.push(rel_str);
             }
         }
-        Ok(files)
+        files
     }
 
     /// Walk using the `ignore` crate, which respects `.gitignore` rules,
     /// `.git/info/exclude`, and the user's global gitignore.
-    fn scan_files_with_gitignore(&self, supported_exts: &[&str]) -> Result<Vec<String>> {
+    fn scan_files_with_gitignore(&self, supported_exts: &[&str]) -> Vec<String> {
         let mut files = Vec::new();
         let walker = ignore::WalkBuilder::new(&self.project_root)
             .follow_links(true)
@@ -1068,10 +1063,7 @@ impl TokenSave {
             .build();
 
         for entry in walker {
-            let entry = match entry {
-                Ok(e) => e,
-                Err(_) => continue,
-            };
+            let Ok(entry) = entry else { continue };
             let Some(ft) = entry.file_type() else {
                 continue;
             };
@@ -1082,7 +1074,7 @@ impl TokenSave {
                 files.push(rel_str);
             }
         }
-        Ok(files)
+        files
     }
 
     /// Checks whether a file should be included: correct extension, not
@@ -1108,7 +1100,7 @@ impl TokenSave {
 
     /// Resolves a path to a relative path string.
     /// If the path is already relative, returns it as-is.
-    /// If absolute, strips the project_root prefix.
+    /// If absolute, strips the `project_root` prefix.
     fn resolve_path(&self, path: &str) -> Option<String> {
         let path = Path::new(path);
         if path.is_absolute() {
@@ -1579,7 +1571,7 @@ impl TokenSave {
         self.db.get_node_distribution(path_prefix).await
     }
 
-    /// Returns calls edges as (source_id, target_id) pairs for cycle detection.
+    /// Returns calls edges as (`source_id`, `target_id`) pairs for cycle detection.
     pub async fn get_call_edges(&self, path_prefix: Option<&str>) -> Result<Vec<(String, String)>> {
         self.db.get_call_edges(path_prefix).await
     }
@@ -1775,23 +1767,20 @@ impl TokenSave {
     /// Count git commits newer than the given UNIX timestamp.
     /// Returns 0 if git is unavailable or the directory is not a git repository.
     pub fn git_commits_since(&self, since_timestamp: i64) -> usize {
-        let repo = match gix::open(&self.project_root) {
-            Ok(r) => r,
-            Err(_) => return 0,
+        let Ok(repo) = gix::open(&self.project_root) else {
+            return 0;
         };
-        let head = match repo.head_commit() {
-            Ok(h) => h,
-            Err(_) => return 0,
+        let Ok(head) = repo.head_commit() else {
+            return 0;
         };
         let sorting = gix::revision::walk::Sorting::ByCommitTimeCutoff {
             order: gix::traverse::commit::simple::CommitTimeOrder::NewestFirst,
             seconds: since_timestamp,
         };
-        let walk = match head.ancestors().sorting(sorting).all() {
-            Ok(w) => w,
-            Err(_) => return 0,
+        let Ok(walk) = head.ancestors().sorting(sorting).all() else {
+            return 0;
         };
-        walk.filter_map(|r| r.ok()).count()
+        walk.filter_map(std::result::Result::ok).count()
     }
 }
 

--- a/src/types.rs
+++ b/src/types.rs
@@ -602,3 +602,43 @@ pub struct ResolvedRef {
     pub confidence: f64,
     pub resolved_by: String,
 }
+
+/// Result of a single string replacement edit.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct EditResult {
+    pub success: bool,
+    pub file_path: String,
+    pub matched_str: String,
+    pub new_str: String,
+    pub message: String,
+}
+
+/// Result of a multi-string replacement edit.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct MultiEditResult {
+    pub success: bool,
+    pub file_path: String,
+    pub applied_count: usize,
+    pub message: String,
+}
+
+/// Result of an insert-at operation.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct InsertResult {
+    pub success: bool,
+    pub file_path: String,
+    pub anchor_line: u32,
+    pub content: String,
+    pub before: bool,
+    pub message: String,
+}
+
+/// Result of an ast-grep rewrite operation.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct AstGrepResult {
+    pub success: bool,
+    pub file_path: String,
+    pub pattern: String,
+    pub rewrite: String,
+    pub message: String,
+}

--- a/src/types.rs
+++ b/src/types.rs
@@ -501,7 +501,7 @@ pub struct BuildContextOptions {
     pub traversal_depth: usize,
     pub min_score: f64,
     /// Additional keywords to search for beyond those extracted from the query.
-    /// Enables agent-driven synonym expansion (e.g. "authentication" → ["login", "session"]).
+    /// Enables agent-driven synonym expansion (e.g. `"authentication"` → `["login", "session"]`).
     pub extra_keywords: Vec<String>,
     /// Node IDs to exclude from results (for session deduplication across calls).
     pub exclude_node_ids: HashSet<String>,
@@ -554,7 +554,7 @@ pub struct TaskContext {
     pub entry_points: Vec<Node>,
     pub code_blocks: Vec<CodeBlock>,
     pub related_files: Vec<String>,
-    /// IDs of all nodes returned as entry points (pass to next call's exclude_node_ids for dedup).
+    /// IDs of all nodes returned as entry points (pass to next call's `exclude_node_ids` for dedup).
     pub seen_node_ids: Vec<String>,
 }
 

--- a/src/upgrade.rs
+++ b/src/upgrade.rs
@@ -1,7 +1,7 @@
 //! Self-update for the tokensave binary.
 //!
 //! Downloads the latest release asset directly from GitHub, extracts the
-//! binary, and replaces the running executable using self_replace.
+//! binary, and replaces the running executable using `self_replace`.
 //! Beta and stable are separate channels — a beta build only sees beta
 //! releases and vice versa. The daemon is stopped before the binary is
 //! replaced and restarted afterwards if it was running.
@@ -111,7 +111,7 @@ fn download_and_extract(url: &str, bin_name: &str) -> Result<std::path::PathBuf>
     ));
 
     let agent: ureq::Agent = ureq::Agent::config_builder()
-        .timeout_global(Some(std::time::Duration::from_secs(300)))
+        .timeout_global(Some(std::time::Duration::from_mins(5)))
         .build()
         .into();
 
@@ -309,21 +309,18 @@ fn replace_for_brew(new_exe: &Path, new_version: &str) -> Result<()> {
         Some(p) if p.file_name().and_then(|n| n.to_str()) == Some("bin") => p,
         _ => return replace_default(new_exe),
     };
-    let version_dir = match bin_dir.parent() {
-        Some(p) => p,
-        None => return replace_default(new_exe),
+    let Some(version_dir) = bin_dir.parent() else {
+        return replace_default(new_exe);
     };
-    let formula_dir = match version_dir.parent() {
-        Some(p) => p,
-        None => return replace_default(new_exe),
+    let Some(formula_dir) = version_dir.parent() else {
+        return replace_default(new_exe);
     };
     let cellar_dir = match formula_dir.parent() {
         Some(p) if p.file_name().and_then(|n| n.to_str()) == Some("Cellar") => p,
         _ => return replace_default(new_exe),
     };
-    let prefix = match cellar_dir.parent() {
-        Some(p) => p,
-        None => return replace_default(new_exe),
+    let Some(prefix) = cellar_dir.parent() else {
+        return replace_default(new_exe);
     };
 
     let Some(bin_name) = canonical.file_name() else {

--- a/src/user_config.rs
+++ b/src/user_config.rs
@@ -46,7 +46,7 @@ pub struct UserConfig {
     #[serde(default)]
     pub last_version_warning_at: i64,
 
-    /// Agent integrations that have been installed (e.g. ["claude", "gemini"]).
+    /// Agent integrations that have been installed (e.g. `["claude", "gemini"]`).
     #[serde(default)]
     pub installed_agents: Vec<String>,
 
@@ -67,7 +67,7 @@ pub struct UserConfig {
     #[serde(default)]
     pub last_installed_version: String,
 
-    /// UNIX timestamp of last LiteLLM pricing fetch.
+    /// UNIX timestamp of last `LiteLLM` pricing fetch.
     #[serde(default)]
     pub last_pricing_fetch_at: i64,
 }

--- a/src/user_config.rs
+++ b/src/user_config.rs
@@ -50,7 +50,7 @@ pub struct UserConfig {
     #[serde(default)]
     pub installed_agents: Vec<String>,
 
-    /// Debounce duration for the daemon file watcher (e.g. "15s", "1m").
+    /// Debounce duration for the daemon file watcher (e.g. "2s", "15s", "1m").
     #[serde(default = "default_daemon_debounce")]
     pub daemon_debounce: String,
 
@@ -62,14 +62,14 @@ pub struct UserConfig {
     #[serde(default)]
     pub last_flags_fetch_at: i64,
 
+    /// UNIX timestamp of last `LiteLLM` pricing fetch.
+    #[serde(default)]
+    pub last_pricing_fetch_at: i64,
+
     /// Version that last ran `install` or `reinstall`. Used to trigger a
     /// silent reinstall when the binary is upgraded.
     #[serde(default)]
     pub last_installed_version: String,
-
-    /// UNIX timestamp of last `LiteLLM` pricing fetch.
-    #[serde(default)]
-    pub last_pricing_fetch_at: i64,
 }
 
 fn default_true() -> bool {
@@ -77,7 +77,7 @@ fn default_true() -> bool {
 }
 
 fn default_daemon_debounce() -> String {
-    "15s".to_string()
+    "2s".to_string()
 }
 
 impl Default for UserConfig {
@@ -96,8 +96,8 @@ impl Default for UserConfig {
             daemon_debounce: default_daemon_debounce(),
             cached_country_flags: Vec::new(),
             last_flags_fetch_at: 0,
-            last_installed_version: String::new(),
             last_pricing_fetch_at: 0,
+            last_installed_version: String::new(),
         }
     }
 }

--- a/tests/agent_test.rs
+++ b/tests/agent_test.rs
@@ -102,7 +102,7 @@ fn make_install_ctx(home: &Path) -> InstallContext {
     InstallContext {
         home: home.to_path_buf(),
         tokensave_bin: "/usr/local/bin/tokensave".to_string(),
-        tool_permissions: EXPECTED_TOOL_PERMS,
+        tool_permissions: expected_tool_perms(),
     }
 }
 
@@ -602,7 +602,7 @@ fn make_install_ctx_with_real_bin(home: &Path) -> InstallContext {
     InstallContext {
         home: home.to_path_buf(),
         tokensave_bin: bin_path.to_string_lossy().to_string(),
-        tool_permissions: EXPECTED_TOOL_PERMS,
+        tool_permissions: expected_tool_perms(),
     }
 }
 
@@ -1260,8 +1260,9 @@ fn test_gemini_install_preserves_existing_settings() {
 
 #[test]
 fn test_tool_names_not_empty() {
-    assert!(!TOOL_NAMES.is_empty());
-    for name in TOOL_NAMES {
+    let names = tool_names();
+    assert!(!names.is_empty());
+    for name in &names {
         assert!(
             name.starts_with("tokensave_"),
             "tool name should start with tokensave_: {name}"
@@ -1271,8 +1272,9 @@ fn test_tool_names_not_empty() {
 
 #[test]
 fn test_expected_tool_perms_not_empty() {
-    assert!(!EXPECTED_TOOL_PERMS.is_empty());
-    for perm in EXPECTED_TOOL_PERMS {
+    let perms = expected_tool_perms();
+    assert!(!perms.is_empty());
+    for perm in &perms {
         assert!(
             perm.starts_with("mcp__tokensave__"),
             "tool perm should start with mcp__tokensave__: {perm}"
@@ -1282,16 +1284,17 @@ fn test_expected_tool_perms_not_empty() {
 
 #[test]
 fn test_tool_perms_match_tool_names() {
-    // Each tool name should have a corresponding permission
+    let names = tool_names();
+    let perms = expected_tool_perms();
     assert_eq!(
-        TOOL_NAMES.len(),
-        EXPECTED_TOOL_PERMS.len(),
-        "TOOL_NAMES and EXPECTED_TOOL_PERMS should have same length"
+        names.len(),
+        perms.len(),
+        "tool_names and expected_tool_perms should have same length"
     );
-    for name in TOOL_NAMES {
+    for name in &names {
         let expected_perm = format!("mcp__tokensave__{name}");
         assert!(
-            EXPECTED_TOOL_PERMS.contains(&expected_perm.as_str()),
+            perms.contains(&expected_perm),
             "missing permission for tool {name}: expected {expected_perm}"
         );
     }

--- a/tests/claude_agent_test.rs
+++ b/tests/claude_agent_test.rs
@@ -2,8 +2,8 @@ use std::path::Path;
 
 use tempfile::TempDir;
 use tokensave::agents::{
-    AgentIntegration, ClaudeIntegration, DoctorCounters, HealthcheckContext, InstallContext,
-    EXPECTED_TOOL_PERMS,
+    expected_tool_perms, AgentIntegration, ClaudeIntegration, DoctorCounters, HealthcheckContext,
+    InstallContext,
 };
 
 // ---------------------------------------------------------------------------
@@ -14,7 +14,7 @@ fn make_install_ctx(home: &Path) -> InstallContext {
     InstallContext {
         home: home.to_path_buf(),
         tokensave_bin: "/usr/local/bin/tokensave".to_string(),
-        tool_permissions: EXPECTED_TOOL_PERMS,
+        tool_permissions: expected_tool_perms(),
     }
 }
 
@@ -33,7 +33,7 @@ fn make_install_ctx_with_real_bin(home: &Path) -> InstallContext {
     InstallContext {
         home: home.to_path_buf(),
         tokensave_bin: bin_path.to_string_lossy().to_string(),
-        tool_permissions: EXPECTED_TOOL_PERMS,
+        tool_permissions: expected_tool_perms(),
     }
 }
 
@@ -123,9 +123,9 @@ fn test_install_creates_settings_with_permissions() {
         .expect("permissions.allow should be an array");
     let allow_strs: Vec<&str> = allow.iter().filter_map(|v| v.as_str()).collect();
 
-    for perm in EXPECTED_TOOL_PERMS {
+    for perm in expected_tool_perms() {
         assert!(
-            allow_strs.contains(perm),
+            allow_strs.contains(&perm.as_str()),
             "permissions.allow should contain {perm}"
         );
     }

--- a/tests/context_test.rs
+++ b/tests/context_test.rs
@@ -239,7 +239,7 @@ async fn test_get_code_reads_source_file() {
     };
 
     let builder = ContextBuilder::new(&db, project);
-    let code = builder.get_code(&node).await.unwrap();
+    let code = builder.get_code(&node).unwrap();
     assert!(code.is_some());
     let content = code.unwrap();
     assert!(content.contains("fn main()"));
@@ -284,7 +284,7 @@ async fn test_get_code_returns_none_for_missing_file() {
     };
 
     let builder = ContextBuilder::new(&db, project);
-    let code = builder.get_code(&node).await.unwrap();
+    let code = builder.get_code(&node).unwrap();
     assert!(code.is_none());
 }
 

--- a/tests/copilot_agent_test.rs
+++ b/tests/copilot_agent_test.rs
@@ -2,8 +2,8 @@ use std::path::Path;
 
 use tempfile::TempDir;
 use tokensave::agents::{
-    AgentIntegration, CopilotIntegration, DoctorCounters, HealthcheckContext, InstallContext,
-    EXPECTED_TOOL_PERMS,
+    expected_tool_perms, AgentIntegration, CopilotIntegration, DoctorCounters, HealthcheckContext,
+    InstallContext,
 };
 
 // ---------------------------------------------------------------------------
@@ -14,7 +14,7 @@ fn make_ctx(home: &Path) -> InstallContext {
     InstallContext {
         home: home.to_path_buf(),
         tokensave_bin: "/usr/local/bin/tokensave".to_string(),
-        tool_permissions: EXPECTED_TOOL_PERMS,
+        tool_permissions: expected_tool_perms(),
     }
 }
 

--- a/tests/mcp_handler_test.rs
+++ b/tests/mcp_handler_test.rs
@@ -1483,3 +1483,324 @@ async fn test_status_no_scope_prefix() {
         "status should not have scope_prefix when None"
     );
 }
+
+// ---------------------------------------------------------------------------
+// Edit tools: tokensave_str_replace, tokensave_multi_str_replace, tokensave_insert_at
+// ---------------------------------------------------------------------------
+
+#[tokio::test]
+async fn test_str_replace_success() {
+    let dir = TempDir::new().unwrap();
+    let project = dir.path();
+    fs::create_dir_all(project.join("src")).unwrap();
+
+    fs::write(project.join("src/main.rs"), "fn hello() {}\nfn world() {}\n")
+        .unwrap();
+
+    let cg = TokenSave::init(project).await.unwrap();
+    cg.index_all().await.unwrap();
+
+    let result = handle_tool_call(
+        &cg,
+        "tokensave_str_replace",
+        json!({
+            "path": "src/main.rs",
+            "old_str": "fn hello() {}",
+            "new_str": "fn hello_updated() {}"
+        }),
+        None,
+        None,
+    )
+    .await
+    .unwrap();
+
+    let text = extract_text(&result.value);
+    let parsed: serde_json::Value = serde_json::from_str(text).unwrap();
+    assert_eq!(parsed["success"], true);
+    assert_eq!(parsed["matched_str"], "fn hello() {}");
+    assert_eq!(parsed["new_str"], "fn hello_updated() {}");
+
+    let content = fs::read_to_string(project.join("src/main.rs")).unwrap();
+    assert!(content.contains("fn hello_updated() {}"));
+    assert!(!content.contains("fn hello() {}"));
+}
+
+#[tokio::test]
+async fn test_str_replace_not_found() {
+    let dir = TempDir::new().unwrap();
+    let project = dir.path();
+    fs::create_dir_all(project.join("src")).unwrap();
+
+    fs::write(project.join("src/main.rs"), "fn hello() {}\n").unwrap();
+
+    let cg = TokenSave::init(project).await.unwrap();
+    cg.index_all().await.unwrap();
+
+    let result = handle_tool_call(
+        &cg,
+        "tokensave_str_replace",
+        json!({
+            "path": "src/main.rs",
+            "old_str": "fn not_exists() {}",
+            "new_str": "fn replaced() {}"
+        }),
+        None,
+        None,
+    )
+    .await
+    .unwrap();
+
+    let text = extract_text(&result.value);
+    let parsed: serde_json::Value = serde_json::from_str(text).unwrap();
+    assert_eq!(parsed["success"], false);
+    assert!(parsed["message"].as_str().unwrap().contains("not found"));
+}
+
+#[tokio::test]
+async fn test_str_replace_multiple_matches_fails() {
+    let dir = TempDir::new().unwrap();
+    let project = dir.path();
+    fs::create_dir_all(project.join("src")).unwrap();
+
+    fs::write(project.join("src/main.rs"), "fn foo() {}\nfn foo() {}\n").unwrap();
+
+    let cg = TokenSave::init(project).await.unwrap();
+    cg.index_all().await.unwrap();
+
+    let result = handle_tool_call(
+        &cg,
+        "tokensave_str_replace",
+        json!({
+            "path": "src/main.rs",
+            "old_str": "fn foo() {}",
+            "new_str": "fn bar() {}"
+        }),
+        None,
+        None,
+    )
+    .await
+    .unwrap();
+
+    let text = extract_text(&result.value);
+    let parsed: serde_json::Value = serde_json::from_str(text).unwrap();
+    assert_eq!(parsed["success"], false);
+    assert!(parsed["message"].as_str().unwrap().contains("matches 2 times"));
+}
+
+#[tokio::test]
+async fn test_multi_str_replace_success() {
+    let dir = TempDir::new().unwrap();
+    let project = dir.path();
+    fs::create_dir_all(project.join("src")).unwrap();
+
+    fs::write(project.join("src/main.rs"), "fn foo() {}\nfn bar() {}\nfn baz() {}\n")
+        .unwrap();
+
+    let cg = TokenSave::init(project).await.unwrap();
+    cg.index_all().await.unwrap();
+
+    let result = handle_tool_call(
+        &cg,
+        "tokensave_multi_str_replace",
+        json!({
+            "path": "src/main.rs",
+            "replacements": [
+                ["fn foo() {}", "fn foo_replaced() {}"],
+                ["fn bar() {}", "fn bar_replaced() {}"]
+            ]
+        }),
+        None,
+        None,
+    )
+    .await
+    .unwrap();
+
+    let text = extract_text(&result.value);
+    let parsed: serde_json::Value = serde_json::from_str(text).unwrap();
+    assert_eq!(parsed["success"], true);
+    assert_eq!(parsed["applied_count"], 2);
+
+    let content = fs::read_to_string(project.join("src/main.rs")).unwrap();
+    assert!(content.contains("fn foo_replaced()"));
+    assert!(content.contains("fn bar_replaced()"));
+    assert!(content.contains("fn baz() {}"));
+}
+
+#[tokio::test]
+async fn test_multi_str_replace_atomic_failure() {
+    let dir = TempDir::new().unwrap();
+    let project = dir.path();
+    fs::create_dir_all(project.join("src")).unwrap();
+
+    fs::write(project.join("src/main.rs"), "fn foo() {}\nfn baz() {}\n").unwrap();
+
+    let cg = TokenSave::init(project).await.unwrap();
+    cg.index_all().await.unwrap();
+
+    let result = handle_tool_call(
+        &cg,
+        "tokensave_multi_str_replace",
+        json!({
+            "path": "src/main.rs",
+            "replacements": [
+                ["fn not_exists() {}", "fn replaced() {}"],
+                ["fn baz() {}", "fn baz_replaced() {}"]
+            ]
+        }),
+        None,
+        None,
+    )
+    .await
+    .unwrap();
+
+    let text = extract_text(&result.value);
+    let parsed: serde_json::Value = serde_json::from_str(text).unwrap();
+    assert_eq!(parsed["success"], false);
+    assert!(parsed["message"].as_str().unwrap().contains("must match exactly once"));
+
+    let content = fs::read_to_string(project.join("src/main.rs")).unwrap();
+    assert!(content.contains("fn foo() {}"));
+    assert!(content.contains("fn baz() {}"));
+    assert!(!content.contains("fn replaced()"));
+}
+
+#[tokio::test]
+async fn test_insert_at_string_anchor_before() {
+    let dir = TempDir::new().unwrap();
+    let project = dir.path();
+    fs::create_dir_all(project.join("src")).unwrap();
+
+    fs::write(project.join("src/main.rs"), "line one\nline two\nline three\n").unwrap();
+
+    let cg = TokenSave::init(project).await.unwrap();
+    cg.index_all().await.unwrap();
+
+    let result = handle_tool_call(
+        &cg,
+        "tokensave_insert_at",
+        json!({
+            "path": "src/main.rs",
+            "anchor": "line two",
+            "content": "inserted line",
+            "before": true
+        }),
+        None,
+        None,
+    )
+    .await
+    .unwrap();
+
+    let text = extract_text(&result.value);
+    let parsed: serde_json::Value = serde_json::from_str(text).unwrap();
+    assert_eq!(parsed["success"], true);
+
+    let content = fs::read_to_string(project.join("src/main.rs")).unwrap();
+    let lines: Vec<&str> = content.lines().collect();
+    assert_eq!(lines[0], "line one");
+    assert_eq!(lines[1], "inserted line");
+    assert_eq!(lines[2], "line two");
+    assert_eq!(lines[3], "line three");
+}
+
+#[tokio::test]
+async fn test_insert_at_line_number() {
+    let dir = TempDir::new().unwrap();
+    let project = dir.path();
+    fs::create_dir_all(project.join("src")).unwrap();
+
+    fs::write(project.join("src/main.rs"), "line one\nline two\nline three\n").unwrap();
+
+    let cg = TokenSave::init(project).await.unwrap();
+    cg.index_all().await.unwrap();
+
+    let result = handle_tool_call(
+        &cg,
+        "tokensave_insert_at",
+        json!({
+            "path": "src/main.rs",
+            "anchor": "2",
+            "content": "inserted at line 2",
+            "before": false
+        }),
+        None,
+        None,
+    )
+    .await
+    .unwrap();
+
+    let text = extract_text(&result.value);
+    let parsed: serde_json::Value = serde_json::from_str(text).unwrap();
+    assert_eq!(parsed["success"], true);
+    assert_eq!(parsed["anchor_line"], 2);
+
+    let content = fs::read_to_string(project.join("src/main.rs")).unwrap();
+    let lines: Vec<&str> = content.lines().collect();
+    assert_eq!(lines[0], "line one");
+    assert_eq!(lines[1], "line two");
+    assert_eq!(lines[2], "inserted at line 2");
+    assert_eq!(lines[3], "line three");
+}
+
+#[tokio::test]
+async fn test_insert_at_anchor_not_found() {
+    let dir = TempDir::new().unwrap();
+    let project = dir.path();
+    fs::create_dir_all(project.join("src")).unwrap();
+
+    fs::write(project.join("src/main.rs"), "line one\nline two\n").unwrap();
+
+    let cg = TokenSave::init(project).await.unwrap();
+    cg.index_all().await.unwrap();
+
+    let result = handle_tool_call(
+        &cg,
+        "tokensave_insert_at",
+        json!({
+            "path": "src/main.rs",
+            "anchor": "nonexistent",
+            "content": "should not be inserted",
+            "before": true
+        }),
+        None,
+        None,
+    )
+    .await
+    .unwrap();
+
+    let text = extract_text(&result.value);
+    let parsed: serde_json::Value = serde_json::from_str(text).unwrap();
+    assert_eq!(parsed["success"], false);
+    assert!(parsed["message"].as_str().unwrap().contains("not found"));
+}
+
+#[tokio::test]
+async fn test_insert_at_ambiguous_anchor() {
+    let dir = TempDir::new().unwrap();
+    let project = dir.path();
+    fs::create_dir_all(project.join("src")).unwrap();
+
+    fs::write(project.join("src/main.rs"), "line foo\nline foo\nline bar\n").unwrap();
+
+    let cg = TokenSave::init(project).await.unwrap();
+    cg.index_all().await.unwrap();
+
+    let result = handle_tool_call(
+        &cg,
+        "tokensave_insert_at",
+        json!({
+            "path": "src/main.rs",
+            "anchor": "foo",
+            "content": "should not be inserted",
+            "before": true
+        }),
+        None,
+        None,
+    )
+    .await
+    .unwrap();
+
+    let text = extract_text(&result.value);
+    let parsed: serde_json::Value = serde_json::from_str(text).unwrap();
+    assert_eq!(parsed["success"], false);
+    assert!(parsed["message"].as_str().unwrap().contains("matches 2 lines"));
+}

--- a/tests/mcp_handler_test.rs
+++ b/tests/mcp_handler_test.rs
@@ -1494,8 +1494,11 @@ async fn test_str_replace_success() {
     let project = dir.path();
     fs::create_dir_all(project.join("src")).unwrap();
 
-    fs::write(project.join("src/main.rs"), "fn hello() {}\nfn world() {}\n")
-        .unwrap();
+    fs::write(
+        project.join("src/main.rs"),
+        "fn hello() {}\nfn world() {}\n",
+    )
+    .unwrap();
 
     let cg = TokenSave::init(project).await.unwrap();
     cg.index_all().await.unwrap();
@@ -1584,7 +1587,10 @@ async fn test_str_replace_multiple_matches_fails() {
     let text = extract_text(&result.value);
     let parsed: serde_json::Value = serde_json::from_str(text).unwrap();
     assert_eq!(parsed["success"], false);
-    assert!(parsed["message"].as_str().unwrap().contains("matches 2 times"));
+    assert!(parsed["message"]
+        .as_str()
+        .unwrap()
+        .contains("matches 2 times"));
 }
 
 #[tokio::test]
@@ -1593,8 +1599,11 @@ async fn test_multi_str_replace_success() {
     let project = dir.path();
     fs::create_dir_all(project.join("src")).unwrap();
 
-    fs::write(project.join("src/main.rs"), "fn foo() {}\nfn bar() {}\nfn baz() {}\n")
-        .unwrap();
+    fs::write(
+        project.join("src/main.rs"),
+        "fn foo() {}\nfn bar() {}\nfn baz() {}\n",
+    )
+    .unwrap();
 
     let cg = TokenSave::init(project).await.unwrap();
     cg.index_all().await.unwrap();
@@ -1656,7 +1665,10 @@ async fn test_multi_str_replace_atomic_failure() {
     let text = extract_text(&result.value);
     let parsed: serde_json::Value = serde_json::from_str(text).unwrap();
     assert_eq!(parsed["success"], false);
-    assert!(parsed["message"].as_str().unwrap().contains("must match exactly once"));
+    assert!(parsed["message"]
+        .as_str()
+        .unwrap()
+        .contains("must match exactly once"));
 
     let content = fs::read_to_string(project.join("src/main.rs")).unwrap();
     assert!(content.contains("fn foo() {}"));
@@ -1670,7 +1682,11 @@ async fn test_insert_at_string_anchor_before() {
     let project = dir.path();
     fs::create_dir_all(project.join("src")).unwrap();
 
-    fs::write(project.join("src/main.rs"), "line one\nline two\nline three\n").unwrap();
+    fs::write(
+        project.join("src/main.rs"),
+        "line one\nline two\nline three\n",
+    )
+    .unwrap();
 
     let cg = TokenSave::init(project).await.unwrap();
     cg.index_all().await.unwrap();
@@ -1708,7 +1724,11 @@ async fn test_insert_at_line_number() {
     let project = dir.path();
     fs::create_dir_all(project.join("src")).unwrap();
 
-    fs::write(project.join("src/main.rs"), "line one\nline two\nline three\n").unwrap();
+    fs::write(
+        project.join("src/main.rs"),
+        "line one\nline two\nline three\n",
+    )
+    .unwrap();
 
     let cg = TokenSave::init(project).await.unwrap();
     cg.index_all().await.unwrap();
@@ -1779,7 +1799,11 @@ async fn test_insert_at_ambiguous_anchor() {
     let project = dir.path();
     fs::create_dir_all(project.join("src")).unwrap();
 
-    fs::write(project.join("src/main.rs"), "line foo\nline foo\nline bar\n").unwrap();
+    fs::write(
+        project.join("src/main.rs"),
+        "line foo\nline foo\nline bar\n",
+    )
+    .unwrap();
 
     let cg = TokenSave::init(project).await.unwrap();
     cg.index_all().await.unwrap();
@@ -1802,5 +1826,8 @@ async fn test_insert_at_ambiguous_anchor() {
     let text = extract_text(&result.value);
     let parsed: serde_json::Value = serde_json::from_str(text).unwrap();
     assert_eq!(parsed["success"], false);
-    assert!(parsed["message"].as_str().unwrap().contains("matches 2 lines"));
+    assert!(parsed["message"]
+        .as_str()
+        .unwrap()
+        .contains("matches 2 lines"));
 }

--- a/tests/mcp_test.rs
+++ b/tests/mcp_test.rs
@@ -93,7 +93,7 @@ fn test_all_error_codes() {
 #[test]
 fn test_tool_definitions_count() {
     let tools = get_tool_definitions();
-    assert_eq!(tools.len(), 37);
+    assert_eq!(tools.len(), 41);
 }
 
 #[test]

--- a/tests/opencode_agent_test.rs
+++ b/tests/opencode_agent_test.rs
@@ -2,8 +2,8 @@ use std::path::Path;
 
 use tempfile::TempDir;
 use tokensave::agents::{
-    AgentIntegration, DoctorCounters, HealthcheckContext, InstallContext, OpenCodeIntegration,
-    EXPECTED_TOOL_PERMS,
+    expected_tool_perms, AgentIntegration, DoctorCounters, HealthcheckContext, InstallContext,
+    OpenCodeIntegration,
 };
 
 // ---------------------------------------------------------------------------
@@ -14,7 +14,7 @@ fn make_ctx(home: &Path) -> InstallContext {
     InstallContext {
         home: home.to_path_buf(),
         tokensave_bin: "/usr/local/bin/tokensave".to_string(),
-        tool_permissions: EXPECTED_TOOL_PERMS,
+        tool_permissions: expected_tool_perms(),
     }
 }
 


### PR DESCRIPTION
## Summary

**Edit primitives for code modification** — four new MCP tools enable Claude&friends to edit files without regex or shell quoting hazards:
  - `tokensave_str_replace` — replaces a unique `old_str` with `new_str`; fails if 0 or >1 matches, protecting against multi-edit bugs
  - `tokensave_multi_str_replace` — applies N `(old, new)` replacements atomically; all-or-nothing transaction
  - `tokensave_insert_at` — inserts content before or after a unique anchor string or line number
  - `tokensave_ast_grep_rewrite` — structural code rewrite via ast-grep CLI (`--rewrite` mode)
- **Auto re-indexing** — all edit tools automatically re-index the modified file in the code graph after writing, so the graph stays in sync without manual steps<!-- What does this PR do? 1-3 bullet points. -->

**Other fixes:**
  - TOOL_NAMES and EXPECTED TOOL_PERMS where static, this patch make them dynamic: doctor and install now add the missing tools
  - Monitor now grouped per project then per tool

**Note**: I am testing for a few days and will report back on the efficiency in practical tests.

## Motivation

- Speed up multiple str replace which is where claude is loosing time and using too many tokens.

## Changes

## Test plan

- [x] `cargo test` passes
- [x] `cargo clippy` has no new warnings
- [x] Tested manually (describe below if applicable)

## Checklist

- [x] `CHANGELOG.md` updated (under `[Unreleased]` if no version bump)
- [x] No secrets, credentials, or `.env` files included
- [ ] Breaking changes documented (if any)
