### PR TITLE
feat: add TOML extraction support

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4041,6 +4041,7 @@ dependencies = [
  "tracing",
  "tracing-subscriber",
  "tree-sitter",
+ "tree-sitter-toml-ng",
  "ureq",
  "walkdir",
  "windows-sys 0.61.2",
@@ -4669,6 +4670,16 @@ name = "tree-sitter-swift"
 version = "0.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4ef216011c3e3df4fa864736f347cb8d509b1066cf0c8549fb1fd81ac9832e59"
+dependencies = [
+ "cc",
+ "tree-sitter-language",
+]
+
+[[package]]
+name = "tree-sitter-toml-ng"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e9adc2c898ae49730e857d75be403da3f92bb81d8e37a2f918a08dd10de5ebb1"
 dependencies = [
  "cc",
  "tree-sitter-language",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -31,7 +31,7 @@ default = ["full"]
 lite = []
 
 medium = ["lang-dart", "lang-pascal", "lang-php", "lang-ruby", "lang-bash", "lang-protobuf", "lang-powershell", "lang-nix", "lang-vbnet"]
-full = ["medium", "lang-lua", "lang-zig", "lang-objc", "lang-perl", "lang-batch", "lang-fortran", "lang-cobol", "lang-msbasic2", "lang-gwbasic", "lang-qbasic", "lang-dockerfile", "lang-glsl", "lang-markdown"]
+full = ["medium", "lang-lua", "lang-zig", "lang-objc", "lang-perl", "lang-batch", "lang-fortran", "lang-cobol", "lang-msbasic2", "lang-gwbasic", "lang-qbasic", "lang-dockerfile", "lang-glsl", "lang-markdown", "lang-toml"]
 
 # Language features (all grammars provided by tokensave-large-treesitters)
 lang-dart = []
@@ -56,6 +56,7 @@ lang-qbasic = []
 lang-dockerfile = []
 lang-glsl = []
 lang-markdown = []
+lang-toml = []
 test-transport = []
 
 [lib]
@@ -68,6 +69,9 @@ path = "src/main.rs"
 [dependencies]
 libsql = "0.9.30"
 tree-sitter = "0.26"
+# TODO(toml): drop direct dep once tokensave-large-treesitters >= 0.3.3 ships
+# the vendored TOML grammar and switch to tokensave_large_treesitters::toml::LANGUAGE.
+tree-sitter-toml-ng = "0.7"
 tokensave-large-treesitters = "0.3.2"
 ort = { version = "2.0.0-rc.12", features = ["load-dynamic"] }
 ndarray = "0.17"

--- a/src/extraction/mod.rs
+++ b/src/extraction/mod.rs
@@ -62,6 +62,8 @@ mod perl_extractor;
 pub(crate) mod qbasic_extractor;
 #[cfg(feature = "lang-qbasic")]
 mod quickbasic_extractor;
+#[cfg(feature = "lang-toml")]
+mod toml_extractor;
 #[cfg(feature = "lang-zig")]
 mod zig_extractor;
 
@@ -125,6 +127,8 @@ pub use perl_extractor::PerlExtractor;
 pub use qbasic_extractor::QBasicExtractor;
 #[cfg(feature = "lang-qbasic")]
 pub use quickbasic_extractor::QuickBasicExtractor;
+#[cfg(feature = "lang-toml")]
+pub use toml_extractor::TomlExtractor;
 #[cfg(feature = "lang-zig")]
 pub use zig_extractor::ZigExtractor;
 
@@ -223,6 +227,8 @@ impl LanguageRegistry {
         extractors.push(Box::new(GlslExtractor));
         #[cfg(feature = "lang-markdown")]
         extractors.push(Box::new(MarkdownExtractor));
+        #[cfg(feature = "lang-toml")]
+        extractors.push(Box::new(TomlExtractor));
 
         Self { extractors }
     }

--- a/src/extraction/toml_extractor.rs
+++ b/src/extraction/toml_extractor.rs
@@ -1,0 +1,230 @@
+/// Tree-sitter based TOML source code extractor.
+///
+/// Parses TOML source files and emits nodes and edges for the code graph.
+/// Each `[table]` and `[[table_array]]` header becomes a `Module` node with
+/// a `Contains` edge from its parent (file or enclosing table).
+use std::time::{Instant, SystemTime, UNIX_EPOCH};
+
+use tree_sitter::{Node as TsNode, Parser, Tree};
+
+use crate::types::{
+    generate_node_id, Edge, EdgeKind, ExtractionResult, Node, NodeKind, Visibility,
+};
+
+pub struct TomlExtractor;
+
+struct ExtractionState {
+    nodes: Vec<Node>,
+    edges: Vec<Edge>,
+    file_path: String,
+    source: Vec<u8>,
+    timestamp: u64,
+    node_stack: Vec<(String, String, usize)>,
+}
+
+impl ExtractionState {
+    fn new(file_path: &str, source: &str) -> Self {
+        let timestamp = SystemTime::now()
+            .duration_since(UNIX_EPOCH)
+            .unwrap_or_default()
+            .as_secs();
+        Self {
+            nodes: Vec::new(),
+            edges: Vec::new(),
+            file_path: file_path.to_string(),
+            source: source.as_bytes().to_vec(),
+            timestamp,
+            node_stack: Vec::new(),
+        }
+    }
+
+    fn node_text(&self, node: TsNode<'_>) -> String {
+        node.utf8_text(&self.source)
+            .unwrap_or("<invalid utf8>")
+            .to_string()
+    }
+}
+
+impl TomlExtractor {
+    pub fn extract_toml(file_path: &str, source: &str) -> ExtractionResult {
+        let start = Instant::now();
+        let mut state = ExtractionState::new(file_path, source);
+
+        let file_node = Node {
+            id: generate_node_id(file_path, &NodeKind::File, file_path, 0),
+            kind: NodeKind::File,
+            name: file_path.to_string(),
+            qualified_name: file_path.to_string(),
+            file_path: file_path.to_string(),
+            start_line: 0,
+            end_line: source.lines().count().saturating_sub(1) as u32,
+            start_column: 0,
+            end_column: 0,
+            signature: None,
+            docstring: None,
+            visibility: Visibility::Pub,
+            is_async: false,
+            branches: 0,
+            loops: 0,
+            returns: 0,
+            max_nesting: 0,
+            unsafe_blocks: 0,
+            unchecked_calls: 0,
+            assertions: 0,
+            updated_at: state.timestamp,
+        };
+        let file_node_id = file_node.id.clone();
+        state.nodes.push(file_node);
+        state
+            .node_stack
+            .push((file_path.to_string(), file_node_id, 0));
+
+        match Self::parse_source(source) {
+            Ok(tree) => {
+                let root = tree.root_node();
+                Self::visit_children(&mut state, root);
+            }
+            Err(_msg) => {
+                // Parse failed; skip extraction rather than creating a self-loop
+            }
+        }
+
+        state.node_stack.pop();
+
+        ExtractionResult {
+            nodes: state.nodes,
+            edges: state.edges,
+            unresolved_refs: Vec::new(),
+            errors: Vec::new(),
+            duration_ms: start.elapsed().as_millis() as u64,
+        }
+    }
+
+    fn parse_source(source: &str) -> Result<Tree, String> {
+        // TODO(toml): switch to `tokensave_large_treesitters::toml::LANGUAGE`
+        // once tokensave-large-treesitters >= 0.3.3 ships the vendored grammar.
+        let mut parser = Parser::new();
+        parser
+            .set_language(&tree_sitter_toml_ng::LANGUAGE.into())
+            .map_err(|e| format!("failed to load toml grammar: {e}"))?;
+        parser
+            .parse(source, None)
+            .ok_or_else(|| "tree-sitter parse returned None".to_string())
+    }
+
+    fn visit_children(state: &mut ExtractionState, node: TsNode<'_>) {
+        let mut cursor = node.walk();
+        if cursor.goto_first_child() {
+            loop {
+                let child = cursor.node();
+                Self::visit_node(state, child);
+                if !cursor.goto_next_sibling() {
+                    break;
+                }
+            }
+        }
+    }
+
+    fn visit_node(state: &mut ExtractionState, node: TsNode<'_>) {
+        match node.kind() {
+            "table" | "table_array_element" => {
+                Self::visit_table(state, node);
+            }
+            _ => {
+                Self::visit_children(state, node);
+            }
+        }
+    }
+
+    fn visit_table(state: &mut ExtractionState, node: TsNode<'_>) {
+        let key_node = node
+            .children(&mut node.walk())
+            .find(|n| matches!(n.kind(), "dotted_key" | "bare_key" | "quoted_key"));
+
+        let Some(key_node) = key_node else {
+            return;
+        };
+
+        let raw_name = state.node_text(key_node).trim().to_string();
+        if raw_name.is_empty() {
+            return;
+        }
+
+        let level = raw_name.split('.').count();
+
+        while state.node_stack.len() > 1 {
+            let last_level = state.node_stack[state.node_stack.len() - 1].2;
+            if last_level >= level {
+                state.node_stack.pop();
+            } else {
+                break;
+            }
+        }
+
+        let kind = NodeKind::Module;
+        let parent_name = &state.node_stack[state.node_stack.len() - 1].0;
+        let qualified_name = format!("{parent_name}::{raw_name}");
+        let id = generate_node_id(
+            &state.file_path,
+            &kind,
+            &raw_name,
+            node.start_position().row as u32,
+        );
+
+        let signature = if node.kind() == "table_array_element" {
+            format!("[[{raw_name}]]")
+        } else {
+            format!("[{raw_name}]")
+        };
+
+        let node_obj = Node {
+            id: id.clone(),
+            kind,
+            name: raw_name.clone(),
+            qualified_name,
+            file_path: state.file_path.clone(),
+            start_line: node.start_position().row as u32,
+            end_line: node.end_position().row as u32,
+            start_column: node.start_position().column as u32,
+            end_column: node.end_position().column as u32,
+            signature: Some(signature),
+            docstring: None,
+            visibility: Visibility::Pub,
+            is_async: false,
+            branches: 0,
+            loops: 0,
+            returns: 0,
+            max_nesting: 0,
+            unsafe_blocks: 0,
+            unchecked_calls: 0,
+            assertions: 0,
+            updated_at: state.timestamp,
+        };
+
+        if let Some((_, parent_id, _)) = state.node_stack.last() {
+            state.edges.push(Edge {
+                source: parent_id.clone(),
+                target: id.clone(),
+                kind: EdgeKind::Contains,
+                line: Some(node.start_position().row as u32),
+            });
+        }
+
+        state.nodes.push(node_obj);
+        state.node_stack.push((raw_name, id, level));
+    }
+}
+
+impl crate::extraction::LanguageExtractor for TomlExtractor {
+    fn extensions(&self) -> &[&str] {
+        &["toml"]
+    }
+
+    fn language_name(&self) -> &'static str {
+        "TOML"
+    }
+
+    fn extract(&self, file_path: &str, source: &str) -> ExtractionResult {
+        Self::extract_toml(file_path, source)
+    }
+}

--- a/tests/toml_extraction_test.rs
+++ b/tests/toml_extraction_test.rs
@@ -20,7 +20,8 @@ fn test_toml_file_node_is_root() {
 
 #[test]
 fn test_toml_extracts_tables() {
-    let source = "[package]\nname = \"foo\"\n\n[dependencies]\nserde = \"1\"\n\n[features]\ndefault = []\n";
+    let source =
+        "[package]\nname = \"foo\"\n\n[dependencies]\nserde = \"1\"\n\n[features]\ndefault = []\n";
     let result = TomlExtractor.extract("Cargo.toml", source);
     assert!(result.errors.is_empty(), "errors: {:?}", result.errors);
     let modules: Vec<_> = result

--- a/tests/toml_extraction_test.rs
+++ b/tests/toml_extraction_test.rs
@@ -1,0 +1,180 @@
+#![cfg(feature = "lang-toml")]
+
+use tokensave::extraction::LanguageExtractor;
+use tokensave::extraction::TomlExtractor;
+use tokensave::types::*;
+
+#[test]
+fn test_toml_file_node_is_root() {
+    let source = "[package]\nname = \"foo\"\n";
+    let result = TomlExtractor.extract("Cargo.toml", source);
+    assert!(result.errors.is_empty(), "errors: {:?}", result.errors);
+    let files: Vec<_> = result
+        .nodes
+        .iter()
+        .filter(|n| n.kind == NodeKind::File)
+        .collect();
+    assert_eq!(files.len(), 1);
+    assert_eq!(files[0].name, "Cargo.toml");
+}
+
+#[test]
+fn test_toml_extracts_tables() {
+    let source = "[package]\nname = \"foo\"\n\n[dependencies]\nserde = \"1\"\n\n[features]\ndefault = []\n";
+    let result = TomlExtractor.extract("Cargo.toml", source);
+    assert!(result.errors.is_empty(), "errors: {:?}", result.errors);
+    let modules: Vec<_> = result
+        .nodes
+        .iter()
+        .filter(|n| n.kind == NodeKind::Module)
+        .collect();
+    assert_eq!(modules.len(), 3);
+    assert_eq!(modules[0].name, "package");
+    assert_eq!(modules[1].name, "dependencies");
+    assert_eq!(modules[2].name, "features");
+}
+
+#[test]
+fn test_toml_dotted_table_hierarchy() {
+    let source = "[a]\nx = 1\n\n[a.b]\ny = 2\n\n[a.b.c]\nz = 3\n\n[a.d]\nw = 4\n";
+    let result = TomlExtractor.extract("config.toml", source);
+    assert!(result.errors.is_empty(), "errors: {:?}", result.errors);
+
+    let a = result.nodes.iter().find(|n| n.name == "a").unwrap();
+    let ab = result.nodes.iter().find(|n| n.name == "a.b").unwrap();
+    let abc = result.nodes.iter().find(|n| n.name == "a.b.c").unwrap();
+    let ad = result.nodes.iter().find(|n| n.name == "a.d").unwrap();
+
+    let contains: Vec<_> = result
+        .edges
+        .iter()
+        .filter(|e| e.kind == EdgeKind::Contains)
+        .collect();
+
+    // `a` (level 1) contains `a.b` and `a.d` (level 2)
+    let a_contains: Vec<_> = contains.iter().filter(|e| e.source == a.id).collect();
+    assert!(a_contains.iter().any(|e| e.target == ab.id));
+    assert!(a_contains.iter().any(|e| e.target == ad.id));
+
+    // `a.b` (level 2) contains `a.b.c` (level 3)
+    let ab_contains: Vec<_> = contains.iter().filter(|e| e.source == ab.id).collect();
+    assert!(ab_contains.iter().any(|e| e.target == abc.id));
+}
+
+#[test]
+fn test_toml_table_array_element() {
+    let source = "[[items]]\nname = \"a\"\n\n[[items]]\nname = \"b\"\n";
+    let result = TomlExtractor.extract("config.toml", source);
+    assert!(result.errors.is_empty(), "errors: {:?}", result.errors);
+    let modules: Vec<_> = result
+        .nodes
+        .iter()
+        .filter(|n| n.kind == NodeKind::Module)
+        .collect();
+    assert_eq!(modules.len(), 2);
+    assert!(modules.iter().all(|m| m.name == "items"));
+    assert!(modules
+        .iter()
+        .all(|m| m.signature.as_deref() == Some("[[items]]")));
+}
+
+#[test]
+fn test_toml_table_signature_format() {
+    let source = "[package.metadata]\nfoo = 1\n";
+    let result = TomlExtractor.extract("Cargo.toml", source);
+    assert!(result.errors.is_empty(), "errors: {:?}", result.errors);
+    let m = result
+        .nodes
+        .iter()
+        .find(|n| n.name == "package.metadata")
+        .unwrap();
+    assert_eq!(m.signature.as_deref(), Some("[package.metadata]"));
+}
+
+#[test]
+fn test_toml_handles_empty_file() {
+    let source = "";
+    let result = TomlExtractor.extract("config.toml", source);
+    assert!(result.errors.is_empty(), "errors: {:?}", result.errors);
+    let files: Vec<_> = result
+        .nodes
+        .iter()
+        .filter(|n| n.kind == NodeKind::File)
+        .collect();
+    assert_eq!(files.len(), 1);
+    let modules: Vec<_> = result
+        .nodes
+        .iter()
+        .filter(|n| n.kind == NodeKind::Module)
+        .collect();
+    assert!(modules.is_empty());
+}
+
+#[test]
+fn test_toml_handles_top_level_keys_only() {
+    let source = "name = \"foo\"\nversion = \"1.0.0\"\n";
+    let result = TomlExtractor.extract("config.toml", source);
+    assert!(result.errors.is_empty(), "errors: {:?}", result.errors);
+    let modules: Vec<_> = result
+        .nodes
+        .iter()
+        .filter(|n| n.kind == NodeKind::Module)
+        .collect();
+    assert!(modules.is_empty(), "should have no Module nodes");
+}
+
+#[test]
+fn test_toml_unrelated_table_after_nested() {
+    // After `[a.b.c]`, a fresh `[x]` (level 1) must re-parent to the file,
+    // not nest under `a.b.c`.
+    let source = "[a.b.c]\nv = 1\n\n[x]\ny = 2\n";
+    let result = TomlExtractor.extract("config.toml", source);
+    assert!(result.errors.is_empty(), "errors: {:?}", result.errors);
+
+    let file = result
+        .nodes
+        .iter()
+        .find(|n| n.kind == NodeKind::File)
+        .unwrap();
+    let x = result.nodes.iter().find(|n| n.name == "x").unwrap();
+    let abc = result.nodes.iter().find(|n| n.name == "a.b.c").unwrap();
+
+    let contains: Vec<_> = result
+        .edges
+        .iter()
+        .filter(|e| e.kind == EdgeKind::Contains)
+        .collect();
+
+    assert!(contains
+        .iter()
+        .any(|e| e.source == file.id && e.target == x.id));
+    assert!(!contains
+        .iter()
+        .any(|e| e.source == abc.id && e.target == x.id));
+}
+
+#[test]
+fn test_toml_quoted_table_key() {
+    let source = "[\"weird key\"]\nv = 1\n";
+    let result = TomlExtractor.extract("config.toml", source);
+    assert!(result.errors.is_empty(), "errors: {:?}", result.errors);
+    let modules: Vec<_> = result
+        .nodes
+        .iter()
+        .filter(|n| n.kind == NodeKind::Module)
+        .collect();
+    assert_eq!(modules.len(), 1);
+    assert_eq!(modules[0].name, "\"weird key\"");
+}
+
+#[test]
+fn test_toml_extensions() {
+    let ext = TomlExtractor;
+    assert!(ext.extensions().contains(&"toml"));
+}
+
+#[test]
+fn test_toml_language_name() {
+    let ext = TomlExtractor;
+    assert_eq!(ext.language_name(), "TOML");
+}


### PR DESCRIPTION
## Summary

Add tree-sitter based TOML extraction for the code graph. Mirrors the markdown extractor (PR #47): each `[table]` and `[[table_array]]` header becomes a `Module` node, and dotted keys (`[a.b.c]`) produce hierarchical `Contains` edges.

## Files changed

| File | Change |
|------|--------|
| `src/extraction/toml_extractor.rs` | New extractor (~230 lines) |
| `src/extraction/mod.rs` | Module registration behind `lang-toml` feature |
| `tests/toml_extraction_test.rs` | 11 test cases, gated by `#![cfg(feature = "lang-toml")]` |
| `Cargo.toml` | Added `lang-toml` feature (in `full`) + `tree-sitter-toml-ng` dep |
| `Cargo.lock` | Updated |

## Implementation

- Parses with `tree-sitter-toml-ng` 0.7
- Each `table` node becomes a `Module`; `table_array_element` likewise (signature `[[name]]` vs `[name]`)
- Hierarchy levels are computed from dotted-key segment count, mirroring how the markdown extractor uses ATX heading depth — `[a.b]` nests under `[a]`, `[a.b.c]` under `[a.b]`
- An unrelated table after a deeper one re-parents to the file (no false nesting)
- Quoted keys are preserved verbatim in the node name
- Companion change for `tokensave-large-treesitters` (separate repo) adds the grammar so a follow-up can swap the parser source from `tree_sitter_toml_ng::LANGUAGE` to `tokensave_large_treesitters::toml::LANGUAGE` and drop the direct dep — same migration that markdown went through in 4fd1a94. `TODO(toml)` comments mark the two call sites.

## Tests

All 11 tests pass covering: file root node, multiple tables, dotted-key hierarchy, table arrays, signature format, empty file, top-level-keys-only, unrelated-table re-parenting, quoted keys, extensions, and language name.

```
cargo test --features full --test toml_extraction_test
test result: ok. 11 passed; 0 failed
```

## Test plan

- [x] `cargo check --features full` passes
- [x] `cargo test --features full --test toml_extraction_test` — 11/11 pass
- [x] `cargo test --no-default-features --features lang-toml --test toml_extraction_test` — 11/11 pass
- [x] `cargo clippy` — no new warnings on the added code

🤖 Generated with [Claude Code](https://claude.com/claude-code)