### PR TITLE
fix: avoid panic when parsing empty Java docstrings

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+- `java_extraction` avoid panic when parsing empty Java docstrings (fixes #44)
+
 ## [4.1.5] - 2026-04-29
 
 ### Added

--- a/src/extraction/java_extractor.rs
+++ b/src/extraction/java_extractor.rs
@@ -965,7 +965,11 @@ impl JavaExtractor {
         let trimmed = comment.trim();
         // Strip /** prefix and */ suffix.
         let inner = if trimmed.starts_with("/**") && trimmed.ends_with("*/") {
-            &trimmed[3..trimmed.len() - 2]
+            if trimmed.len() >= 5 {
+                &trimmed[3..trimmed.len() - 2]
+            } else {
+                "" // Handles "/**/"
+            }
         } else {
             trimmed
         };

--- a/tests/java_extraction_test.rs
+++ b/tests/java_extraction_test.rs
@@ -3,6 +3,30 @@ use tokensave::extraction::LanguageExtractor;
 use tokensave::types::*;
 
 #[test]
+fn test_java_empty_javadoc_no_panic() {
+    let source = r#"
+public class PanicReproduction {
+    /**/
+    public enum Problem {
+        VALUE
+    }
+}
+"#;
+    let extractor = JavaExtractor;
+    let result = extractor.extract("PanicReproduction.java", source);
+    assert!(result.errors.is_empty(), "errors: {:?}", result.errors);
+
+    let enums: Vec<_> = result
+        .nodes
+        .iter()
+        .filter(|n| n.kind == NodeKind::Enum)
+        .collect();
+    assert_eq!(enums.len(), 1);
+    assert_eq!(enums[0].name, "Problem");
+    assert!(enums[0].docstring.is_none() || enums[0].docstring.as_ref().unwrap().is_empty());
+}
+
+#[test]
 fn test_java_extract_package() {
     let source = r#"package com.example.app;
 


### PR DESCRIPTION
## Summary

Added a length check in `clean_javadoc` to safely handle short docstrings.

-

## Motivation

The Java extractor would panic when encountering the 4-character docstring `/**/` because it attempted a slice `[3..len-2]` which evaluates to `[3..2]`.

## Changes

<!-- Key files/areas modified. Highlight anything non-obvious. -->

-

## Test plan

- [x] `cargo test` passes
- [x] `cargo clippy` has no new warnings
- [ ] Tested manually (describe below if applicable)

<!-- For new language extractors: fixture file added, extraction test added. -->
<!-- For sync/DB changes: tested with `tokensave sync --doctor` on a real project. -->

## Checklist

- [x] `CHANGELOG.md` updated (under `[Unreleased]` if no version bump)
- [x] No secrets, credentials, or `.env` files included
- [x] Breaking changes documented (if any)
