### PR TITLE
feat: add markdown extraction support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+- **Markdown extraction** — tree-sitter based markdown parser that extracts headers as `Module` nodes with hierarchical `Contains` edges, and code links as `Uses` edges for cross-reference tracking (PR #47)
+
 ### Fixed
 - `java_extraction` avoid panic when parsing empty Java docstrings (fixes #44)
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4041,6 +4041,7 @@ dependencies = [
  "tracing",
  "tracing-subscriber",
  "tree-sitter",
+ "tree-sitter-markdown-fork",
  "ureq",
  "walkdir",
  "windows-sys 0.61.2",
@@ -4541,6 +4542,16 @@ checksum = "8daaf5f4235188a58603c39760d5fa5d4b920d36a299c934adddae757f32a10c"
 dependencies = [
  "cc",
  "tree-sitter-language",
+]
+
+[[package]]
+name = "tree-sitter-markdown-fork"
+version = "0.7.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3d5ad4a0fbf1d16abe5391387dab9e25977ba0c86661627a2e8680386c8a1c27"
+dependencies = [
+ "cc",
+ "tree-sitter",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -31,7 +31,7 @@ default = ["full"]
 lite = []
 
 medium = ["lang-dart", "lang-pascal", "lang-php", "lang-ruby", "lang-bash", "lang-protobuf", "lang-powershell", "lang-nix", "lang-vbnet"]
-full = ["medium", "lang-lua", "lang-zig", "lang-objc", "lang-perl", "lang-batch", "lang-fortran", "lang-cobol", "lang-msbasic2", "lang-gwbasic", "lang-qbasic", "lang-dockerfile", "lang-glsl"]
+full = ["medium", "lang-lua", "lang-zig", "lang-objc", "lang-perl", "lang-batch", "lang-fortran", "lang-cobol", "lang-msbasic2", "lang-gwbasic", "lang-qbasic", "lang-dockerfile", "lang-glsl", "lang-markdown"]
 
 # Language features (all grammars provided by tokensave-large-treesitters)
 lang-dart = []
@@ -55,6 +55,7 @@ lang-gwbasic = []
 lang-qbasic = []
 lang-dockerfile = []
 lang-glsl = []
+lang-markdown = []
 test-transport = []
 
 [lib]
@@ -67,6 +68,7 @@ path = "src/main.rs"
 [dependencies]
 libsql = "0.9.30"
 tree-sitter = "0.26"
+tree-sitter-markdown-fork = "0.7"
 tokensave-large-treesitters = "0.3.1"
 ort = { version = "2.0.0-rc.12", features = ["load-dynamic"] }
 ndarray = "0.17"

--- a/src/doctor.rs
+++ b/src/doctor.rs
@@ -204,6 +204,23 @@ fn check_network(dc: &mut DoctorCounters) {
     }
 }
 
+/// Print final summary.
+fn print_summary(dc: &DoctorCounters) {
+    eprintln!();
+    if dc.issues == 0 && dc.warnings == 0 {
+        eprintln!("\x1b[32mAll checks passed.\x1b[0m");
+    } else if dc.issues == 0 {
+        eprintln!("\x1b[33m{} warning(s), no issues.\x1b[0m", dc.warnings);
+    } else {
+        eprintln!(
+            "\x1b[31m{} issue(s), {} warning(s).\x1b[0m",
+            dc.issues, dc.warnings
+        );
+        eprintln!("Run \x1b[1mtokensave install\x1b[0m to fix most issues.");
+    }
+    eprintln!();
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -228,21 +245,4 @@ mod tests {
         // 1536 = 1.5 KB
         assert_eq!(format_bytes(1536), "1.5 KB");
     }
-}
-
-/// Print final summary.
-fn print_summary(dc: &DoctorCounters) {
-    eprintln!();
-    if dc.issues == 0 && dc.warnings == 0 {
-        eprintln!("\x1b[32mAll checks passed.\x1b[0m");
-    } else if dc.issues == 0 {
-        eprintln!("\x1b[33m{} warning(s), no issues.\x1b[0m", dc.warnings);
-    } else {
-        eprintln!(
-            "\x1b[31m{} issue(s), {} warning(s).\x1b[0m",
-            dc.issues, dc.warnings
-        );
-        eprintln!("Run \x1b[1mtokensave install\x1b[0m to fix most issues.");
-    }
-    eprintln!();
 }

--- a/src/errors.rs
+++ b/src/errors.rs
@@ -118,8 +118,11 @@ mod tests {
 
     #[test]
     fn json_error_from_serde() {
-        let serde_err = serde_json::from_str::<serde_json::Value>("bad json").unwrap_err();
-        let err: TokenSaveError = serde_err.into();
+        let serde_err = serde_json::from_str::<serde_json::Value>("bad json");
+        let err: TokenSaveError = match serde_err {
+            Err(e) => e.into(),
+            Ok(_) => panic!("expected JSON parse error"),
+        };
         assert!(err.to_string().contains("json error"));
     }
 }

--- a/src/extraction/markdown_extractor.rs
+++ b/src/extraction/markdown_extractor.rs
@@ -1,0 +1,348 @@
+/// Tree-sitter based Markdown source code extractor.
+///
+/// Parses Markdown source files and emits nodes and edges for the code graph.
+use std::time::{Instant, SystemTime, UNIX_EPOCH};
+
+use tree_sitter::{Node as TsNode, Parser, Tree};
+
+use crate::types::{
+    generate_node_id, Edge, EdgeKind, ExtractionResult, Node, NodeKind, Visibility,
+};
+
+pub struct MarkdownExtractor;
+
+struct ExtractionState {
+    nodes: Vec<Node>,
+    edges: Vec<Edge>,
+    file_path: String,
+    source: Vec<u8>,
+    timestamp: u64,
+    node_stack: Vec<(String, String, usize)>,
+}
+
+impl ExtractionState {
+    fn new(file_path: &str, source: &str) -> Self {
+        let timestamp = SystemTime::now()
+            .duration_since(UNIX_EPOCH)
+            .unwrap_or_default()
+            .as_secs();
+        Self {
+            nodes: Vec::new(),
+            edges: Vec::new(),
+            file_path: file_path.to_string(),
+            source: source.as_bytes().to_vec(),
+            timestamp,
+            node_stack: Vec::new(),
+        }
+    }
+
+    fn node_text(&self, node: TsNode<'_>) -> String {
+        node.utf8_text(&self.source)
+            .unwrap_or("<invalid utf8>")
+            .to_string()
+    }
+}
+
+impl MarkdownExtractor {
+    pub fn extract_markdown(file_path: &str, source: &str) -> ExtractionResult {
+        let start = Instant::now();
+        let mut state = ExtractionState::new(file_path, source);
+
+        let file_node = Node {
+            id: generate_node_id(file_path, &NodeKind::File, file_path, 0),
+            kind: NodeKind::File,
+            name: file_path.to_string(),
+            qualified_name: file_path.to_string(),
+            file_path: file_path.to_string(),
+            start_line: 0,
+            end_line: source.lines().count().saturating_sub(1) as u32,
+            start_column: 0,
+            end_column: 0,
+            signature: None,
+            docstring: None,
+            visibility: Visibility::Pub,
+            is_async: false,
+            branches: 0,
+            loops: 0,
+            returns: 0,
+            max_nesting: 0,
+            unsafe_blocks: 0,
+            unchecked_calls: 0,
+            assertions: 0,
+            updated_at: state.timestamp,
+        };
+        let file_node_id = file_node.id.clone();
+        state.nodes.push(file_node);
+        state
+            .node_stack
+            .push((file_path.to_string(), file_node_id, 0));
+
+        match Self::parse_source(source) {
+            Ok(tree) => {
+                let root = tree.root_node();
+                Self::visit_children(&mut state, root);
+            }
+            Err(_msg) => {
+                state.edges.push(Edge {
+                    source: state.node_stack[0].1.clone(),
+                    target: state.node_stack[0].1.clone(),
+                    kind: EdgeKind::Contains,
+                    line: Some(0),
+                });
+            }
+        }
+
+        state.node_stack.pop();
+
+        ExtractionResult {
+            nodes: state.nodes,
+            edges: state.edges,
+            unresolved_refs: Vec::new(),
+            errors: Vec::new(),
+            duration_ms: start.elapsed().as_millis() as u64,
+        }
+    }
+
+    fn parse_source(source: &str) -> Result<Tree, String> {
+        let mut parser = Parser::new();
+        parser
+            .set_language(&tree_sitter_markdown_fork::language())
+            .map_err(|e| format!("failed to load markdown grammar: {e}"))?;
+        parser
+            .parse(source, None)
+            .ok_or_else(|| "tree-sitter parse returned None".to_string())
+    }
+
+    fn visit_children(state: &mut ExtractionState, node: TsNode<'_>) {
+        let mut cursor = node.walk();
+        if cursor.goto_first_child() {
+            loop {
+                let child = cursor.node();
+                Self::visit_node(state, child);
+                if !cursor.goto_next_sibling() {
+                    break;
+                }
+            }
+        }
+    }
+
+    fn visit_node(state: &mut ExtractionState, node: TsNode<'_>) {
+        let kind = node.kind();
+        match kind {
+            "atx_heading" => {
+                Self::visit_heading(state, node);
+            }
+            "link" => {
+                Self::visit_link(state, node);
+            }
+            _ => {
+                Self::visit_children(state, node);
+            }
+        }
+    }
+
+    fn visit_heading(state: &mut ExtractionState, node: TsNode<'_>) {
+        let marker = node
+            .children(&mut node.walk())
+            .find(|n| n.kind().starts_with("atx_h") && n.kind().contains("_marker"));
+        let level = marker
+            .as_ref()
+            .map_or(1, |m| {
+                let kind = m.kind();
+                let parts: Vec<&str> = kind.split('_').collect();
+                if parts.len() >= 2 {
+                    parts[1]
+                        .trim_start_matches('h')
+                        .parse::<usize>()
+                        .unwrap_or(1)
+                } else {
+                    1
+                }
+            })
+            .min(6);
+
+        let title_node = node
+            .children(&mut node.walk())
+            .find(|n| n.kind() == "heading_content")
+            .map(|n| state.node_text(n).trim().to_string())
+            .unwrap_or_default();
+
+        if title_node.is_empty() {
+            return;
+        }
+
+        while state.node_stack.len() > 1 {
+            let last_level = state.node_stack[state.node_stack.len() - 1].2;
+            if last_level >= level {
+                state.node_stack.pop();
+            } else {
+                break;
+            }
+        }
+
+        let kind = NodeKind::Module;
+        let parent_name = &state.node_stack[state.node_stack.len() - 1].0;
+        let qualified_name = format!("{parent_name}::{title_node}");
+        let id = generate_node_id(
+            &state.file_path,
+            &kind,
+            &title_node,
+            node.start_position().row as u32,
+        );
+
+        let node_obj = Node {
+            id: id.clone(),
+            kind,
+            name: title_node.clone(),
+            qualified_name: qualified_name.clone(),
+            file_path: state.file_path.clone(),
+            start_line: node.start_position().row as u32,
+            end_line: node.end_position().row as u32,
+            start_column: node.start_position().column as u32,
+            end_column: node.end_position().column as u32,
+            signature: Some(format!("{} {}", "#".repeat(level), title_node)),
+            docstring: None,
+            visibility: Visibility::Pub,
+            is_async: false,
+            branches: 0,
+            loops: 0,
+            returns: 0,
+            max_nesting: 0,
+            unsafe_blocks: 0,
+            unchecked_calls: 0,
+            assertions: 0,
+            updated_at: state.timestamp,
+        };
+
+        if let Some((_, parent_id, _)) = state.node_stack.last() {
+            state.edges.push(Edge {
+                source: parent_id.clone(),
+                target: id.clone(),
+                kind: EdgeKind::Contains,
+                line: Some(node.start_position().row as u32),
+            });
+        }
+
+        state.nodes.push(node_obj);
+        state.node_stack.push((title_node, id, level));
+    }
+
+    fn visit_link(state: &mut ExtractionState, node: TsNode<'_>) {
+        let url_node = node
+            .children(&mut node.walk())
+            .find(|n| n.kind() == "link_destination");
+
+        let Some(url_node) = url_node else {
+            return;
+        };
+
+        let url = state.node_text(url_node);
+
+        if url.starts_with("http://") || url.starts_with("https://") {
+            return;
+        }
+
+        let target_path = url.trim_start_matches("file:");
+        let target_ext = target_path.rsplit('.').next().unwrap_or("");
+
+        if !is_code_extension(target_ext) {
+            return;
+        }
+
+        let text_node = node
+            .children(&mut node.walk())
+            .find(|n| n.kind() == "link_text");
+        let link_text = text_node.map_or_else(|| target_path.to_string(), |n| state.node_text(n));
+
+        let target_id = generate_node_id(target_path, &NodeKind::Use, &link_text, 0);
+
+        if let Some((_, parent_id, _)) = state.node_stack.last() {
+            state.edges.push(Edge {
+                source: parent_id.clone(),
+                target: target_id,
+                kind: EdgeKind::Uses,
+                line: Some(node.start_position().row as u32),
+            });
+        }
+    }
+}
+
+fn is_code_extension(ext: &str) -> bool {
+    matches!(
+        ext,
+        "rs" | "py"
+            | "js"
+            | "ts"
+            | "tsx"
+            | "jsx"
+            | "go"
+            | "java"
+            | "c"
+            | "cpp"
+            | "h"
+            | "hpp"
+            | "cs"
+            | "rb"
+            | "php"
+            | "swift"
+            | "kt"
+            | "scala"
+            | "R"
+            | "sh"
+            | "bash"
+            | "zsh"
+            | "fish"
+            | "ps1"
+            | "ex"
+            | "exs"
+            | "erl"
+            | "hrl"
+            | "fs"
+            | "fsx"
+            | "ml"
+            | "mli"
+            | "hs"
+            | "lhs"
+            | "lua"
+            | "pl"
+            | "pm"
+            | "t"
+            | "nix"
+            | "yaml"
+            | "yml"
+            | "toml"
+            | "json"
+            | "xml"
+            | "html"
+            | "htm"
+            | "css"
+            | "scss"
+            | "sass"
+            | "less"
+            | "md"
+            | "markdown"
+            | "sql"
+            | "db"
+            | "proto"
+            | "v"
+            | "vhd"
+            | "vhdl"
+            | "sage"
+            | "sagews"
+            | "ipynb"
+    )
+}
+
+impl crate::extraction::LanguageExtractor for MarkdownExtractor {
+    fn extensions(&self) -> &[&str] {
+        &["md", "markdown"]
+    }
+
+    fn language_name(&self) -> &'static str {
+        "Markdown"
+    }
+
+    fn extract(&self, file_path: &str, source: &str) -> ExtractionResult {
+        Self::extract_markdown(file_path, source)
+    }
+}

--- a/src/extraction/markdown_extractor.rs
+++ b/src/extraction/markdown_extractor.rs
@@ -83,12 +83,7 @@ impl MarkdownExtractor {
                 Self::visit_children(&mut state, root);
             }
             Err(_msg) => {
-                state.edges.push(Edge {
-                    source: state.node_stack[0].1.clone(),
-                    target: state.node_stack[0].1.clone(),
-                    kind: EdgeKind::Contains,
-                    line: Some(0),
-                });
+                // Parse failed; skip extraction rather than creating a self-loop
             }
         }
 
@@ -132,6 +127,7 @@ impl MarkdownExtractor {
             "atx_heading" => {
                 Self::visit_heading(state, node);
             }
+            // TODO: Add support for setext_heading (H1\n===, H2\n---)
             "link" => {
                 Self::visit_link(state, node);
             }
@@ -142,6 +138,9 @@ impl MarkdownExtractor {
     }
 
     fn visit_heading(state: &mut ExtractionState, node: TsNode<'_>) {
+        // TODO: Count '#' characters in marker text instead of parsing
+        // tree-sitter node kind string (atx_h2_marker -> extract "2").
+        // Counting '#' chars is simpler and more robust.
         let marker = node
             .children(&mut node.walk())
             .find(|n| n.kind().starts_with("atx_h") && n.kind().contains("_marker"));
@@ -254,7 +253,7 @@ impl MarkdownExtractor {
             .find(|n| n.kind() == "link_text");
         let link_text = text_node.map_or_else(|| target_path.to_string(), |n| state.node_text(n));
 
-        let target_id = generate_node_id(target_path, &NodeKind::Use, &link_text, 0);
+        let target_id = generate_node_id(target_path, &NodeKind::File, target_path, 0);
 
         if let Some((_, parent_id, _)) = state.node_stack.last() {
             state.edges.push(Edge {
@@ -268,6 +267,9 @@ impl MarkdownExtractor {
 }
 
 fn is_code_extension(ext: &str) -> bool {
+    // Only include actual programming-language source files.
+    // Config (yaml, toml, json), markup (html, css, markdown), and
+    // notebook (ipynb) files are excluded to avoid low-signal edges.
     matches!(
         ext,
         "rs" | "py"
@@ -308,28 +310,13 @@ fn is_code_extension(ext: &str) -> bool {
             | "pm"
             | "t"
             | "nix"
-            | "yaml"
-            | "yml"
-            | "toml"
-            | "json"
-            | "xml"
-            | "html"
-            | "htm"
-            | "css"
-            | "scss"
-            | "sass"
-            | "less"
-            | "md"
-            | "markdown"
             | "sql"
-            | "db"
             | "proto"
             | "v"
             | "vhd"
             | "vhdl"
             | "sage"
             | "sagews"
-            | "ipynb"
     )
 }
 

--- a/src/extraction/mod.rs
+++ b/src/extraction/mod.rs
@@ -50,6 +50,8 @@ mod glsl_extractor;
 mod gwbasic_extractor;
 #[cfg(feature = "lang-lua")]
 mod lua_extractor;
+#[cfg(feature = "lang-markdown")]
+mod markdown_extractor;
 #[cfg(feature = "lang-msbasic2")]
 mod msbasic2_extractor;
 #[cfg(feature = "lang-objc")]
@@ -111,6 +113,8 @@ pub use glsl_extractor::GlslExtractor;
 pub use gwbasic_extractor::GwBasicExtractor;
 #[cfg(feature = "lang-lua")]
 pub use lua_extractor::LuaExtractor;
+#[cfg(feature = "lang-markdown")]
+pub use markdown_extractor::MarkdownExtractor;
 #[cfg(feature = "lang-msbasic2")]
 pub use msbasic2_extractor::MsBasic2Extractor;
 #[cfg(feature = "lang-objc")]
@@ -217,6 +221,8 @@ impl LanguageRegistry {
         extractors.push(Box::new(DockerfileExtractor));
         #[cfg(feature = "lang-glsl")]
         extractors.push(Box::new(GlslExtractor));
+        #[cfg(feature = "lang-markdown")]
+        extractors.push(Box::new(MarkdownExtractor));
 
         Self { extractors }
     }

--- a/tests/extraction_test.rs
+++ b/tests/extraction_test.rs
@@ -342,7 +342,7 @@ fn test_language_registry_finds_scala_extractor() {
 fn test_language_registry_returns_none_for_unknown() {
     let registry = LanguageRegistry::new();
     assert!(registry.extractor_for_file("style.css").is_none());
-    assert!(registry.extractor_for_file("README.md").is_none());
+    assert!(registry.extractor_for_file("README.unknown").is_none());
 }
 
 #[test]

--- a/tests/integration_test.rs
+++ b/tests/integration_test.rs
@@ -36,7 +36,10 @@ fn test_ignore_crate_nested_gitignore_direct() {
         })
         .collect();
 
-    assert!(files.contains(&"src/lib.rs".to_string()), "lib.rs must be found");
+    assert!(
+        files.contains(&"src/lib.rs".to_string()),
+        "lib.rs must be found"
+    );
     assert!(
         !files.iter().any(|f| f.contains("vendor")),
         "nested .gitignore (*) must exclude vendor/gen.rs; got: {files:?}"
@@ -474,7 +477,10 @@ async fn test_nested_gitignore_excludes_files_in_subdir() {
     let cg = setup_gitignore_project(project).await;
     let result = cg.index_all().await.unwrap();
 
-    assert_eq!(result.file_count, 1, "vendor/ should be excluded by nested .gitignore");
+    assert_eq!(
+        result.file_count, 1,
+        "vendor/ should be excluded by nested .gitignore"
+    );
 
     let files = cg.get_all_files().await.unwrap();
     let paths: Vec<&str> = files.iter().map(|f| f.path.as_str()).collect();
@@ -494,7 +500,11 @@ async fn test_nested_gitignore_scope_is_limited_to_its_directory() {
 
     fs::create_dir_all(project.join("src/internal")).unwrap();
     fs::write(project.join("src/lib.rs"), "pub fn public_api() {}\n").unwrap();
-    fs::write(project.join("src/internal/secret.rs"), "pub fn secret() {}\n").unwrap();
+    fs::write(
+        project.join("src/internal/secret.rs"),
+        "pub fn secret() {}\n",
+    )
+    .unwrap();
     // The nested .gitignore only covers files within src/internal/.
     fs::write(project.join("src/internal/.gitignore"), "*.rs\n").unwrap();
 
@@ -532,7 +542,11 @@ async fn test_nested_gitignore_negation_overrides_parent_rule() {
     )
     .unwrap();
     // This sibling file stays excluded by the root rule.
-    fs::write(project.join("src/exceptions/ignored.rs"), "pub fn ignored() {}\n").unwrap();
+    fs::write(
+        project.join("src/exceptions/ignored.rs"),
+        "pub fn ignored() {}\n",
+    )
+    .unwrap();
 
     let cg = setup_gitignore_project(project).await;
     cg.index_all().await.unwrap();
@@ -571,7 +585,10 @@ async fn test_nested_gitignore_applies_to_deeper_descendants() {
     let files = cg.get_all_files().await.unwrap();
     let paths: Vec<&str> = files.iter().map(|f| f.path.as_str()).collect();
     assert!(paths.contains(&"src/lib.rs"), "src/lib.rs must be indexed");
-    assert!(paths.contains(&"src/mid/mid.rs"), "src/mid/mid.rs must be indexed");
+    assert!(
+        paths.contains(&"src/mid/mid.rs"),
+        "src/mid/mid.rs must be indexed"
+    );
     assert!(
         !paths.iter().any(|p| p.contains("deep")),
         "src/mid/deep/leaf.rs must be excluded by mid-level .gitignore"

--- a/tests/markdown_extraction_test.rs
+++ b/tests/markdown_extraction_test.rs
@@ -1,0 +1,217 @@
+use tokensave::extraction::LanguageExtractor;
+use tokensave::extraction::MarkdownExtractor;
+use tokensave::types::*;
+
+#[test]
+fn test_markdown_file_node_is_root() {
+    let source = "# Hello\n\nSome content.";
+    let result = MarkdownExtractor.extract("README.md", source);
+    assert!(result.errors.is_empty(), "errors: {:?}", result.errors);
+    let files: Vec<_> = result
+        .nodes
+        .iter()
+        .filter(|n| n.kind == NodeKind::File)
+        .collect();
+    assert_eq!(files.len(), 1);
+    assert_eq!(files[0].name, "README.md");
+}
+
+#[test]
+fn test_markdown_extracts_headers() {
+    let source = "# Title\n\n## Section\n\n### Subsection";
+    let result = MarkdownExtractor.extract("README.md", source);
+    assert!(result.errors.is_empty(), "errors: {:?}", result.errors);
+    let modules: Vec<_> = result
+        .nodes
+        .iter()
+        .filter(|n| n.kind == NodeKind::Module)
+        .collect();
+    assert_eq!(modules.len(), 3);
+    assert_eq!(modules[0].name, "Title");
+    assert_eq!(modules[1].name, "Section");
+    assert_eq!(modules[2].name, "Subsection");
+}
+
+#[test]
+fn test_markdown_header_hierarchy() {
+    let source = "# Top\n\n## Section1\n\n### Deep\n\n## Section2";
+    let result = MarkdownExtractor.extract("README.md", source);
+    assert!(result.errors.is_empty(), "errors: {:?}", result.errors);
+    // Section1 and Section2 should be children of Top
+    // Deep should be child of Section1
+    let top = result.nodes.iter().find(|n| n.name == "Top").unwrap();
+    let section1 = result.nodes.iter().find(|n| n.name == "Section1").unwrap();
+    let section2 = result.nodes.iter().find(|n| n.name == "Section2").unwrap();
+    let deep = result.nodes.iter().find(|n| n.name == "Deep").unwrap();
+
+    let contains_edges: Vec<_> = result
+        .edges
+        .iter()
+        .filter(|e| e.kind == EdgeKind::Contains)
+        .collect();
+
+    // Check Top contains Section1 and Section2
+    let top_contains: Vec<_> = contains_edges
+        .iter()
+        .filter(|e| e.source == top.id)
+        .collect();
+    assert!(top_contains.iter().any(|e| e.target == section1.id));
+    assert!(top_contains.iter().any(|e| e.target == section2.id));
+
+    // Check Section1 contains Deep
+    let section1_contains: Vec<_> = contains_edges
+        .iter()
+        .filter(|e| e.source == section1.id)
+        .collect();
+    assert!(section1_contains.iter().any(|e| e.target == deep.id));
+}
+
+#[test]
+fn test_markdown_extracts_code_links() {
+    let source = "See [main.rs](src/main.rs) for details.";
+    let result = MarkdownExtractor.extract("README.md", source);
+    assert!(result.errors.is_empty(), "errors: {:?}", result.errors);
+    let uses_edges: Vec<_> = result
+        .edges
+        .iter()
+        .filter(|e| e.kind == EdgeKind::Uses)
+        .collect();
+    assert!(
+        !uses_edges.is_empty(),
+        "should have Uses edge for code link"
+    );
+}
+
+#[test]
+fn test_markdown_skips_external_links() {
+    let source = "Check [Google](https://google.com) for more.";
+    let result = MarkdownExtractor.extract("README.md", source);
+    assert!(result.errors.is_empty(), "errors: {:?}", result.errors);
+    let uses_edges: Vec<_> = result
+        .edges
+        .iter()
+        .filter(|e| e.kind == EdgeKind::Uses)
+        .collect();
+    assert!(
+        uses_edges.is_empty(),
+        "should not create Uses edge for external links"
+    );
+}
+
+#[test]
+fn test_markdown_skips_non_code_links() {
+    let source = "See [image](docs/image.png) for diagram.";
+    let result = MarkdownExtractor.extract("README.md", source);
+    assert!(result.errors.is_empty(), "errors: {:?}", result.errors);
+    // .png is not a code extension, so no Uses edge
+    let uses_edges: Vec<_> = result
+        .edges
+        .iter()
+        .filter(|e| e.kind == EdgeKind::Uses)
+        .collect();
+    assert!(
+        uses_edges.is_empty(),
+        "should not create Uses edge for non-code links"
+    );
+}
+
+#[test]
+fn test_markdown_handles_code_blocks() {
+    // Code blocks should not be treated as headers
+    let source = "# Title\n\n```rust\nfn main() {}\n```\n\n## Next";
+    let result = MarkdownExtractor.extract("README.md", source);
+    assert!(result.errors.is_empty(), "errors: {:?}", result.errors);
+    let modules: Vec<_> = result
+        .nodes
+        .iter()
+        .filter(|n| n.kind == NodeKind::Module)
+        .collect();
+    assert_eq!(modules.len(), 2);
+    assert_eq!(modules[0].name, "Title");
+    assert_eq!(modules[1].name, "Next");
+}
+
+#[test]
+fn test_markdown_handles_empty_file() {
+    let source = "";
+    let result = MarkdownExtractor.extract("README.md", source);
+    assert!(result.errors.is_empty(), "errors: {:?}", result.errors);
+    // Should still have a File node
+    let files: Vec<_> = result
+        .nodes
+        .iter()
+        .filter(|n| n.kind == NodeKind::File)
+        .collect();
+    assert_eq!(files.len(), 1);
+}
+
+#[test]
+fn test_markdown_handles_no_headers() {
+    let source = "Just some plain text without any headers.";
+    let result = MarkdownExtractor.extract("README.md", source);
+    assert!(result.errors.is_empty(), "errors: {:?}", result.errors);
+    let modules: Vec<_> = result
+        .nodes
+        .iter()
+        .filter(|n| n.kind == NodeKind::Module)
+        .collect();
+    assert!(modules.is_empty(), "should have no Module nodes");
+}
+
+#[test]
+fn test_markdown_extensions() {
+    let ext = MarkdownExtractor;
+    let extensions = ext.extensions();
+    assert!(extensions.contains(&"md"));
+    assert!(extensions.contains(&"markdown"));
+}
+
+#[test]
+fn test_markdown_language_name() {
+    let ext = MarkdownExtractor;
+    assert_eq!(ext.language_name(), "Markdown");
+}
+
+#[test]
+fn test_markdown_multiple_links_same_line() {
+    let source = "See [main](src/main.rs) and [lib](src/lib.rs).";
+    let result = MarkdownExtractor.extract("README.md", source);
+    assert!(result.errors.is_empty(), "errors: {:?}", result.errors);
+    let uses_edges: Vec<_> = result
+        .edges
+        .iter()
+        .filter(|e| e.kind == EdgeKind::Uses)
+        .collect();
+    assert_eq!(uses_edges.len(), 2);
+}
+
+#[test]
+fn test_markdown_links_with_fragments() {
+    let source = "See [section](#section) for details.";
+    let result = MarkdownExtractor.extract("README.md", source);
+    assert!(result.errors.is_empty(), "errors: {:?}", result.errors);
+    // Fragment links don't have file extensions that match code patterns
+    let uses_edges: Vec<_> = result
+        .edges
+        .iter()
+        .filter(|e| e.kind == EdgeKind::Uses)
+        .collect();
+    assert!(
+        uses_edges.is_empty(),
+        "fragment links should not create Uses edges"
+    );
+}
+
+#[test]
+fn test_markdown_handles_header_with_punctuation() {
+    let source = "# Hello, World! (2024)";
+    let result = MarkdownExtractor.extract("README.md", source);
+    assert!(result.errors.is_empty(), "errors: {:?}", result.errors);
+    let modules: Vec<_> = result
+        .nodes
+        .iter()
+        .filter(|n| n.kind == NodeKind::Module)
+        .collect();
+    assert_eq!(modules.len(), 1);
+    assert_eq!(modules[0].name, "Hello, World! (2024)");
+}

--- a/tests/mcp_server_test.rs
+++ b/tests/mcp_server_test.rs
@@ -1023,7 +1023,14 @@ async fn test_logging_set_level_returns_success() {
 #[tokio::test]
 async fn test_logging_set_level_all_levels() {
     let levels = [
-        "debug", "info", "notice", "warning", "error", "critical", "alert", "emergency",
+        "debug",
+        "info",
+        "notice",
+        "warning",
+        "error",
+        "critical",
+        "alert",
+        "emergency",
     ];
     for (idx, level) in levels.iter().enumerate() {
         let id = json!(600 + idx as u64);
@@ -1056,11 +1063,7 @@ async fn test_logging_set_level_does_not_break_session() {
     let responses = run_server_with_messages(
         server,
         vec![
-            jsonrpc_request(
-                json!(700),
-                "logging/setLevel",
-                json!({"level": "warning"}),
-            ),
+            jsonrpc_request(json!(700), "logging/setLevel", json!({"level": "warning"})),
             jsonrpc_request(json!(701), "ping", json!({})),
         ],
     )

--- a/tests/types_test.rs
+++ b/tests/types_test.rs
@@ -357,10 +357,21 @@ fn extraction_result_sanitize_no_empty_names() {
     result.sanitize();
 
     assert_eq!(result.nodes.len(), 1, "empty-name node should be removed");
-    assert_eq!(result.edges.len(), 1, "edge referencing bad node should be removed");
+    assert_eq!(
+        result.edges.len(),
+        1,
+        "edge referencing bad node should be removed"
+    );
     assert_eq!(edge_good_to_good.source, result.edges[0].source);
-    assert!(result.unresolved_refs.is_empty(), "unresolved ref from bad node should be removed");
-    assert_eq!(result.errors.len(), 1, "sanitize should log a stripped-node error");
+    assert!(
+        result.unresolved_refs.is_empty(),
+        "unresolved ref from bad node should be removed"
+    );
+    assert_eq!(
+        result.errors.len(),
+        1,
+        "sanitize should log a stripped-node error"
+    );
 }
 
 #[test]


### PR DESCRIPTION
## Summary

Add tree-sitter based markdown extraction for the code graph. Enables tokensave to parse markdown files and extract:

- **Headers** as `Module` nodes with hierarchical relationships (`Contains` edges)  
- **Code links** (links to source files) as `Uses` edges for cross-reference tracking

## Files changed

| File | Change |
|------|--------|
| `src/extraction/markdown_extractor.rs` | Main extractor (~350 lines) |
| `src/extraction/mod.rs` | Module registration |
| `tests/markdown_extraction_test.rs` | 14 test cases |
| `Cargo.toml` | Added `lang-markdown` feature + `tree-sitter-markdown-fork` dep |
| `Cargo.lock` | Updated |

## Implementation

- Uses `tree-sitter-markdown-fork` for parsing
- Extracts ATX headings (`# heading`) with parent-child hierarchy
- Extracts links to code files (`.rs`, `.py`, `.ts`, etc.) as `Uses` edges
- Skips external HTTP(S) links and non-code file links

## Tests

All 14 tests pass covering header extraction, link extraction, hierarchy, and edge cases.