### PR TITLE
Delegate Homebrew upgrades to brew

### DIFF
--- a/src/upgrade.rs
+++ b/src/upgrade.rs
@@ -556,6 +556,31 @@ fn restart_daemon() {
     }
 }
 
+fn brew_upgrade_command() -> (&'static str, [&'static str; 2]) {
+    ("brew", ["upgrade", "tokensave"])
+}
+
+fn run_brew_upgrade(current: &str) -> Result<String> {
+    let (program, args) = brew_upgrade_command();
+    eprintln!(
+        "Delegating upgrade to Homebrew: {program} {}",
+        args.join(" ")
+    );
+
+    let status = std::process::Command::new(program)
+        .args(args)
+        .status()
+        .map_err(io_err("failed to run Homebrew upgrade"))?;
+
+    if status.success() {
+        Ok(current.to_string())
+    } else {
+        Err(TokenSaveError::Config {
+            message: format!("Homebrew upgrade failed with status: {status}"),
+        })
+    }
+}
+
 /// Check for a newer version and perform the upgrade if one is available.
 ///
 /// Stops the daemon before replacing the binary and restarts it after if
@@ -573,6 +598,11 @@ pub fn run_upgrade() -> Result<String> {
         InstallMethod::Unknown => "",
     };
     eprintln!("Current version: v{current} ({channel} channel{method_suffix})");
+
+    if matches!(method, InstallMethod::Brew) {
+        return run_brew_upgrade(current);
+    }
+
     eprintln!("Checking for updates...");
 
     let latest = cloud::fetch_latest_version().ok_or_else(|| TokenSaveError::Config {
@@ -738,6 +768,14 @@ mod tests {
     #[test]
     fn test_current_platform_not_unknown() {
         assert_ne!(current_platform(), "unknown");
+    }
+
+    #[test]
+    fn brew_upgrade_command_delegates_to_homebrew() {
+        let (program, args) = brew_upgrade_command();
+
+        assert_eq!(program, "brew");
+        assert_eq!(args, ["upgrade", "tokensave"]);
     }
 
     #[test]


### PR DESCRIPTION
## Summary

- Delegate `tokensave upgrade` to `brew upgrade tokensave` when the current install is detected as Homebrew-managed.
- Keep the existing self-upgrade flow unchanged for non-Homebrew installs.
- Add a small unit test for the delegated Homebrew command.

## Context

This follows the discussion in #67. When a Homebrew-installed `tokensave` self-upgrades by mutating the Cellar directly, Homebrew can later fail because its recorded keg path/version no longer matches what is on disk, for example:

```text
Error: /opt/homebrew/Cellar/tokensave/4.3.13 is not a directory
```

After discussing the issue with the maintainer, the agreed direction is to preserve the single user-facing command (`tokensave upgrade`) while letting Homebrew perform the actual package-manager upgrade for Homebrew-managed installs.

## Solution

`run_upgrade()` now checks `InstallMethod::Brew` early and runs:

```sh
brew upgrade tokensave
```

This avoids downloading/replacing the binary inside `tokensave` for Homebrew installs, so Homebrew remains responsible for Cellar layout, linked keg state, receipts, and metadata.

## Testing

```sh
cargo fmt --check
cargo test upgrade::
cargo test brew_upgrade_command_delegates_to_homebrew
```
