### PR TITLE
feat: add Kiro agent integration

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+- **Kiro agent integration.** `tokensave install --agent kiro` now installs the MCP server, global steering, managed Kiro agent config, default CLI agent selection, and Kiro hook mappings for prompt context, delegated tool context, and post-write re-indexing. Doctor and uninstall support are included with coverage for workspace overrides and idempotent cleanup.
+
 ## [5.1.1] - 2026-05-16
 
 ### Performance

--- a/README.md
+++ b/README.md
@@ -70,8 +70,8 @@ AI coding agents waste tokens exploring codebases. Every grep, glob, and file re
 |---|---|---|
 | **Smart Context Building** | **Semantic Search** | **Impact Analysis** |
 | One tool call returns everything the agent needs -- entry points, related symbols, and code snippets. | Find code by meaning, not just text. Search for "authentication" and find `login`, `validateToken`, `AuthService`. | Know exactly what breaks before you change it. Trace callers, callees, and the full impact radius of any symbol. |
-| **48 MCP Tools** | **34 Languages** | **9 Agent Integrations** |
-| From call graph traversal to dead code detection, atomic edit primitives, code-health metrics, test mapping, and complexity analysis. | Rust, Go, Java, Python, TypeScript, C, C++, Swift, and 26 more, including Markdown header extraction. Three tiers (lite/medium/full) control binary size. | Claude Code, Codex CLI, Gemini CLI, Cursor, OpenCode, Copilot, Cline, Roo Code, Zed, Antigravity, Kilo CLI, Kimi CLI, Mistral Vibe. |
+| **48 MCP Tools** | **34 Languages** | **14 Agent Integrations** |
+| From call graph traversal to dead code detection, atomic edit primitives, code-health metrics, test mapping, and complexity analysis. | Rust, Go, Java, Python, TypeScript, C, C++, Swift, and 26 more, including Markdown header extraction. Three tiers (lite/medium/full) control binary size. | Claude Code, Codex CLI, Gemini CLI, Kiro, Cursor, OpenCode, Copilot, Cline, Roo Code, Zed, Antigravity, Kilo CLI, Kimi CLI, Mistral Vibe. |
 | **Multi-Branch Indexing (opt-in)** | **100% Local** | **Always Fresh** |
 | Optional per-branch databases. Cross-branch diff and search without switching your checkout. | No data leaves your machine. No API keys. No external services. Everything runs on a local libSQL database. | Background daemon syncs the index automatically. Survives reboots. Restarts after upgrades. |
 | **Subprocess-Isolated Extraction** | **Code-Health Analytics** | **Atomic Edit Primitives** |
@@ -127,6 +127,7 @@ tokensave install --agent copilot         # GitHub Copilot
 tokensave install --agent cursor          # Cursor
 tokensave install --agent gemini          # Gemini CLI
 tokensave install --agent kilo            # Kilo CLI
+tokensave install --agent kiro            # AWS Kiro
 tokensave install --agent kimi            # Moonshot Kimi CLI
 tokensave install --agent opencode        # OpenCode
 tokensave install --agent roo-code        # Roo Code
@@ -134,7 +135,7 @@ tokensave install --agent vibe            # Mistral Vibe
 tokensave install --agent zed             # Zed
 ```
 
-Each agent gets its MCP server registered in the native config format. Claude Code additionally gets a PreToolUse hook (blocks wasteful Explore agents), a UserPromptSubmit hook, a Stop hook, prompt rules in CLAUDE.md, and auto-allowed tool permissions.
+Each agent gets its MCP server registered in the native config format. Claude Code additionally gets a PreToolUse hook (blocks wasteful Explore agents), a UserPromptSubmit hook, a Stop hook, prompt rules in CLAUDE.md, and auto-allowed tool permissions. Kiro gets global MCP config, read-only tokensave auto-approval, AGENTS.md steering, and a tokensave-managed default agent with delegation guardrail hooks plus post-write sync; user-managed Kiro agents are preserved.
 
 All changes are idempotent -- safe to run again after upgrading. After agent setup, you'll be offered a global git post-commit hook and the background daemon service.
 
@@ -355,7 +356,7 @@ Different from the criterion bench above: criterion measures per-iteration laten
 
 ## 48 MCP Tools
 
-The discovery and analysis tools are read-only, safe to call in parallel, and annotated with `readOnlyHint`. The four edit primitives (the only writers) are scoped to single files and re-index in place. The three core tools (`tokensave_context`, `tokensave_search`, `tokensave_status`) are marked `anthropic/alwaysLoad` so they bypass the client's tool-search round-trip.
+The discovery and analysis tools are read-only, safe to call in parallel, and annotated with `readOnlyHint`. The edit primitives are scoped to single files and re-index in place; session baseline and memory-recording tools also mutate local `.tokensave` state and are annotated as non-read-only. The three core tools (`tokensave_context`, `tokensave_search`, `tokensave_status`) are marked `anthropic/alwaysLoad` so they bypass the client's tool-search round-trip.
 
 ### Discovery
 
@@ -701,7 +702,7 @@ tokensave is a ground-up Rust rewrite of [CodeGraph](https://www.npmjs.com/packa
 | **Install** | `brew install`, `cargo install`, `scoop install` | `npx @colbymchenry/codegraph` |
 | **Languages** | 34 (3 tiers: lite/medium/full) | 19+ |
 | **MCP tools** | 48 | 9 |
-| **Agent integrations** | 13 (Claude, Codex, Gemini, OpenCode, Cursor, Cline, Copilot, Roo Code, Zed, Antigravity, Kilo, Kimi, Vibe) | 1 (Claude Code) |
+| **Agent integrations** | 14 (Claude, Codex, Gemini, OpenCode, Cursor, Cline, Copilot, Roo Code, Zed, Antigravity, Kilo, Kiro, Kimi, Vibe) | 1 (Claude Code) |
 | **Background daemon** | Yes (launchd/systemd/Windows Service) | No (hook-based sync only) |
 | **Multi-branch indexing** | Yes, opt-in (per-branch DBs, cross-branch diff/search) | No |
 | **Complexity metrics** | AST-extracted (branches, loops, nesting depth, cyclomatic) | No |
@@ -746,7 +747,7 @@ tokensave works at the symbol level: functions, structs, fields, call edges, typ
 
 ### Broadest agent support
 
-9 AI coding agent integrations with per-agent native configuration formats. No other tool covers as many agents with as deep an integration. Claude Code gets hooks, prompt rules, and auto-allowed tool permissions. Other agents get MCP server registration in their native config format.
+14 AI coding agent integrations with per-agent native configuration formats. No other tool covers as many agents with as deep an integration. Claude Code gets hooks, prompt rules, and auto-allowed tool permissions. Kiro gets global MCP config, read-only tokensave auto-approval, AGENTS.md steering, a managed agent, and hooks for delegation guardrails plus post-write sync. Other agents get MCP server registration in their native config format.
 
 ### Multi-branch indexing
 

--- a/docs/KIRO-INTEGRATION.md
+++ b/docs/KIRO-INTEGRATION.md
@@ -1,0 +1,138 @@
+# Kiro integration
+
+This documents the defaults installed by:
+
+```bash
+tokensave install --agent kiro
+```
+
+The integration configures Kiro's shared MCP and steering defaults, writes a
+tokensave-owned Kiro agent, and selects that agent as the default only when doing
+so does not overwrite a user's existing custom default-agent choice.
+
+## Installed files
+
+| File | Purpose |
+|---|---|
+| `~/.kiro/settings/mcp.json` | Registers the global `tokensave` MCP server with `command`, `args: ["serve"]`, `disabled: false`, and `autoApprove` for read-only `tokensave_*` tools. |
+| `~/.kiro/steering/AGENTS.md` | Adds a bounded global Kiro steering block that tells normal Kiro sessions to prefer tokensave MCP tools for codebase research. |
+| `~/.kiro/agents/tokensave.json` | Adds the tokensave-managed Kiro agent with hooks for delegation guardrails and post-write sync. |
+| `~/.kiro/settings/cli.json` | Sets `chat.defaultAgent` to `tokensave` when the setting is absent or still points at Kiro's built-in default. |
+
+If a user already has `~/.kiro/agents/tokensave.json` and it is not the file
+tokensave writes, install and uninstall leave it untouched. In that case
+tokensave also does not point `chat.defaultAgent` at that user-managed file.
+If `chat.defaultAgent` already names another custom agent, install leaves that
+choice unchanged and prints a warning.
+
+Uninstall removes only the steering block bounded by tokensave's installed
+marker, the global MCP server entry, the tokensave-owned agent file, and
+`chat.defaultAgent` when it points at that owned agent. User-authored steering
+after the installed block remains in place.
+
+## Tool approval defaults
+
+Kiro supports MCP-level `autoApprove`. The installed default uses it only for
+tools whose MCP annotation sets `readOnlyHint: true`.
+
+Read-only graph, search, health, branch, body, and session-recall tools run
+without a prompt. Tools that can mutate files or local tokensave state remain
+available, but Kiro asks before using them. Today that means these tools are
+not auto-approved:
+
+- `tokensave_str_replace`
+- `tokensave_multi_str_replace`
+- `tokensave_insert_at`
+- `tokensave_ast_grep_rewrite`
+- `tokensave_session_start`
+- `tokensave_session_end`
+- `tokensave_record_decision`
+- `tokensave_record_code_area`
+
+This is intentionally more conservative than Claude Code's permission model.
+Kiro's MCP security model supports auto-approval, but default setup should only
+pre-approve frequent, read-only, limited-scope tools.
+
+## Workspace overrides
+
+Kiro can also load workspace MCP settings from `.kiro/settings/mcp.json`. A
+workspace `mcpServers.tokensave` entry takes precedence over the global
+`~/.kiro/settings/mcp.json` entry installed by tokensave.
+
+`tokensave doctor --agent kiro` checks the current workspace for that override.
+It reports a problem when the workspace entry disables tokensave, omits the
+`serve` argument, or points at a different command than the global install. It
+also warns when the workspace entry shadows the global read-only `autoApprove`
+defaults.
+
+## Default-agent judgement call
+
+The install is intentionally conservative:
+
+- `chat.defaultAgent` absent, empty, or `kiro_default`: set it to `tokensave`.
+- `chat.defaultAgent` already `tokensave`: leave it unchanged.
+- `chat.defaultAgent` names another custom agent: leave it unchanged and warn.
+- `~/.kiro/agents/tokensave.json` exists but is user-managed: leave it unchanged
+  and do not select it as the default.
+
+Users can still select the tokensave agent manually later, or copy the hook
+mapping into their own agent configuration.
+
+## Custom agents after setup
+
+Users can still create their own Kiro custom agents after running the default
+tokensave setup. Those agents can inherit the global MCP server by setting:
+
+```json
+{
+  "includeMcpJson": true
+}
+```
+
+For a global custom agent under `~/.kiro/agents/`, the installed steering file
+can also be referenced instead of copied:
+
+```json
+{
+  "prompt": "file://../steering/AGENTS.md"
+}
+```
+
+That keeps first-run setup simple and consistent with other tokensave agent
+harnesses: tokensave owns its own default agent settings, while other custom
+agents remain user-managed.
+
+## Hooks
+
+Kiro hooks are an agent-configuration field. `tokensave install --agent kiro`
+writes them into the tokensave-owned agent file:
+
+| Kiro hook | Matcher | Command | Purpose |
+|---|---|---|---|
+| `preToolUse` | `delegate` | `tokensave hook-kiro-pre-tool-use` | Blocks delegation when the delegated task is codebase research that should try tokensave MCP tools first. |
+| `preToolUse` | `subagent` | `tokensave hook-kiro-pre-tool-use` | Applies the same guardrail to Kiro subagents. |
+| `userPromptSubmit` | none | `tokensave hook-kiro-prompt-submit` | Silently resets the project-local per-turn savings counter. |
+| `postToolUse` | `fs_write` | `tokensave hook-kiro-post-tool-use` | Silently runs an incremental `tokensave sync` after Kiro writes files, so the graph is re-indexed before later MCP queries. |
+
+Kiro and Claude Code use different hook protocols. Claude's `PreToolUse` hook
+expects a JSON decision on stdout. Kiro passes hook events on stdin and blocks
+`preToolUse` by receiving exit code `2` with the reason on stderr, so Kiro uses
+separate hidden hook subcommands.
+
+The default steering still tells Kiro not to use `delegate` for codebase
+exploration, architecture mapping, call graph work, symbol lookup, or other code
+research until tokensave MCP tools have been tried. Delegation remains available
+for execution-oriented work such as builds, tests, generated reports, or
+independent implementation tasks.
+
+## Deliberate non-defaults
+
+No `execute_bash`, `fs_write` pre-approval, shell post-hook, or `stop` hook is
+installed. Shell commands are too broad for default sync triggering, and Kiro's
+stop event should not be used for Claude-style accounting until Kiro's persisted
+session format is verified.
+
+Kiro-specific session accounting is also held back. Claude's stop hook parses
+Claude session transcripts; Kiro does not share that transcript format, so
+session accounting should only be added after Kiro's persisted session format is
+verified.

--- a/docs/TOKEN-SAVE-WHATSNEW.md
+++ b/docs/TOKEN-SAVE-WHATSNEW.md
@@ -185,7 +185,7 @@ Some features don't fit neatly into "languages" or "tools." They're the connecti
 
 **The worldwide counter** (1.4.0) aggregates anonymous token-savings counts across all TokenSave users via a Cloudflare Worker. `tokensave status` shows three tiers: project, all local projects, and worldwide. The counter is opt-out. Getting the accounting right took a few iterations: 1.5.4 fixed an inflation bug, and the periodic flush interval moved from shutdown-only to every 30 seconds during MCP sessions.
 
-**MCP resources** (3.3.0) expose four read-only resources via the standard `resources/list` and `resources/read` protocol: `tokensave://status`, `tokensave://files`, `tokensave://overview`, and `tokensave://branches`. MCP annotations (`readOnlyHint`, `title`) on all 37 tools and `anthropic/alwaysLoad` on the three core tools ensure clients can run all tokensave tools concurrently without permission prompts and load the essentials without a tool-search round-trip.
+**MCP resources** (3.3.0) expose four read-only resources via the standard `resources/list` and `resources/read` protocol: `tokensave://status`, `tokensave://files`, `tokensave://overview`, and `tokensave://branches`. MCP annotations (`readOnlyHint`, `title`) distinguish read-only tools from edit and session-memory tools, and `anthropic/alwaysLoad` on the three core tools lets clients load the essentials without a tool-search round-trip.
 
 **Atomic config writes** (3.0.1) protect agent config files from corruption. A `.bak` copy is created before any modification, new content is written to a `.new` sibling file, and an atomic `rename(2)` moves it into place. A crash during install can't leave a half-written config. Twenty regression tests cover the full lifecycle.
 

--- a/docs/USER-GUIDE.md
+++ b/docs/USER-GUIDE.md
@@ -181,7 +181,7 @@ This is the default. It registers the MCP server in `~/.claude/settings.json`, g
 
 ### Other agents
 
-Tokensave supports thirteen agents. Pass `--agent` to install for a specific one:
+Tokensave supports fourteen agents. Pass `--agent` to install for a specific one:
 
 ```bash
 tokensave install --agent claude      # Claude Code (default)
@@ -195,11 +195,19 @@ tokensave install --agent cline       # Cline
 tokensave install --agent roo-code    # Roo Code
 tokensave install --agent antigravity # Antigravity (Windsurf)
 tokensave install --agent kilo        # Kilo CLI
+tokensave install --agent kiro        # AWS Kiro
 tokensave install --agent kimi        # Moonshot Kimi CLI
 tokensave install --agent vibe        # Mistral Vibe
 ```
 
 Each agent gets an appropriate configuration: MCP server registration, tool permissions (where the agent supports them), and prompt rules in the agent's instruction file.
+
+Kiro setup registers tokensave in `~/.kiro/settings/mcp.json`, adds steering in
+`~/.kiro/steering/AGENTS.md`, and writes a tokensave-managed agent with hooks
+that block research delegation until tokensave MCP tools have been tried and
+sync the index after Kiro writes files. If you already have a different custom
+default agent or a user-managed `tokensave` agent, tokensave leaves it alone and
+prints a warning.
 
 The install is idempotent — safe to run again after upgrading tokensave. You'll also be offered the option to set up a global git post-commit hook and the background daemon (more on those below).
 
@@ -384,7 +392,10 @@ To check only a specific agent:
 ```bash
 tokensave doctor --agent claude
 tokensave doctor --agent codex
+tokensave doctor --agent kiro
 ```
+
+The accepted agent values are the same values supported by `tokensave install --agent`.
 
 ---
 
@@ -517,7 +528,7 @@ Marked functions are excluded from `tokensave_test_risk` coverage calculations, 
 | `tokensave_session_start` | Save current health metrics as a baseline before starting work. |
 | `tokensave_session_end` | Compare current health against the baseline to detect structural degradation during the session. |
 
-All tools are read-only and safe to call in parallel, except `tokensave_session_start` which writes a baseline file.
+Discovery and analysis tools are read-only and safe to call in parallel. Session baseline tools write/remove `.tokensave/session_baseline.json`, memory-recording tools update the project database, and edit tools modify source files.
 
 ---
 

--- a/src/agents/kiro.rs
+++ b/src/agents/kiro.rs
@@ -1,0 +1,997 @@
+//! AWS Kiro agent integration.
+//!
+//! Handles registration of the tokensave MCP server in Kiro's shared global
+//! MCP config (`~/.kiro/settings/mcp.json`), adds global AGENTS.md steering
+//! (`~/.kiro/steering/AGENTS.md`), and installs a tokensave-managed Kiro
+//! agent selected as the default when doing so does not overwrite a user's
+//! existing default-agent choice.
+//!
+//! User-owned Kiro agents remain user-managed. If `~/.kiro/agents/tokensave.json`
+//! already exists and is not the file tokensave writes, install and uninstall
+//! leave it untouched.
+
+use std::io::Write;
+use std::ops::Range;
+use std::path::{Path, PathBuf};
+
+use serde_json::json;
+
+use crate::errors::{Result, TokenSaveError};
+
+use super::{
+    backup_and_write_json, backup_config_file, load_json_file, load_json_file_strict,
+    read_only_tool_names, safe_write_json_file, tool_names, AgentIntegration, DoctorCounters,
+    HealthcheckContext, InstallContext,
+};
+
+/// Kiro agent.
+pub struct KiroIntegration;
+
+const PROMPT_MARKER: &str = "## Prefer tokensave MCP tools";
+const PROMPT_END_MARKER: &str = "<!-- tokensave:kiro:end -->";
+const KIRO_AGENT_NAME: &str = "tokensave";
+const OWNED_AGENT_DESCRIPTION: &str =
+    "Default Kiro agent with tokensave MCP tools and code-research guardrails.";
+const KIRO_PRE_TOOL_HOOK: &str = "hook-kiro-pre-tool-use";
+const KIRO_PROMPT_HOOK: &str = "hook-kiro-prompt-submit";
+const KIRO_POST_TOOL_HOOK: &str = "hook-kiro-post-tool-use";
+const KIRO_SHORT_HOOK_TIMEOUT_MS: u64 = 5_000;
+const KIRO_SYNC_HOOK_TIMEOUT_MS: u64 = 30_000;
+
+fn kiro_home(home: &Path) -> PathBuf {
+    if let Ok(kiro) = std::env::var("KIRO_HOME") {
+        let kiro_path = PathBuf::from(&kiro);
+        let is_real_home = super::home_dir().as_deref() == Some(home);
+        if is_real_home || kiro_path.starts_with(home) {
+            return kiro_path;
+        }
+    }
+    home.join(".kiro")
+}
+
+fn mcp_config_path(home: &Path) -> PathBuf {
+    kiro_home(home).join("settings/mcp.json")
+}
+
+fn cli_config_path(home: &Path) -> PathBuf {
+    kiro_home(home).join("settings/cli.json")
+}
+
+fn managed_agent_path(home: &Path) -> PathBuf {
+    kiro_home(home).join("agents/tokensave.json")
+}
+
+fn steering_path(home: &Path) -> PathBuf {
+    kiro_home(home).join("steering/AGENTS.md")
+}
+
+fn workspace_mcp_config_path(project_path: &Path) -> PathBuf {
+    project_path.join(".kiro/settings/mcp.json")
+}
+
+impl AgentIntegration for KiroIntegration {
+    fn name(&self) -> &'static str {
+        "Kiro"
+    }
+
+    fn id(&self) -> &'static str {
+        "kiro"
+    }
+
+    fn install(&self, ctx: &InstallContext) -> Result<()> {
+        std::fs::create_dir_all(kiro_home(&ctx.home)).ok();
+
+        let mcp_path = mcp_config_path(&ctx.home);
+        install_mcp_server(&mcp_path, &ctx.tokensave_bin)?;
+
+        let steering = steering_path(&ctx.home);
+        install_prompt_rules(&steering)?;
+
+        let agent_path = managed_agent_path(&ctx.home);
+        let owns_agent = install_managed_agent(&agent_path, &ctx.tokensave_bin)?;
+
+        let cli_path = cli_config_path(&ctx.home);
+        install_default_agent(&cli_path, owns_agent)?;
+
+        eprintln!();
+        eprintln!("Setup complete. Next steps:");
+        eprintln!("  1. cd into your project and run: tokensave init");
+        eprintln!("  2. Start a new Kiro session");
+        eprintln!("     tokensave tools are now available through Kiro MCP");
+        eprintln!(
+            "     the tokensave Kiro agent includes hooks for delegation guardrails and sync"
+        );
+        Ok(())
+    }
+
+    fn uninstall(&self, ctx: &InstallContext) -> Result<()> {
+        uninstall_mcp_server(&mcp_config_path(&ctx.home));
+        uninstall_prompt_rules(&steering_path(&ctx.home));
+        let agent_path = managed_agent_path(&ctx.home);
+        let owned_agent = is_owned_agent_file(&agent_path);
+        uninstall_managed_agent(&agent_path);
+        uninstall_default_agent(&cli_config_path(&ctx.home), &agent_path, owned_agent);
+
+        eprintln!();
+        eprintln!("Uninstall complete. Tokensave has been removed from Kiro.");
+        eprintln!("Start a new Kiro session for changes to take effect.");
+        Ok(())
+    }
+
+    fn healthcheck(&self, dc: &mut DoctorCounters, ctx: &HealthcheckContext) {
+        eprintln!("\n\x1b[1mKiro integration\x1b[0m");
+        let global_server = doctor_check_mcp_config(dc, &ctx.home);
+        doctor_check_workspace_mcp_override(
+            dc,
+            &ctx.home,
+            &ctx.project_path,
+            global_server.as_ref(),
+        );
+        doctor_check_steering(dc, &ctx.home);
+        doctor_check_managed_agent(dc, &ctx.home);
+        doctor_check_default_agent(dc, &ctx.home);
+    }
+
+    fn is_detected(&self, home: &Path) -> bool {
+        kiro_home(home).is_dir()
+    }
+
+    fn primary_config_path(&self, home: &Path) -> Option<PathBuf> {
+        Some(mcp_config_path(home))
+    }
+
+    fn has_tokensave(&self, home: &Path) -> bool {
+        let path = mcp_config_path(home);
+        if !path.exists() {
+            return false;
+        }
+        let json = load_json_file(&path);
+        json.get("mcpServers")
+            .and_then(|v| v.get("tokensave"))
+            .is_some()
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Install helpers
+// ---------------------------------------------------------------------------
+
+fn mcp_server_entry(tokensave_bin: &str) -> serde_json::Value {
+    json!({
+        "command": tokensave_bin,
+        "args": ["serve"],
+        "disabled": false,
+        "autoApprove": read_only_tool_names()
+    })
+}
+
+fn mutating_tool_names() -> Vec<String> {
+    let read_only: std::collections::HashSet<String> = read_only_tool_names().into_iter().collect();
+    tool_names()
+        .into_iter()
+        .filter(|name| !read_only.contains(name))
+        .collect()
+}
+
+fn hook_command(tokensave_bin: &str, subcommand: &str) -> String {
+    format!("{tokensave_bin} {subcommand}")
+}
+
+fn managed_agent_config(tokensave_bin: &str) -> serde_json::Value {
+    json!({
+        "name": KIRO_AGENT_NAME,
+        "description": OWNED_AGENT_DESCRIPTION,
+        "includeMcpJson": true,
+        "prompt": "file://../steering/AGENTS.md",
+        "tools": ["*"],
+        "hooks": {
+            "userPromptSubmit": [
+                {
+                    "command": hook_command(tokensave_bin, KIRO_PROMPT_HOOK),
+                    "timeout_ms": KIRO_SHORT_HOOK_TIMEOUT_MS
+                }
+            ],
+            "preToolUse": [
+                {
+                    "matcher": "delegate",
+                    "command": hook_command(tokensave_bin, KIRO_PRE_TOOL_HOOK),
+                    "timeout_ms": KIRO_SHORT_HOOK_TIMEOUT_MS
+                },
+                {
+                    "matcher": "subagent",
+                    "command": hook_command(tokensave_bin, KIRO_PRE_TOOL_HOOK),
+                    "timeout_ms": KIRO_SHORT_HOOK_TIMEOUT_MS
+                }
+            ],
+            "postToolUse": [
+                {
+                    "matcher": "fs_write",
+                    "command": hook_command(tokensave_bin, KIRO_POST_TOOL_HOOK),
+                    "timeout_ms": KIRO_SYNC_HOOK_TIMEOUT_MS
+                }
+            ]
+        }
+    })
+}
+
+/// Register MCP server in ~/.kiro/settings/mcp.json.
+fn install_mcp_server(path: &Path, tokensave_bin: &str) -> Result<()> {
+    let backup = backup_config_file(path)?;
+    let mut config = match load_json_file_strict(path) {
+        Ok(v) => v,
+        Err(e) => {
+            if let Some(ref b) = backup {
+                eprintln!("  Backup preserved at: {}", b.display());
+            }
+            return Err(e);
+        }
+    };
+
+    ensure_json_object(&config, path)?;
+    ensure_child_object(&mut config, "mcpServers", path)?;
+    config["mcpServers"]["tokensave"] = mcp_server_entry(tokensave_bin);
+
+    safe_write_json_file(path, &config, backup.as_deref())?;
+    eprintln!(
+        "\x1b[32m✔\x1b[0m Added tokensave MCP server to {}",
+        path.display()
+    );
+    Ok(())
+}
+
+/// Create or refresh the tokensave-owned Kiro agent.
+///
+/// Returns true when tokensave owns the resulting agent file. A pre-existing
+/// user-managed `tokensave.json` is preserved and returns false so the default
+/// agent selector is not pointed at a file whose policy tokensave does not own.
+fn install_managed_agent(path: &Path, tokensave_bin: &str) -> Result<bool> {
+    if path.exists() && !is_owned_agent_file(path) {
+        eprintln!(
+            "  {} already exists and is user-managed, leaving unchanged",
+            path.display()
+        );
+        return Ok(false);
+    }
+
+    let backup = backup_config_file(path)?;
+    let config = managed_agent_config(tokensave_bin);
+    safe_write_json_file(path, &config, backup.as_deref())?;
+    eprintln!(
+        "\x1b[32m✔\x1b[0m Wrote tokensave Kiro agent to {}",
+        path.display()
+    );
+    Ok(true)
+}
+
+fn install_default_agent(path: &Path, owns_agent: bool) -> Result<()> {
+    if !owns_agent {
+        eprintln!(
+            "  Skipping Kiro default-agent update because tokensave does not own the agent file"
+        );
+        return Ok(());
+    }
+
+    let backup = backup_config_file(path)?;
+    let mut config = match load_json_file_strict(path) {
+        Ok(v) => v,
+        Err(e) => {
+            if let Some(ref b) = backup {
+                eprintln!("  Backup preserved at: {}", b.display());
+            }
+            return Err(e);
+        }
+    };
+
+    ensure_json_object(&config, path)?;
+    ensure_child_object(&mut config, "chat", path)?;
+
+    match config["chat"].get("defaultAgent") {
+        Some(v) if v.as_str() == Some(KIRO_AGENT_NAME) => {
+            eprintln!("  Kiro default agent already set to tokensave");
+            return Ok(());
+        }
+        Some(v) if v.as_str().is_some_and(is_builtin_default_agent) => {}
+        Some(v) if is_empty_default_agent(v) => {}
+        None => {}
+        Some(v) => {
+            eprintln!(
+                "  Kiro default agent is {}, leaving user choice unchanged",
+                format_json_scalar(v)
+            );
+            return Ok(());
+        }
+    }
+
+    config["chat"]["defaultAgent"] = json!(KIRO_AGENT_NAME);
+    safe_write_json_file(path, &config, backup.as_deref())?;
+    eprintln!(
+        "\x1b[32m✔\x1b[0m Set Kiro default agent in {}",
+        path.display()
+    );
+    Ok(())
+}
+
+fn is_builtin_default_agent(agent: &str) -> bool {
+    matches!(agent, "kiro_default" | "default")
+}
+
+fn is_empty_default_agent(value: &serde_json::Value) -> bool {
+    value.is_null() || value.as_str() == Some("")
+}
+
+fn format_json_scalar(value: &serde_json::Value) -> String {
+    value
+        .as_str()
+        .map_or_else(|| value.to_string(), |s| format!("\"{s}\""))
+}
+
+fn ensure_json_object(config: &serde_json::Value, path: &Path) -> Result<()> {
+    if config.is_object() {
+        Ok(())
+    } else {
+        Err(TokenSaveError::Config {
+            message: format!("{} must contain a JSON object", path.display()),
+        })
+    }
+}
+
+fn ensure_child_object(config: &mut serde_json::Value, key: &str, path: &Path) -> Result<()> {
+    if config.get(key).is_none() {
+        config[key] = json!({});
+        return Ok(());
+    }
+    if config.get(key).is_some_and(serde_json::Value::is_object) {
+        Ok(())
+    } else {
+        Err(TokenSaveError::Config {
+            message: format!("{}.{} must be a JSON object", path.display(), key),
+        })
+    }
+}
+
+/// Append global AGENTS.md steering for default Kiro sessions.
+fn install_prompt_rules(path: &Path) -> Result<()> {
+    let existing = if path.exists() {
+        std::fs::read_to_string(path).unwrap_or_default()
+    } else {
+        String::new()
+    };
+    if existing.contains(PROMPT_MARKER) {
+        if existing.contains(PROMPT_END_MARKER) {
+            eprintln!("  Kiro AGENTS.md already contains tokensave rules, skipping");
+            return Ok(());
+        }
+        if let Some(range) = legacy_prompt_block_range(&existing) {
+            let mut updated = existing;
+            updated.replace_range(range, &prompt_rules_text());
+            std::fs::write(path, updated).map_err(|e| TokenSaveError::Config {
+                message: format!("failed to write {}: {e}", path.display()),
+            })?;
+            eprintln!(
+                "\x1b[32m✔\x1b[0m Updated tokensave rules in {}",
+                path.display()
+            );
+        } else {
+            eprintln!(
+                "  Kiro AGENTS.md contains legacy or edited tokensave rules without an end marker, leaving unchanged"
+            );
+        }
+        return Ok(());
+    }
+    if let Some(parent) = path.parent() {
+        std::fs::create_dir_all(parent).map_err(|e| TokenSaveError::Config {
+            message: format!("failed to create {}: {e}", parent.display()),
+        })?;
+    }
+    let mut f = std::fs::OpenOptions::new()
+        .create(true)
+        .append(true)
+        .open(path)
+        .map_err(|e| TokenSaveError::Config {
+            message: format!("failed to open {}: {e}", path.display()),
+        })?;
+    write!(f, "\n{}\n", prompt_rules_text()).map_err(|e| TokenSaveError::Config {
+        message: format!("failed to write {}: {e}", path.display()),
+    })?;
+    eprintln!(
+        "\x1b[32m✔\x1b[0m Appended tokensave rules to {}",
+        path.display()
+    );
+    Ok(())
+}
+
+fn prompt_rules_text() -> String {
+    format!(
+        "{}\n\n{}",
+        prompt_rules_text_without_end_marker(),
+        PROMPT_END_MARKER
+    )
+}
+
+fn prompt_rules_text_without_end_marker() -> &'static str {
+    "## Prefer tokensave MCP tools\n\n\
+Before reading source files or scanning the codebase, use the tokensave MCP tools \
+(`tokensave_context`, `tokensave_search`, `tokensave_callers`, `tokensave_callees`, \
+`tokensave_impact`, `tokensave_node`, `tokensave_files`, `tokensave_affected`). \
+They provide semantic results from a pre-built local knowledge graph and are faster \
+than broad file reads.\n\n\
+Do not use Kiro's `delegate` tool for codebase exploration, architecture mapping, \
+call graph work, symbol lookup, or other code research until tokensave MCP tools \
+have been tried. Delegation is still appropriate for long-running execution work \
+such as builds, tests, generated reports, or independent implementation tasks.\n\n\
+If a code analysis question cannot be fully answered by tokensave MCP tools, try \
+querying the SQLite database directly at `.tokensave/tokensave.db` (tables: `nodes`, \
+`edges`, `files`). Use SQL for structural queries that go beyond the MCP tools.\n\n\
+If you discover a gap where an extractor, schema, or tokensave tool could answer a \
+question natively, propose opening an issue at \
+https://github.com/aovestdipaperino/tokensave. Remind the user to strip sensitive \
+or proprietary code from the bug description before submitting."
+}
+
+// ---------------------------------------------------------------------------
+// Uninstall helpers
+// ---------------------------------------------------------------------------
+
+fn uninstall_mcp_server(path: &Path) {
+    if !path.exists() {
+        eprintln!("  {} not found, skipping", path.display());
+        return;
+    }
+    let Ok(contents) = std::fs::read_to_string(path) else {
+        return;
+    };
+    let Ok(mut config) = serde_json::from_str::<serde_json::Value>(&contents) else {
+        return;
+    };
+    let Some(servers) = config.get_mut("mcpServers").and_then(|v| v.as_object_mut()) else {
+        eprintln!("  No tokensave MCP server in {}, skipping", path.display());
+        return;
+    };
+    if servers.remove("tokensave").is_none() {
+        eprintln!("  No tokensave MCP server in {}, skipping", path.display());
+        return;
+    }
+    if servers.is_empty() {
+        config.as_object_mut().map(|o| o.remove("mcpServers"));
+    }
+    let is_empty = config.as_object().is_some_and(serde_json::Map::is_empty);
+    if is_empty {
+        std::fs::remove_file(path).ok();
+        eprintln!("\x1b[32m✔\x1b[0m Removed {} (was empty)", path.display());
+    } else if backup_and_write_json(path, &config) {
+        eprintln!(
+            "\x1b[32m✔\x1b[0m Removed tokensave MCP server from {}",
+            path.display()
+        );
+    }
+}
+
+fn uninstall_prompt_rules(path: &Path) {
+    if !path.exists() {
+        return;
+    }
+    let Ok(contents) = std::fs::read_to_string(path) else {
+        return;
+    };
+    if !contents.contains(PROMPT_MARKER) {
+        eprintln!("  Kiro AGENTS.md does not contain tokensave rules, skipping");
+        return;
+    }
+    let Some(range) = tokensave_prompt_block_range(&contents) else {
+        eprintln!(
+            "  Kiro AGENTS.md contains tokensave rules without an owned end marker; leaving unchanged"
+        );
+        return;
+    };
+    let mut new_contents = String::new();
+    new_contents.push_str(contents[..range.start].trim_end());
+    let remainder = &contents[range.end..];
+    if !remainder.is_empty() {
+        new_contents.push_str("\n\n");
+        new_contents.push_str(remainder.trim_start());
+    }
+    let new_contents = new_contents.trim().to_string();
+    if new_contents.is_empty() {
+        std::fs::remove_file(path).ok();
+        eprintln!("\x1b[32m✔\x1b[0m Removed {} (was empty)", path.display());
+    } else {
+        std::fs::write(path, format!("{new_contents}\n")).ok();
+        eprintln!(
+            "\x1b[32m✔\x1b[0m Removed tokensave rules from {}",
+            path.display()
+        );
+    }
+}
+
+fn uninstall_managed_agent(path: &Path) {
+    if !path.exists() {
+        return;
+    }
+    if !is_owned_agent_file(path) {
+        eprintln!("  {} is user-managed, leaving unchanged", path.display());
+        return;
+    }
+    if std::fs::remove_file(path).is_ok() {
+        eprintln!(
+            "\x1b[32m✔\x1b[0m Removed tokensave Kiro agent from {}",
+            path.display()
+        );
+        if let Some(parent) = path.parent() {
+            std::fs::remove_dir(parent).ok();
+        }
+    }
+}
+
+fn uninstall_default_agent(path: &Path, agent_path: &Path, owned_agent: bool) {
+    if !path.exists() {
+        return;
+    }
+    let Ok(contents) = std::fs::read_to_string(path) else {
+        return;
+    };
+    let Ok(mut config) = serde_json::from_str::<serde_json::Value>(&contents) else {
+        return;
+    };
+    if config
+        .get("chat")
+        .and_then(|v| v.get("defaultAgent"))
+        .and_then(serde_json::Value::as_str)
+        != Some(KIRO_AGENT_NAME)
+    {
+        return;
+    }
+    if agent_path.exists() && !owned_agent {
+        eprintln!(
+            "  Kiro default agent points at a user-managed tokensave agent, leaving unchanged"
+        );
+        return;
+    }
+
+    let Some(chat) = config.get_mut("chat").and_then(|v| v.as_object_mut()) else {
+        return;
+    };
+    chat.remove("defaultAgent");
+    if chat.is_empty() {
+        config.as_object_mut().map(|o| o.remove("chat"));
+    }
+
+    let is_empty = config.as_object().is_some_and(serde_json::Map::is_empty);
+    if is_empty {
+        std::fs::remove_file(path).ok();
+        eprintln!("\x1b[32m✔\x1b[0m Removed {} (was empty)", path.display());
+    } else if backup_and_write_json(path, &config) {
+        eprintln!(
+            "\x1b[32m✔\x1b[0m Removed tokensave Kiro default agent from {}",
+            path.display()
+        );
+    }
+}
+
+fn is_owned_agent_file(path: &Path) -> bool {
+    if !path.exists() {
+        return false;
+    }
+    let config = load_json_file(path);
+    is_owned_agent_config(&config)
+}
+
+fn is_owned_agent_config(config: &serde_json::Value) -> bool {
+    config.get("name").and_then(serde_json::Value::as_str) == Some(KIRO_AGENT_NAME)
+        && config
+            .get("description")
+            .and_then(serde_json::Value::as_str)
+            == Some(OWNED_AGENT_DESCRIPTION)
+}
+
+fn tokensave_prompt_block_range(contents: &str) -> Option<Range<usize>> {
+    let start = contents.find(PROMPT_MARKER)?;
+    if let Some(end_marker) = contents[start..].find(PROMPT_END_MARKER) {
+        let end = start + end_marker + PROMPT_END_MARKER.len();
+        return Some(start..end);
+    }
+    legacy_prompt_block_range(contents)
+}
+
+fn legacy_prompt_block_range(contents: &str) -> Option<Range<usize>> {
+    let start = contents.find(PROMPT_MARKER)?;
+    let after_marker = start + PROMPT_MARKER.len();
+    let end = contents[after_marker..]
+        .find("\n## ")
+        .map_or(contents.len(), |pos| after_marker + pos);
+    let candidate = &contents[start..end];
+    if candidate.trim() == prompt_rules_text_without_end_marker() {
+        Some(start..end)
+    } else {
+        None
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Healthcheck helpers
+// ---------------------------------------------------------------------------
+
+fn doctor_check_mcp_config(dc: &mut DoctorCounters, home: &Path) -> Option<serde_json::Value> {
+    let path = mcp_config_path(home);
+    if !path.exists() {
+        dc.warn(&format!(
+            "{} not found -- run `tokensave install --agent kiro` if you use Kiro",
+            path.display()
+        ));
+        return None;
+    }
+
+    let config = load_json_file(&path);
+    let server = config.get("mcpServers").and_then(|v| v.get("tokensave"));
+
+    let Some(server_value) = server else {
+        dc.fail(&format!(
+            "MCP server NOT registered in {} -- run `tokensave install --agent kiro`",
+            path.display()
+        ));
+        return None;
+    };
+    let Some(server) = server_value.as_object() else {
+        dc.fail(&format!(
+            "MCP server in {} is not an object -- run `tokensave install --agent kiro`",
+            path.display()
+        ));
+        return None;
+    };
+    dc.pass(&format!("MCP server registered in {}", path.display()));
+
+    let has_serve = server
+        .get("args")
+        .and_then(|v| v.as_array())
+        .is_some_and(|arr| arr.iter().any(|v| v.as_str() == Some("serve")));
+    if has_serve {
+        dc.pass("MCP server args include \"serve\"");
+    } else {
+        dc.fail("MCP server args missing \"serve\" -- run `tokensave install --agent kiro`");
+    }
+
+    let disabled = server
+        .get("disabled")
+        .and_then(serde_json::Value::as_bool)
+        .unwrap_or(false);
+    if disabled {
+        dc.fail("MCP server is disabled -- run `tokensave install --agent kiro`");
+    } else {
+        dc.pass("MCP server is enabled");
+    }
+
+    let expected = read_only_tool_names();
+    let approved_count = server
+        .get("autoApprove")
+        .and_then(|v| v.as_array())
+        .map_or(0, |arr| {
+            expected
+                .iter()
+                .filter(|name| arr.iter().any(|v| v.as_str() == Some(name.as_str())))
+                .count()
+        });
+    if approved_count >= expected.len() {
+        dc.pass(&format!(
+            "All {} read-only tokensave tools auto-approved",
+            expected.len()
+        ));
+    } else {
+        dc.warn(&format!(
+            "{approved_count}/{} read-only tokensave tools auto-approved -- run `tokensave install --agent kiro` to update",
+            expected.len()
+        ));
+    }
+
+    let auto_approve = server.get("autoApprove").and_then(|v| v.as_array());
+    if let Some(auto_approve) = auto_approve {
+        let has_broad = auto_approve.iter().any(|v| v.as_str() == Some("*"));
+        let mutating_approved: Vec<String> = mutating_tool_names()
+            .into_iter()
+            .filter(|name| {
+                auto_approve
+                    .iter()
+                    .any(|v| v.as_str() == Some(name.as_str()))
+            })
+            .collect();
+        if has_broad || !mutating_approved.is_empty() {
+            dc.warn(
+                "Kiro MCP autoApprove includes mutating tokensave tools -- run `tokensave install --agent kiro` to restore read-only defaults",
+            );
+        } else {
+            dc.pass("Kiro MCP autoApprove excludes mutating tokensave tools");
+        }
+    }
+
+    Some(server_value.clone())
+}
+
+fn doctor_check_workspace_mcp_override(
+    dc: &mut DoctorCounters,
+    home: &Path,
+    project_path: &Path,
+    global_server: Option<&serde_json::Value>,
+) {
+    let path = workspace_mcp_config_path(project_path);
+    if path == mcp_config_path(home) {
+        return;
+    }
+    if !path.exists() {
+        dc.pass("No workspace Kiro MCP tokensave override");
+        return;
+    }
+
+    let config = load_json_file(&path);
+    let server = config.get("mcpServers").and_then(|v| v.get("tokensave"));
+    let Some(server_value) = server else {
+        dc.pass("No workspace Kiro MCP tokensave override");
+        return;
+    };
+    let Some(server) = server_value.as_object() else {
+        dc.fail(&format!(
+            "Workspace Kiro MCP tokensave entry in {} is not an object and shadows the global install",
+            path.display()
+        ));
+        return;
+    };
+
+    let mut compatible = true;
+    let disabled = server
+        .get("disabled")
+        .and_then(serde_json::Value::as_bool)
+        .unwrap_or(false);
+    if disabled {
+        dc.fail(&format!(
+            "Workspace Kiro MCP tokensave entry in {} is disabled and shadows the global install",
+            path.display()
+        ));
+        compatible = false;
+    }
+
+    let has_serve = server
+        .get("args")
+        .and_then(|v| v.as_array())
+        .is_some_and(|arr| arr.iter().any(|v| v.as_str() == Some("serve")));
+    if !has_serve {
+        dc.fail(&format!(
+            "Workspace Kiro MCP tokensave entry in {} is missing \"serve\" and shadows the global install",
+            path.display()
+        ));
+        compatible = false;
+    }
+
+    if let Some(global_server) = global_server {
+        let workspace_command = server.get("command").and_then(|v| v.as_str());
+        let global_command = global_server.get("command").and_then(|v| v.as_str());
+        if workspace_command != global_command {
+            dc.fail(&format!(
+                "Workspace Kiro MCP tokensave command in {} differs from the global install",
+                path.display()
+            ));
+            compatible = false;
+        }
+    }
+
+    let expected = read_only_tool_names();
+    let approved_count = server
+        .get("autoApprove")
+        .and_then(|v| v.as_array())
+        .map_or(0, |arr| {
+            expected
+                .iter()
+                .filter(|name| arr.iter().any(|v| v.as_str() == Some(name.as_str())))
+                .count()
+        });
+    if approved_count < expected.len() {
+        dc.warn(&format!(
+            "Workspace Kiro MCP tokensave entry auto-approves {approved_count}/{} read-only tools and shadows the global install",
+            expected.len()
+        ));
+    }
+
+    if let Some(auto_approve) = server.get("autoApprove").and_then(|v| v.as_array()) {
+        let has_broad = auto_approve.iter().any(|v| v.as_str() == Some("*"));
+        let mutating_approved = mutating_tool_names().into_iter().any(|name| {
+            auto_approve
+                .iter()
+                .any(|v| v.as_str() == Some(name.as_str()))
+        });
+        if has_broad || mutating_approved {
+            dc.warn(
+                "Workspace Kiro MCP tokensave entry auto-approves mutating tools and shadows the global install",
+            );
+        }
+    }
+
+    if compatible {
+        dc.pass(&format!(
+            "Workspace Kiro MCP tokensave override in {} is compatible",
+            path.display()
+        ));
+    }
+}
+
+fn doctor_check_steering(dc: &mut DoctorCounters, home: &Path) {
+    let path = steering_path(home);
+    if !path.exists() {
+        dc.warn("~/.kiro/steering/AGENTS.md does not exist");
+        return;
+    }
+    let has_rules = std::fs::read_to_string(&path)
+        .unwrap_or_default()
+        .contains(PROMPT_MARKER);
+    if has_rules {
+        dc.pass("Kiro global AGENTS.md contains tokensave rules");
+    } else {
+        dc.fail(
+            "Kiro global AGENTS.md missing tokensave rules -- run `tokensave install --agent kiro`",
+        );
+    }
+}
+
+fn doctor_check_managed_agent(dc: &mut DoctorCounters, home: &Path) {
+    let path = managed_agent_path(home);
+    if !path.exists() {
+        dc.fail(&format!(
+            "Kiro tokensave agent NOT installed at {} -- run `tokensave install --agent kiro`",
+            path.display()
+        ));
+        return;
+    }
+
+    let config = load_json_file(&path);
+    if !is_owned_agent_config(&config) {
+        dc.warn(&format!(
+            "{} is user-managed; tokensave hooks were not installed there",
+            path.display()
+        ));
+        return;
+    }
+
+    dc.pass(&format!("Kiro tokensave agent: {}", path.display()));
+
+    if config
+        .get("includeMcpJson")
+        .and_then(serde_json::Value::as_bool)
+        == Some(true)
+    {
+        dc.pass("Kiro tokensave agent includes global/workspace MCP config");
+    } else {
+        dc.fail("Kiro tokensave agent missing includeMcpJson=true -- run `tokensave install --agent kiro`");
+    }
+
+    if config
+        .get("tools")
+        .and_then(|v| v.as_array())
+        .is_some_and(|arr| arr.iter().any(|v| v.as_str() == Some("*")))
+    {
+        dc.pass("Kiro tokensave agent keeps default tool access");
+    } else {
+        dc.warn("Kiro tokensave agent tools list may not include all default Kiro tools");
+    }
+
+    if config.get("prompt").and_then(serde_json::Value::as_str)
+        == Some("file://../steering/AGENTS.md")
+    {
+        dc.pass("Kiro tokensave agent references global steering");
+    } else {
+        dc.fail(
+            "Kiro tokensave agent prompt should reference global steering -- run `tokensave install --agent kiro`",
+        );
+    }
+
+    doctor_check_agent_hook(
+        dc,
+        &config,
+        "userPromptSubmit",
+        None,
+        KIRO_PROMPT_HOOK,
+        KIRO_SHORT_HOOK_TIMEOUT_MS,
+    );
+    doctor_check_agent_hook(
+        dc,
+        &config,
+        "preToolUse",
+        Some("delegate"),
+        KIRO_PRE_TOOL_HOOK,
+        KIRO_SHORT_HOOK_TIMEOUT_MS,
+    );
+    doctor_check_agent_hook(
+        dc,
+        &config,
+        "preToolUse",
+        Some("subagent"),
+        KIRO_PRE_TOOL_HOOK,
+        KIRO_SHORT_HOOK_TIMEOUT_MS,
+    );
+    doctor_check_agent_hook(
+        dc,
+        &config,
+        "postToolUse",
+        Some("fs_write"),
+        KIRO_POST_TOOL_HOOK,
+        KIRO_SYNC_HOOK_TIMEOUT_MS,
+    );
+}
+
+fn doctor_check_agent_hook(
+    dc: &mut DoctorCounters,
+    config: &serde_json::Value,
+    event: &str,
+    matcher: Option<&str>,
+    subcommand: &str,
+    timeout_ms: u64,
+) {
+    let hook = find_agent_hook(config, event, matcher, subcommand);
+    let Some(hook) = hook else {
+        let matcher_label = matcher.map_or(String::new(), |m| format!(" ({m})"));
+        dc.fail(&format!(
+            "Kiro {event}{matcher_label} hook missing {subcommand} -- run `tokensave install --agent kiro`"
+        ));
+        return;
+    };
+
+    let timeout_ok = hook.get("timeout_ms").and_then(serde_json::Value::as_u64) == Some(timeout_ms);
+    if timeout_ok {
+        let matcher_label = matcher.map_or(String::new(), |m| format!(" ({m})"));
+        dc.pass(&format!("Kiro {event}{matcher_label} hook installed"));
+    } else {
+        dc.warn(&format!(
+            "Kiro {event} hook timeout differs from tokensave default -- run `tokensave install --agent kiro` to update"
+        ));
+    }
+}
+
+fn find_agent_hook<'a>(
+    config: &'a serde_json::Value,
+    event: &str,
+    matcher: Option<&str>,
+    subcommand: &str,
+) -> Option<&'a serde_json::Value> {
+    config
+        .get("hooks")
+        .and_then(|v| v.get(event))
+        .and_then(serde_json::Value::as_array)?
+        .iter()
+        .find(|hook| {
+            let matcher_ok = match matcher {
+                Some(expected) => {
+                    hook.get("matcher").and_then(serde_json::Value::as_str) == Some(expected)
+                }
+                None => hook.get("matcher").is_none(),
+            };
+            matcher_ok
+                && hook
+                    .get("command")
+                    .and_then(serde_json::Value::as_str)
+                    .is_some_and(|cmd| cmd.split_whitespace().any(|part| part == subcommand))
+        })
+}
+
+fn doctor_check_default_agent(dc: &mut DoctorCounters, home: &Path) {
+    let path = cli_config_path(home);
+    if !path.exists() {
+        dc.fail(&format!(
+            "{} not found -- run `tokensave install --agent kiro`",
+            path.display()
+        ));
+        return;
+    }
+
+    let config = load_json_file(&path);
+    let default_agent = config
+        .get("chat")
+        .and_then(|v| v.get("defaultAgent"))
+        .and_then(serde_json::Value::as_str);
+
+    match default_agent {
+        Some(KIRO_AGENT_NAME) => dc.pass("Kiro default agent is tokensave"),
+        Some(agent) if is_builtin_default_agent(agent) => dc.warn(
+            "Kiro default agent is still the built-in default -- run `tokensave install --agent kiro`",
+        ),
+        Some(agent) => dc.warn(&format!(
+            "Kiro default agent is \"{agent}\"; tokensave hooks run only when the tokensave agent is selected"
+        )),
+        None => dc.warn(
+            "Kiro default agent is not set; tokensave hooks run only when the tokensave agent is selected",
+        ),
+    }
+}

--- a/src/agents/mod.rs
+++ b/src/agents/mod.rs
@@ -15,6 +15,7 @@ pub mod cursor;
 pub mod gemini;
 pub mod kilo;
 pub mod kimi;
+pub mod kiro;
 pub mod opencode;
 pub mod roo_code;
 pub mod vibe;
@@ -35,6 +36,7 @@ pub use cursor::CursorIntegration;
 pub use gemini::GeminiIntegration;
 pub use kilo::KiloIntegration;
 pub use kimi::KimiIntegration;
+pub use kiro::KiroIntegration;
 pub use opencode::OpenCodeIntegration;
 pub use roo_code::RooCodeIntegration;
 pub use vibe::VibeIntegration;
@@ -117,6 +119,7 @@ pub fn get_integration(id: &str) -> Result<Box<dyn AgentIntegration>> {
         "roo-code" => Ok(Box::new(RooCodeIntegration)),
         "antigravity" => Ok(Box::new(AntigravityIntegration)),
         "kilo" => Ok(Box::new(KiloIntegration)),
+        "kiro" => Ok(Box::new(KiroIntegration)),
         "kimi" => Ok(Box::new(KimiIntegration)),
         "vibe" => Ok(Box::new(VibeIntegration)),
         _ => Err(TokenSaveError::Config {
@@ -142,6 +145,7 @@ pub fn all_integrations() -> Vec<Box<dyn AgentIntegration>> {
         Box::new(RooCodeIntegration),
         Box::new(AntigravityIntegration),
         Box::new(KiloIntegration),
+        Box::new(KiroIntegration),
         Box::new(KimiIntegration),
         Box::new(VibeIntegration),
     ]
@@ -161,6 +165,7 @@ pub fn available_integrations() -> Vec<&'static str> {
         "roo-code",
         "antigravity",
         "kilo",
+        "kiro",
         "kimi",
         "vibe",
     ]
@@ -1368,6 +1373,20 @@ mod git_hook_tests {
 pub fn tool_names() -> Vec<String> {
     get_tool_definitions()
         .iter()
+        .map(|t| t.name.clone())
+        .collect()
+}
+
+pub fn read_only_tool_names() -> Vec<String> {
+    get_tool_definitions()
+        .iter()
+        .filter(|t| {
+            t.annotations
+                .as_ref()
+                .and_then(|annotations| annotations.get("readOnlyHint"))
+                .and_then(serde_json::Value::as_bool)
+                .unwrap_or(false)
+        })
         .map(|t| t.name.clone())
         .collect()
 }

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -1,10 +1,14 @@
-use clap::{Parser, Subcommand};
+use clap::{builder::PossibleValuesParser, Parser, Subcommand};
+
+fn agent_value_parser() -> PossibleValuesParser {
+    PossibleValuesParser::new(tokensave::agents::available_integrations())
+}
 
 /// Code intelligence for Rust codebases.
 #[derive(Parser)]
 #[command(
     name = "tokensave",
-    about = "Code intelligence for 15 languages — semantic graph queries instead of file reads",
+    about = "Code intelligence for 34 languages — semantic graph queries instead of file reads",
     version
 )]
 pub struct Cli {
@@ -120,7 +124,7 @@ pub enum Commands {
     #[command(name = "install", visible_alias = "claude-install")]
     Install {
         /// Agent to configure (auto-detects if omitted)
-        #[arg(long)]
+        #[arg(long, value_parser = agent_value_parser())]
         agent: Option<String>,
     },
     /// Refresh settings for all already-installed agents
@@ -129,7 +133,7 @@ pub enum Commands {
     #[command(name = "uninstall", visible_alias = "claude-uninstall")]
     Uninstall {
         /// Agent to remove (removes all if omitted)
-        #[arg(long)]
+        #[arg(long, value_parser = agent_value_parser())]
         agent: Option<String>,
     },
     /// Extraction worker (spawned by tokensave itself; not for direct use).
@@ -144,6 +148,15 @@ pub enum Commands {
     /// Stop hook handler (prints session token savings)
     #[command(name = "hook-stop", hide = true)]
     HookStop,
+    /// Kiro PreToolUse hook handler (called by Kiro, not by users directly)
+    #[command(name = "hook-kiro-pre-tool-use", hide = true)]
+    HookKiroPreToolUse,
+    /// Kiro UserPromptSubmit hook handler (called by Kiro, not by users directly)
+    #[command(name = "hook-kiro-prompt-submit", hide = true)]
+    HookKiroPromptSubmit,
+    /// Kiro PostToolUse hook handler for incremental sync
+    #[command(name = "hook-kiro-post-tool-use", hide = true)]
+    HookKiroPostToolUse,
     /// Start MCP server over stdio
     Serve {
         /// Project path
@@ -189,7 +202,7 @@ pub enum Commands {
     /// Check tokensave installation, configuration, and agent integration
     Doctor {
         /// Check only this agent (default: all agents)
-        #[arg(long)]
+        #[arg(long, value_parser = agent_value_parser())]
         agent: Option<String>,
     },
     /// Background file watcher daemon

--- a/src/hooks.rs
+++ b/src/hooks.rs
@@ -1,8 +1,21 @@
-//! Hook handlers for Claude Code integration.
+//! Hook handlers for Claude Code and Kiro integrations.
 //!
 //! These functions are invoked by Claude Code's hook system to intercept
 //! tool calls, redirect exploration work to tokensave MCP tools, and
-//! track per-session token savings.
+//! track per-session token savings. Kiro invokes its own handlers with hook
+//! events on stdin and expects blocking decisions through process exit codes.
+
+use std::io::Read;
+use std::path::{Path, PathBuf};
+
+use serde_json::Value;
+
+const TOKENSAVE_RESEARCH_BLOCK_REASON: &str = "STOP: Use tokensave MCP tools \
+(tokensave_context, tokensave_search, tokensave_callees, tokensave_callers, \
+tokensave_impact, tokensave_files, tokensave_affected) instead of agents for \
+code research. Tokensave is faster and more precise for symbol relationships, \
+call paths, and code structure. Only use agents for code exploration if you \
+have already tried tokensave and it cannot answer the question.";
 
 /// `PreToolUse` hook handler for Claude Code's Agent tool matcher.
 ///
@@ -27,12 +40,7 @@ pub fn evaluate_hook_decision(tool_input: &str) -> String {
         "hookSpecificOutput": {
             "hookEventName": "PreToolUse",
             "permissionDecision": "deny",
-            "permissionDecisionReason": "STOP: Use tokensave MCP tools (tokensave_context, tokensave_search, \
-                       tokensave_callees, tokensave_callers, tokensave_impact, tokensave_files, \
-                       tokensave_affected) instead of agents for code research. Tokensave is \
-                       faster and more precise for symbol relationships, call paths, and code \
-                       structure. Only use agents for code exploration if you have already tried \
-                       tokensave and it cannot answer the question."
+            "permissionDecisionReason": TOKENSAVE_RESEARCH_BLOCK_REASON
         }
     });
 
@@ -46,33 +54,129 @@ pub fn evaluate_hook_decision(tool_input: &str) -> String {
 
     // Check if the prompt is exploration/research work that tokensave can handle
     if let Some(prompt) = parsed.get("prompt").and_then(|v| v.as_str()) {
-        let lower = prompt.to_ascii_lowercase();
-        let exploration_patterns = [
-            "explore",
-            "codebase structure",
-            "codebase architecture",
-            "codebase overview",
-            "source files contents",
-            "read every",
-            "full contents",
-            "entire codebase",
-            "architecture and structure",
-            "call graph",
-            "call path",
-            "call chain",
-            "symbol relat",
-            "symbol lookup",
-            "who calls",
-            "callers of",
-            "callees of",
-        ];
-        if exploration_patterns.iter().any(|pat| lower.contains(pat)) {
+        if is_code_research_prompt(prompt) {
             return block_msg.to_string();
         }
     }
 
     // Empty string = no output -> Claude Code implicitly allows the tool call
     String::new()
+}
+
+fn is_code_research_prompt(prompt: &str) -> bool {
+    let lower = prompt.to_ascii_lowercase();
+    let exploration_patterns = [
+        "explore",
+        "codebase structure",
+        "codebase architecture",
+        "codebase overview",
+        "source files contents",
+        "read every",
+        "full contents",
+        "entire codebase",
+        "architecture and structure",
+        "call graph",
+        "call path",
+        "call chain",
+        "symbol relat",
+        "symbol lookup",
+        "who calls",
+        "callers of",
+        "callees of",
+    ];
+    exploration_patterns.iter().any(|pat| lower.contains(pat))
+}
+
+/// Kiro `preToolUse` hook handler.
+///
+/// Kiro sends the hook event JSON on stdin. Returning exit code 2 blocks the
+/// tool call and sends stderr back to the model. This is intentionally separate
+/// from Claude's hook handler because Claude expects a JSON decision on stdout.
+pub fn hook_kiro_pre_tool_use() -> i32 {
+    let event = read_stdin_to_string();
+    if let Some(reason) = evaluate_kiro_pre_tool_use(&event) {
+        eprintln!("{reason}");
+        2
+    } else {
+        0
+    }
+}
+
+/// Pure decision logic for Kiro `preToolUse` hook events.
+///
+/// Returns a block reason only for Kiro delegation/subagent tool calls whose
+/// task text looks like codebase research that tokensave MCP tools should
+/// answer first.
+pub fn evaluate_kiro_pre_tool_use(event_json: &str) -> Option<&'static str> {
+    let parsed: Value = serde_json::from_str(event_json).ok()?;
+    let tool_name = parsed.get("tool_name").and_then(Value::as_str)?;
+    if !is_kiro_delegation_tool(tool_name) {
+        return None;
+    }
+
+    if kiro_event_has_research_text(parsed.get("tool_input").unwrap_or(&Value::Null)) {
+        Some(TOKENSAVE_RESEARCH_BLOCK_REASON)
+    } else {
+        None
+    }
+}
+
+fn is_kiro_delegation_tool(tool_name: &str) -> bool {
+    matches!(tool_name, "delegate" | "subagent" | "use_subagent")
+}
+
+fn kiro_event_has_research_text(value: &Value) -> bool {
+    let mut text = Vec::new();
+    collect_kiro_task_strings(value, &mut text);
+    if text.is_empty() {
+        collect_strings(value, &mut text);
+    }
+    text.iter().any(|s| is_code_research_prompt(s))
+}
+
+fn collect_kiro_task_strings<'a>(value: &'a Value, out: &mut Vec<&'a str>) {
+    match value {
+        Value::Object(map) => {
+            for (key, child) in map {
+                let key = key.to_ascii_lowercase();
+                if key.contains("prompt")
+                    || key.contains("task")
+                    || key.contains("query")
+                    || key.contains("instruction")
+                    || key.contains("message")
+                    || key.contains("description")
+                {
+                    collect_strings(child, out);
+                } else {
+                    collect_kiro_task_strings(child, out);
+                }
+            }
+        }
+        Value::Array(items) => {
+            for item in items {
+                collect_kiro_task_strings(item, out);
+            }
+        }
+        Value::String(s) => out.push(s),
+        _ => {}
+    }
+}
+
+fn collect_strings<'a>(value: &'a Value, out: &mut Vec<&'a str>) {
+    match value {
+        Value::String(s) => out.push(s),
+        Value::Array(items) => {
+            for item in items {
+                collect_strings(item, out);
+            }
+        }
+        Value::Object(map) => {
+            for child in map.values() {
+                collect_strings(child, out);
+            }
+        }
+        _ => {}
+    }
 }
 
 /// `UserPromptSubmit` hook handler: resets the per-session local counter.
@@ -84,6 +188,73 @@ pub async fn hook_prompt_submit() {
     if let Ok(cg) = crate::tokensave::TokenSave::open(&project_path).await {
         let _ = cg.reset_local_counter().await;
     }
+}
+
+/// Kiro `userPromptSubmit` hook handler.
+///
+/// Kiro adds successful hook stdout to context, so this handler stays silent.
+pub async fn hook_kiro_prompt_submit() -> i32 {
+    let event = read_stdin_to_string();
+    reset_counter_for_kiro_event(&event).await;
+    0
+}
+
+/// Kiro `postToolUse` hook handler used to keep the graph fresh after writes.
+///
+/// The installed Kiro agent maps this to `fs_write`. The hook discovers the
+/// nearest initialized tokensave project from Kiro's `cwd` field and runs a
+/// silent incremental sync. Missing indexes and concurrent syncs are no-ops.
+pub async fn hook_kiro_post_tool_use() -> i32 {
+    let event = read_stdin_to_string();
+    match sync_for_kiro_event(&event).await {
+        Ok(()) => 0,
+        Err(e) => {
+            eprintln!("tokensave sync failed: {e}");
+            1
+        }
+    }
+}
+
+async fn reset_counter_for_kiro_event(event_json: &str) {
+    let Some(project_root) = kiro_project_root(event_json) else {
+        return;
+    };
+    if let Ok(cg) = crate::tokensave::TokenSave::open(&project_root).await {
+        let _ = cg.reset_local_counter().await;
+    }
+}
+
+async fn sync_for_kiro_event(event_json: &str) -> crate::errors::Result<()> {
+    let Some(project_root) = kiro_project_root(event_json) else {
+        return Ok(());
+    };
+    let cg = crate::tokensave::TokenSave::open(&project_root).await?;
+    match cg.sync().await {
+        Ok(_) | Err(crate::errors::TokenSaveError::SyncLock { .. }) => Ok(()),
+        Err(e) => Err(e),
+    }
+}
+
+fn kiro_project_root(event_json: &str) -> Option<PathBuf> {
+    let cwd = kiro_event_cwd(event_json).or_else(|| std::env::current_dir().ok())?;
+    crate::config::discover_project_root(&cwd)
+}
+
+fn kiro_event_cwd(event_json: &str) -> Option<PathBuf> {
+    let parsed: Value = serde_json::from_str(event_json).ok()?;
+    let cwd = parsed.get("cwd").and_then(Value::as_str)?;
+    let path = Path::new(cwd);
+    if path.as_os_str().is_empty() {
+        None
+    } else {
+        Some(path.to_path_buf())
+    }
+}
+
+fn read_stdin_to_string() -> String {
+    let mut input = String::new();
+    let _ = std::io::stdin().read_to_string(&mut input);
+    input
 }
 
 /// `Stop` hook handler: ingests new session data and prints a cost receipt.

--- a/src/main.rs
+++ b/src/main.rs
@@ -146,18 +146,17 @@ async fn run(cli: Cli) -> tokensave::errors::Result<()> {
     // retired in 4.3.12. The beta channel is open again as of v5.0.0-beta.1
     // and beta users now stay on beta until they explicitly switch off.
 
-    // Best-effort check: warn if install needs re-running
-    if !matches!(command, Commands::Install { .. } | Commands::Reinstall) {
+    let skip_agent_install_maintenance = should_skip_agent_install_maintenance(&command);
+
+    // Best-effort check: warn if install needs re-running.
+    if !skip_agent_install_maintenance {
         tokensave::agents::claude::check_install_stale();
     }
 
     // Silent reinstall: if the running version is newer than the one that last
     // installed agents, re-run the install for every tracked agent so that
     // permissions, hooks, and MCP config stay in sync with the new binary.
-    if !matches!(
-        command,
-        Commands::Install { .. } | Commands::Reinstall | Commands::Uninstall { .. }
-    ) {
+    if !skip_agent_install_maintenance {
         let running = env!("CARGO_PKG_VERSION");
         if !user_config.installed_agents.is_empty()
             && !running.is_empty()
@@ -828,6 +827,24 @@ async fn run(cli: Cli) -> tokensave::errors::Result<()> {
         Commands::HookStop => {
             tokensave::hooks::hook_stop().await;
         }
+        Commands::HookKiroPreToolUse => {
+            let code = tokensave::hooks::hook_kiro_pre_tool_use();
+            if code != 0 {
+                process::exit(code);
+            }
+        }
+        Commands::HookKiroPromptSubmit => {
+            let code = tokensave::hooks::hook_kiro_prompt_submit().await;
+            if code != 0 {
+                process::exit(code);
+            }
+        }
+        Commands::HookKiroPostToolUse => {
+            let code = tokensave::hooks::hook_kiro_post_tool_use().await;
+            if code != 0 {
+                process::exit(code);
+            }
+        }
         Commands::Serve { path } => {
             if std::env::var("DISABLE_TOKENSAVE").as_deref() == Ok("true") {
                 // Allow users to opt out per-project by setting
@@ -1217,6 +1234,52 @@ async fn run(cli: Cli) -> tokensave::errors::Result<()> {
         }
     }
     Ok(())
+}
+
+fn should_skip_agent_install_maintenance(command: &Commands) -> bool {
+    matches!(
+        command,
+        Commands::Install { .. }
+            | Commands::Reinstall
+            | Commands::Uninstall { .. }
+            | Commands::Doctor { .. }
+    )
+}
+
+#[cfg(test)]
+mod startup_tests {
+    use super::{should_skip_agent_install_maintenance, Commands};
+
+    #[test]
+    fn doctor_skips_agent_install_maintenance() {
+        let command = Commands::Doctor {
+            agent: Some("kiro".to_string()),
+        };
+        assert!(should_skip_agent_install_maintenance(&command));
+    }
+
+    #[test]
+    fn explicit_agent_config_commands_skip_agent_install_maintenance() {
+        assert!(should_skip_agent_install_maintenance(&Commands::Install {
+            agent: Some("kiro".to_string()),
+        }));
+        assert!(should_skip_agent_install_maintenance(&Commands::Reinstall));
+        assert!(should_skip_agent_install_maintenance(
+            &Commands::Uninstall {
+                agent: Some("kiro".to_string()),
+            }
+        ));
+    }
+
+    #[test]
+    fn normal_commands_keep_agent_install_maintenance() {
+        assert!(!should_skip_agent_install_maintenance(&Commands::Status {
+            path: None,
+            json: false,
+            short: false,
+            details: false,
+        }));
+    }
 }
 
 // handle_branch_action, handle_wipe, handle_list, handle_no_command,

--- a/src/mcp/server.rs
+++ b/src/mcp/server.rs
@@ -575,8 +575,10 @@ impl McpServer {
                     Start with tokensave_context for any code exploration task \
                     — it returns relevant symbols, relationships, and code \
                     snippets for a natural-language query. Use tokensave_search \
-                    to find specific symbols by name. All tools are read-only \
-                    and safe to call in parallel. \
+                    to find specific symbols by name. Discovery and analysis \
+                    tools are read-only and safe to call in parallel. Edit \
+                    and session-memory tools can mutate local project state \
+                    and declare readOnlyHint=false. \
                     When a tool result contains a `tokensave_metrics:` line, \
                     report the savings to the user (e.g. 'TokenSave\\'d ~N tokens')."
             }),

--- a/src/mcp/tools/definitions.rs
+++ b/src/mcp/tools/definitions.rs
@@ -1504,15 +1504,19 @@ fn def_session_start() -> ToolDefinition {
 }
 
 fn def_session_end() -> ToolDefinition {
-    def(
-        "tokensave_session_end",
-        "Session End",
-        "Re-scan and compare current health against session baseline (saved by session_start). Returns diff showing what improved or degraded.",
-        json!({
+    ToolDefinition {
+        name: "tokensave_session_end".to_string(),
+        description: "Re-scan and compare current health against session baseline (saved by session_start). Returns diff showing what improved or degraded.".to_string(),
+        input_schema: json!({
             "type": "object",
             "properties": {}
         }),
-    )
+        annotations: Some(json!({
+            "readOnlyHint": false,
+            "title": "Session End"
+        })),
+        meta: None,
+    }
 }
 
 fn def_body() -> ToolDefinition {

--- a/src/mcp/tools/handlers/mod.rs
+++ b/src/mcp/tools/handlers/mod.rs
@@ -326,6 +326,7 @@ mod tests {
             "tokensave_insert_at",
             "tokensave_ast_grep_rewrite",
             "tokensave_session_start",
+            "tokensave_session_end",
             "tokensave_record_decision",
             "tokensave_record_code_area",
         ];

--- a/tests/agent_test.rs
+++ b/tests/agent_test.rs
@@ -10,7 +10,7 @@ use tokensave::agents::*;
 #[test]
 fn test_get_all_integrations() {
     let all = all_integrations();
-    assert_eq!(all.len(), 13);
+    assert_eq!(all.len(), 14);
 }
 
 #[test]
@@ -27,9 +27,10 @@ fn test_available_integrations() {
     assert!(ids.contains(&"roo-code"));
     assert!(ids.contains(&"antigravity"));
     assert!(ids.contains(&"kilo"));
+    assert!(ids.contains(&"kiro"));
     assert!(ids.contains(&"kimi"));
     assert!(ids.contains(&"vibe"));
-    assert_eq!(ids.len(), 13);
+    assert_eq!(ids.len(), 14);
 }
 
 #[test]
@@ -46,6 +47,7 @@ fn test_get_integration_valid() {
         "roo-code",
         "antigravity",
         "kilo",
+        "kiro",
         "kimi",
         "vibe",
     ] {
@@ -88,6 +90,7 @@ fn test_agent_names_are_human_readable() {
         ("roo-code", "Roo Code"),
         ("antigravity", "Antigravity"),
         ("kilo", "Kilo CLI"),
+        ("kiro", "Kiro"),
         ("kimi", "Kimi CLI"),
         ("vibe", "Mistral Vibe"),
     ];
@@ -887,6 +890,7 @@ fn test_every_tested_agent_advertises_primary_config_path() {
         (&KiloIntegration, "kilo"),
         (&AntigravityIntegration, "antigravity"),
         (&CodexIntegration, "codex"),
+        (&KiroIntegration, "kiro"),
         (&KimiIntegration, "kimi"),
     ];
     for (agent, id) in agents {
@@ -1627,6 +1631,7 @@ fn test_uninstall_without_install_does_not_crash() {
     ZedIntegration.uninstall(&ctx).unwrap();
     ClineIntegration.uninstall(&ctx).unwrap();
     RooCodeIntegration.uninstall(&ctx).unwrap();
+    KiroIntegration.uninstall(&ctx).unwrap();
     VibeIntegration.uninstall(&ctx).unwrap();
 }
 
@@ -1695,6 +1700,38 @@ fn test_tool_names_not_empty() {
         assert!(
             name.starts_with("tokensave_"),
             "tool name should start with tokensave_: {name}"
+        );
+    }
+}
+
+#[test]
+fn test_read_only_tool_names_excludes_mutating_tools() {
+    let read_only = read_only_tool_names();
+    let read_only_set: std::collections::HashSet<&str> =
+        read_only.iter().map(String::as_str).collect();
+    let known_tools: std::collections::HashSet<String> = tool_names().into_iter().collect();
+    assert!(!read_only.is_empty());
+
+    for name in &read_only {
+        assert!(
+            known_tools.contains(name),
+            "read-only tool should be a known MCP tool: {name}"
+        );
+    }
+
+    for mutating in [
+        "tokensave_str_replace",
+        "tokensave_multi_str_replace",
+        "tokensave_insert_at",
+        "tokensave_ast_grep_rewrite",
+        "tokensave_session_start",
+        "tokensave_session_end",
+        "tokensave_record_decision",
+        "tokensave_record_code_area",
+    ] {
+        assert!(
+            !read_only_set.contains(mutating),
+            "mutating tool should not be read-only: {mutating}"
         );
     }
 }

--- a/tests/hooks_test.rs
+++ b/tests/hooks_test.rs
@@ -1,4 +1,4 @@
-use tokensave::hooks::evaluate_hook_decision;
+use tokensave::hooks::{evaluate_hook_decision, evaluate_kiro_pre_tool_use};
 
 fn is_blocked(json: &str) -> bool {
     let v: serde_json::Value = serde_json::from_str(json).unwrap();
@@ -147,4 +147,58 @@ fn test_block_response_uses_correct_hook_schema() {
     assert!(v["hookSpecificOutput"]["permissionDecisionReason"]
         .as_str()
         .is_some());
+}
+
+#[test]
+fn test_kiro_blocks_delegate_code_research_task() {
+    let input = r#"{
+        "hook_event_name": "preToolUse",
+        "tool_name": "delegate",
+        "tool_input": {
+            "task": "Explore the codebase architecture and call graph"
+        }
+    }"#;
+    let reason = evaluate_kiro_pre_tool_use(input).unwrap();
+    assert!(reason.contains("tokensave MCP tools"));
+}
+
+#[test]
+fn test_kiro_blocks_subagent_research_prompt() {
+    let input = r#"{
+        "hook_event_name": "preToolUse",
+        "tool_name": "subagent",
+        "tool_input": {
+            "prompt": "who calls the process_data function?"
+        }
+    }"#;
+    assert!(evaluate_kiro_pre_tool_use(input).is_some());
+}
+
+#[test]
+fn test_kiro_allows_delegate_execution_task() {
+    let input = r#"{
+        "hook_event_name": "preToolUse",
+        "tool_name": "delegate",
+        "tool_input": {
+            "task": "Run the full test suite and report failures"
+        }
+    }"#;
+    assert!(evaluate_kiro_pre_tool_use(input).is_none());
+}
+
+#[test]
+fn test_kiro_allows_non_delegation_tool() {
+    let input = r#"{
+        "hook_event_name": "preToolUse",
+        "tool_name": "read",
+        "tool_input": {
+            "prompt": "Explore the entire codebase"
+        }
+    }"#;
+    assert!(evaluate_kiro_pre_tool_use(input).is_none());
+}
+
+#[test]
+fn test_kiro_allows_invalid_json() {
+    assert!(evaluate_kiro_pre_tool_use("not json").is_none());
 }

--- a/tests/kiro_agent_test.rs
+++ b/tests/kiro_agent_test.rs
@@ -1,0 +1,452 @@
+use std::io::Write;
+use std::path::Path;
+
+use tempfile::TempDir;
+use tokensave::agents::{
+    read_only_tool_names, tool_names, AgentIntegration, DoctorCounters, HealthcheckContext,
+    InstallContext, KiroIntegration,
+};
+
+fn make_ctx(home: &Path) -> InstallContext {
+    InstallContext {
+        home: home.to_path_buf(),
+        tokensave_bin: "/usr/local/bin/tokensave".to_string(),
+        tool_permissions: Vec::new(),
+    }
+}
+
+fn read_json(path: &Path) -> serde_json::Value {
+    serde_json::from_str(&std::fs::read_to_string(path).unwrap()).unwrap()
+}
+
+fn assert_hook(
+    agent: &serde_json::Value,
+    event: &str,
+    matcher: Option<&str>,
+    subcommand: &str,
+    timeout_ms: u64,
+) {
+    let hooks = agent["hooks"][event].as_array().unwrap();
+    let hook = hooks
+        .iter()
+        .find(|hook| {
+            let matcher_matches = match matcher {
+                Some(expected) => hook["matcher"].as_str() == Some(expected),
+                None => hook.get("matcher").is_none(),
+            };
+            matcher_matches
+                && hook["command"]
+                    .as_str()
+                    .is_some_and(|command| command.contains(subcommand))
+        })
+        .unwrap_or_else(|| panic!("missing hook {event} {matcher:?} {subcommand}"));
+    assert_eq!(hook["timeout_ms"].as_u64(), Some(timeout_ms));
+}
+
+#[test]
+fn test_install_creates_global_mcp_steering_agent_and_default() {
+    let dir = TempDir::new().unwrap();
+    let home = dir.path();
+    let ctx = make_ctx(home);
+
+    KiroIntegration.install(&ctx).unwrap();
+
+    let mcp_path = home.join(".kiro/settings/mcp.json");
+    assert!(mcp_path.exists(), "global Kiro MCP config should exist");
+    let mcp = read_json(&mcp_path);
+    let server = &mcp["mcpServers"]["tokensave"];
+    assert!(server.is_object(), "mcpServers.tokensave should exist");
+    assert_eq!(server["command"].as_str(), Some("/usr/local/bin/tokensave"));
+    assert_eq!(
+        server["args"].as_array().unwrap(),
+        &[serde_json::json!("serve")]
+    );
+    assert_eq!(server["disabled"], serde_json::json!(false));
+
+    let auto_approve = server["autoApprove"].as_array().unwrap();
+    assert!(
+        !auto_approve.iter().any(|v| v.as_str() == Some("*")),
+        "autoApprove should not broadly allow every tokensave tool"
+    );
+    for tool in read_only_tool_names() {
+        assert!(
+            auto_approve
+                .iter()
+                .any(|v| v.as_str() == Some(tool.as_str())),
+            "autoApprove should include {tool}"
+        );
+    }
+    for tool in mutating_tool_names() {
+        assert!(
+            !auto_approve
+                .iter()
+                .any(|v| v.as_str() == Some(tool.as_str())),
+            "autoApprove should not include mutating tool {tool}"
+        );
+    }
+
+    let steering_path = home.join(".kiro/steering/AGENTS.md");
+    assert!(steering_path.exists(), "global Kiro AGENTS.md should exist");
+    let steering = std::fs::read_to_string(&steering_path).unwrap();
+    assert!(steering.contains("## Prefer tokensave MCP tools"));
+    assert!(steering.contains("delegate"));
+
+    let agent_path = home.join(".kiro/agents/tokensave.json");
+    assert!(agent_path.exists(), "managed Kiro agent should exist");
+    let agent = read_json(&agent_path);
+    assert_eq!(agent["name"].as_str(), Some("tokensave"));
+    assert_eq!(agent["includeMcpJson"].as_bool(), Some(true));
+    assert_eq!(
+        agent["prompt"].as_str(),
+        Some("file://../steering/AGENTS.md")
+    );
+    assert_eq!(
+        agent["tools"].as_array().unwrap(),
+        &[serde_json::json!("*")]
+    );
+    assert_hook(
+        &agent,
+        "userPromptSubmit",
+        None,
+        "hook-kiro-prompt-submit",
+        5_000,
+    );
+    assert_hook(
+        &agent,
+        "preToolUse",
+        Some("delegate"),
+        "hook-kiro-pre-tool-use",
+        5_000,
+    );
+    assert_hook(
+        &agent,
+        "preToolUse",
+        Some("subagent"),
+        "hook-kiro-pre-tool-use",
+        5_000,
+    );
+    assert_hook(
+        &agent,
+        "postToolUse",
+        Some("fs_write"),
+        "hook-kiro-post-tool-use",
+        30_000,
+    );
+
+    let cli_path = home.join(".kiro/settings/cli.json");
+    assert!(cli_path.exists(), "Kiro CLI settings should exist");
+    let cli = read_json(&cli_path);
+    assert_eq!(cli["chat"]["defaultAgent"].as_str(), Some("tokensave"));
+}
+
+#[test]
+fn test_install_preserves_existing_mcp_config_and_writes_backup() {
+    let dir = TempDir::new().unwrap();
+    let home = dir.path();
+    let mcp_path = home.join(".kiro/settings/mcp.json");
+    std::fs::create_dir_all(mcp_path.parent().unwrap()).unwrap();
+    std::fs::write(
+        &mcp_path,
+        r#"{"mcpServers":{"other":{"command":"other-bin"}},"theme":"dark"}"#,
+    )
+    .unwrap();
+
+    let ctx = make_ctx(home);
+    KiroIntegration.install(&ctx).unwrap();
+
+    let mcp = read_json(&mcp_path);
+    assert!(mcp["mcpServers"]["tokensave"].is_object());
+    assert!(mcp["mcpServers"]["other"].is_object());
+    assert_eq!(mcp["theme"].as_str(), Some("dark"));
+    assert!(
+        home.join(".kiro/settings/mcp.json.bak").exists(),
+        "install should preserve a backup before rewriting existing config"
+    );
+}
+
+#[test]
+fn test_install_and_uninstall_preserve_existing_steering_content() {
+    let dir = TempDir::new().unwrap();
+    let home = dir.path();
+    let ctx = make_ctx(home);
+
+    let steering_path = home.join(".kiro/steering/AGENTS.md");
+    std::fs::create_dir_all(steering_path.parent().unwrap()).unwrap();
+    std::fs::write(
+        &steering_path,
+        "## Existing Kiro guidance\n\nKeep this user-authored guidance.\n",
+    )
+    .unwrap();
+
+    KiroIntegration.install(&ctx).unwrap();
+
+    let installed = std::fs::read_to_string(&steering_path).unwrap();
+    assert!(installed.contains("## Existing Kiro guidance"));
+    assert!(installed.contains("Keep this user-authored guidance."));
+    assert!(installed.contains("## Prefer tokensave MCP tools"));
+
+    KiroIntegration.uninstall(&ctx).unwrap();
+
+    let uninstalled = std::fs::read_to_string(&steering_path).unwrap();
+    assert!(uninstalled.contains("## Existing Kiro guidance"));
+    assert!(uninstalled.contains("Keep this user-authored guidance."));
+    assert!(!uninstalled.contains("## Prefer tokensave MCP tools"));
+}
+
+#[test]
+fn test_uninstall_preserves_user_steering_after_tokensave_block() {
+    let dir = TempDir::new().unwrap();
+    let home = dir.path();
+    let ctx = make_ctx(home);
+
+    KiroIntegration.install(&ctx).unwrap();
+
+    let steering_path = home.join(".kiro/steering/AGENTS.md");
+    std::fs::OpenOptions::new()
+        .append(true)
+        .open(&steering_path)
+        .unwrap()
+        .write_all(b"\nUser guidance appended after setup without a new heading.\n")
+        .unwrap();
+
+    KiroIntegration.uninstall(&ctx).unwrap();
+
+    let uninstalled = std::fs::read_to_string(&steering_path).unwrap();
+    assert!(uninstalled.contains("User guidance appended after setup without a new heading."));
+    assert!(!uninstalled.contains("## Prefer tokensave MCP tools"));
+}
+
+#[test]
+fn test_uninstall_leaves_edited_legacy_steering_without_end_marker() {
+    let dir = TempDir::new().unwrap();
+    let home = dir.path();
+    let ctx = make_ctx(home);
+
+    let steering_path = home.join(".kiro/steering/AGENTS.md");
+    std::fs::create_dir_all(steering_path.parent().unwrap()).unwrap();
+    std::fs::write(
+        &steering_path,
+        "## Prefer tokensave MCP tools\n\nLegacy tokensave guidance edited by the user.\n\
+User guidance under the same heading.\n",
+    )
+    .unwrap();
+
+    KiroIntegration.uninstall(&ctx).unwrap();
+
+    let uninstalled = std::fs::read_to_string(&steering_path).unwrap();
+    assert!(uninstalled.contains("Legacy tokensave guidance edited by the user."));
+    assert!(uninstalled.contains("User guidance under the same heading."));
+}
+
+#[test]
+fn test_uninstall_removes_tokensave_and_preserves_other_mcp_servers() {
+    let dir = TempDir::new().unwrap();
+    let home = dir.path();
+    let ctx = make_ctx(home);
+
+    let mcp_path = home.join(".kiro/settings/mcp.json");
+    std::fs::create_dir_all(mcp_path.parent().unwrap()).unwrap();
+    std::fs::write(
+        &mcp_path,
+        r#"{"mcpServers":{"other":{"command":"other-bin"}},"theme":"dark"}"#,
+    )
+    .unwrap();
+
+    KiroIntegration.install(&ctx).unwrap();
+    KiroIntegration.uninstall(&ctx).unwrap();
+
+    let mcp = read_json(&mcp_path);
+    assert!(mcp["mcpServers"]["other"].is_object());
+    assert!(mcp["mcpServers"].get("tokensave").is_none());
+    assert_eq!(mcp["theme"].as_str(), Some("dark"));
+
+    assert!(!home.join(".kiro/agents/tokensave.json").exists());
+    let cli = std::fs::read_to_string(home.join(".kiro/settings/cli.json")).unwrap_or_default();
+    assert!(
+        !cli.contains("defaultAgent"),
+        "uninstall should remove tokensave default agent"
+    );
+    let steering =
+        std::fs::read_to_string(home.join(".kiro/steering/AGENTS.md")).unwrap_or_default();
+    assert!(!steering.contains("## Prefer tokensave MCP tools"));
+}
+
+#[test]
+fn test_install_and_uninstall_preserve_user_managed_custom_agent() {
+    let dir = TempDir::new().unwrap();
+    let home = dir.path();
+    let ctx = make_ctx(home);
+
+    let agent_path = home.join(".kiro/agents/tokensave.json");
+    std::fs::create_dir_all(agent_path.parent().unwrap()).unwrap();
+    let custom_agent = serde_json::json!({
+        "name": "tokensave",
+        "description": "User-managed custom agent",
+        "includeMcpJson": true,
+        "hooks": {
+            "preToolUse": [
+                {
+                    "matcher": "delegate",
+                    "command": "echo user-managed hook"
+                }
+            ]
+        }
+    });
+    std::fs::write(
+        &agent_path,
+        serde_json::to_string_pretty(&custom_agent).unwrap(),
+    )
+    .unwrap();
+
+    KiroIntegration.install(&ctx).unwrap();
+    assert_eq!(read_json(&agent_path), custom_agent);
+    assert!(
+        !home.join(".kiro/settings/cli.json").exists(),
+        "install should not point defaultAgent at a user-managed tokensave agent"
+    );
+
+    KiroIntegration.uninstall(&ctx).unwrap();
+    assert_eq!(read_json(&agent_path), custom_agent);
+}
+
+#[test]
+fn test_install_preserves_existing_custom_default_agent_choice() {
+    let dir = TempDir::new().unwrap();
+    let home = dir.path();
+    let ctx = make_ctx(home);
+
+    let cli_path = home.join(".kiro/settings/cli.json");
+    std::fs::create_dir_all(cli_path.parent().unwrap()).unwrap();
+    std::fs::write(
+        &cli_path,
+        r#"{"chat":{"defaultAgent":"my-team-agent"},"telemetry":{"enabled":false}}"#,
+    )
+    .unwrap();
+
+    KiroIntegration.install(&ctx).unwrap();
+
+    let cli = read_json(&cli_path);
+    assert_eq!(cli["chat"]["defaultAgent"].as_str(), Some("my-team-agent"));
+    assert_eq!(cli["telemetry"]["enabled"].as_bool(), Some(false));
+    assert!(home.join(".kiro/agents/tokensave.json").exists());
+}
+
+#[test]
+fn test_install_replaces_builtin_default_agent_choice() {
+    let dir = TempDir::new().unwrap();
+    let home = dir.path();
+    let ctx = make_ctx(home);
+
+    let cli_path = home.join(".kiro/settings/cli.json");
+    std::fs::create_dir_all(cli_path.parent().unwrap()).unwrap();
+    std::fs::write(&cli_path, r#"{"chat":{"defaultAgent":"kiro_default"}}"#).unwrap();
+
+    KiroIntegration.install(&ctx).unwrap();
+
+    let cli = read_json(&cli_path);
+    assert_eq!(cli["chat"]["defaultAgent"].as_str(), Some("tokensave"));
+}
+
+#[test]
+fn test_has_tokensave_tracks_global_mcp_entry() {
+    let dir = TempDir::new().unwrap();
+    let home = dir.path();
+    let ctx = make_ctx(home);
+
+    assert!(!KiroIntegration.has_tokensave(home));
+
+    KiroIntegration.install(&ctx).unwrap();
+    assert!(KiroIntegration.has_tokensave(home));
+
+    KiroIntegration.uninstall(&ctx).unwrap();
+    assert!(!KiroIntegration.has_tokensave(home));
+}
+
+#[test]
+fn test_healthcheck_clean_install_has_no_issues_or_warnings() {
+    let dir = TempDir::new().unwrap();
+    let home = dir.path();
+    let ctx = make_ctx(home);
+
+    KiroIntegration.install(&ctx).unwrap();
+
+    let mut dc = DoctorCounters::new();
+    let hctx = HealthcheckContext {
+        home: home.to_path_buf(),
+        project_path: home.to_path_buf(),
+    };
+    KiroIntegration.healthcheck(&mut dc, &hctx);
+
+    assert_eq!(dc.issues, 0, "clean Kiro install should have no issues");
+    assert_eq!(dc.warnings, 0, "clean Kiro install should have no warnings");
+}
+
+#[test]
+fn test_healthcheck_fails_when_workspace_mcp_disables_tokensave() {
+    let home_dir = TempDir::new().unwrap();
+    let project_dir = TempDir::new().unwrap();
+    let home = home_dir.path();
+    let project = project_dir.path();
+    let ctx = make_ctx(home);
+
+    KiroIntegration.install(&ctx).unwrap();
+
+    let workspace_mcp_path = project.join(".kiro/settings/mcp.json");
+    std::fs::create_dir_all(workspace_mcp_path.parent().unwrap()).unwrap();
+    std::fs::write(
+        &workspace_mcp_path,
+        r#"{"mcpServers":{"tokensave":{"command":"/usr/local/bin/tokensave","args":["serve"],"disabled":true}}}"#,
+    )
+    .unwrap();
+
+    let mut dc = DoctorCounters::new();
+    let hctx = HealthcheckContext {
+        home: home.to_path_buf(),
+        project_path: project.to_path_buf(),
+    };
+    KiroIntegration.healthcheck(&mut dc, &hctx);
+
+    assert!(
+        dc.issues > 0,
+        "workspace Kiro MCP override that disables tokensave should be unhealthy"
+    );
+}
+
+#[test]
+fn test_healthcheck_fails_when_workspace_mcp_shadows_global_command() {
+    let home_dir = TempDir::new().unwrap();
+    let project_dir = TempDir::new().unwrap();
+    let home = home_dir.path();
+    let project = project_dir.path();
+    let ctx = make_ctx(home);
+
+    KiroIntegration.install(&ctx).unwrap();
+
+    let workspace_mcp_path = project.join(".kiro/settings/mcp.json");
+    std::fs::create_dir_all(workspace_mcp_path.parent().unwrap()).unwrap();
+    std::fs::write(
+        &workspace_mcp_path,
+        r#"{"mcpServers":{"tokensave":{"command":"other-tokensave","args":["serve"],"disabled":false}}}"#,
+    )
+    .unwrap();
+
+    let mut dc = DoctorCounters::new();
+    let hctx = HealthcheckContext {
+        home: home.to_path_buf(),
+        project_path: project.to_path_buf(),
+    };
+    KiroIntegration.healthcheck(&mut dc, &hctx);
+
+    assert!(
+        dc.issues > 0,
+        "workspace Kiro MCP override with a different command should be unhealthy"
+    );
+}
+
+fn mutating_tool_names() -> Vec<String> {
+    let read_only: std::collections::HashSet<String> = read_only_tool_names().into_iter().collect();
+    tool_names()
+        .into_iter()
+        .filter(|name| !read_only.contains(name))
+        .collect()
+}


### PR DESCRIPTION
## Summary
- add first-class Kiro install, uninstall, and doctor support
- install Kiro MCP config, global steering, managed agent settings, default CLI agent selection, and hook mappings
- add Kiro-specific hook commands for prompt context, delegated tool context, and post-write re-indexing
- document the Kiro integration and update user-facing agent docs
- add focused Kiro integration tests and update agent/hook coverage

## Notes
- Targets `master` as a stable feature.
- Includes an `[Unreleased]` `CHANGELOG.md` entry per `CONTRIBUTING.md`.

## Verification
- `cargo fmt --all -- --check`
- `cargo test`
- `cargo clippy`
- Kiro install/uninstall smoke tests with temporary `HOME`
