### PR TITLE
fix: make edit prefixes UTF-8 safe

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 - **Kiro agent integration.** `tokensave install --agent kiro` now installs the MCP server, global steering, managed Kiro agent config, default CLI agent selection, and Kiro hook mappings for prompt context, delegated tool context, and post-write re-indexing. Doctor and uninstall support are included with coverage for workspace overrides and idempotent cleanup.
 
+### Fixed
+- **Edit tool UTF-8 failure handling.** `tokensave_multi_str_replace` and `tokensave_insert_at` no longer panic when failure previews or long anchors contain multi-byte UTF-8 characters.
+
 ## [5.1.1] - 2026-05-16
 
 ### Performance

--- a/src/tokensave.rs
+++ b/src/tokensave.rs
@@ -1469,6 +1469,19 @@ impl TokenSave {
         Ok(())
     }
 
+    fn utf8_prefix_at_or_before(s: &str, max_bytes: usize) -> &str {
+        // Preserve byte budgets while avoiding invalid UTF-8 slice boundaries.
+        if s.len() <= max_bytes {
+            return s;
+        }
+
+        let mut end = max_bytes;
+        while !s.is_char_boundary(end) && end > 0 {
+            end -= 1;
+        }
+        &s[..end]
+    }
+
     /// Performs a single string replacement.
     /// Fails if `old_str` is not found or matches more than once.
     pub async fn str_replace(
@@ -1557,7 +1570,7 @@ impl TokenSave {
                     applied_count: 0,
                     message: format!(
                         "replacement '{}' matches {} times, must match exactly once",
-                        if old.len() > 20 { &old[..20] } else { old },
+                        Self::utf8_prefix_at_or_before(old, 20),
                         count
                     ),
                 });
@@ -1626,10 +1639,11 @@ impl TokenSave {
             }
             line_num - 1
         } else {
+            let anchor_prefix = Self::utf8_prefix_at_or_before(anchor, 100);
             let matching_lines: Vec<usize> = lines
                 .iter()
                 .enumerate()
-                .filter(|(_, line)| line.contains(&anchor[..anchor.len().min(100)]))
+                .filter(|(_, line)| line.contains(anchor_prefix))
                 .map(|(i, _)| i)
                 .collect();
 

--- a/tests/mcp_handler_test.rs
+++ b/tests/mcp_handler_test.rs
@@ -1787,6 +1787,45 @@ async fn test_multi_str_replace_atomic_failure() {
 }
 
 #[tokio::test]
+async fn test_multi_str_replace_unicode_preview_does_not_panic() {
+    let dir = TempDir::new().unwrap();
+    let project = dir.path();
+    fs::create_dir_all(project.join("src")).unwrap();
+
+    let original = "fn main() {}\n";
+    fs::write(project.join("src/main.rs"), original).unwrap();
+
+    let cg = TokenSave::init(project).await.unwrap();
+    cg.index_all().await.unwrap();
+
+    let missing_old = format!("{}é", "a".repeat(19));
+    let result = handle_tool_call(
+        &cg,
+        "tokensave_multi_str_replace",
+        json!({
+            "path": "src/main.rs",
+            "replacements": [
+                [missing_old, "replacement"]
+            ]
+        }),
+        None,
+        None,
+    )
+    .await
+    .unwrap();
+
+    let text = extract_text(&result.value);
+    let parsed: serde_json::Value = serde_json::from_str(text).unwrap();
+    assert_eq!(parsed["success"], false);
+    let message = parsed["message"].as_str().unwrap();
+    assert!(message.contains("matches 0 times"));
+    assert!(message.contains("must match exactly once"));
+
+    let content = fs::read_to_string(project.join("src/main.rs")).unwrap();
+    assert_eq!(content, original);
+}
+
+#[tokio::test]
 async fn test_str_replace_unsupported_file_type_succeeds() {
     // Regression: editing unsupported types (e.g. .css) previously wrote the
     // file then returned a reindex error, silently mutating the file.
@@ -2139,6 +2178,43 @@ async fn test_insert_at_anchor_not_found() {
     let parsed: serde_json::Value = serde_json::from_str(text).unwrap();
     assert_eq!(parsed["success"], false);
     assert!(parsed["message"].as_str().unwrap().contains("not found"));
+}
+
+#[tokio::test]
+async fn test_insert_at_unicode_anchor_prefix_does_not_panic() {
+    let dir = TempDir::new().unwrap();
+    let project = dir.path();
+    fs::create_dir_all(project.join("src")).unwrap();
+
+    let original = "line one\nline two\n";
+    fs::write(project.join("src/main.rs"), original).unwrap();
+
+    let cg = TokenSave::init(project).await.unwrap();
+    cg.index_all().await.unwrap();
+
+    let long_anchor = format!("{}é", "a".repeat(99));
+    let result = handle_tool_call(
+        &cg,
+        "tokensave_insert_at",
+        json!({
+            "path": "src/main.rs",
+            "anchor": long_anchor,
+            "content": "should not be inserted",
+            "before": true
+        }),
+        None,
+        None,
+    )
+    .await
+    .unwrap();
+
+    let text = extract_text(&result.value);
+    let parsed: serde_json::Value = serde_json::from_str(text).unwrap();
+    assert_eq!(parsed["success"], false);
+    assert!(parsed["message"].as_str().unwrap().contains("not found"));
+
+    let content = fs::read_to_string(project.join("src/main.rs")).unwrap();
+    assert_eq!(content, original);
 }
 
 #[tokio::test]


### PR DESCRIPTION
## Summary

- Add a private UTF-8-safe byte-budgeted prefix helper for edit tool previews and anchor matching.
- Use it in multi-replace failure messages and long string-anchor searches.
- Add MCP regression coverage for non-ASCII failed edit inputs and update the changelog.

## Motivation

Failed edit requests should return structured failure responses and leave files unchanged for valid UTF-8 input, instead of panicking when an internal byte limit lands inside a multi-byte character.

## Changes

- `src/tokensave.rs`: centralizes safe prefix slicing and applies it to the two edit-tool paths.
- `tests/mcp_handler_test.rs`: covers multi-replace preview and insert-at anchor regressions through the MCP handler boundary.
- `CHANGELOG.md`: notes the fix under `[Unreleased]`.

## Test plan

- [x] `cargo test --test mcp_handler_test test_multi_str_replace_unicode_preview_does_not_panic --no-default-features --features lite`
- [x] `cargo test --test mcp_handler_test test_insert_at_unicode_anchor_prefix_does_not_panic --no-default-features --features lite`
- [x] `cargo test --test mcp_handler_test --no-default-features --features lite`
- [x] `cargo fmt --all -- --check`
- [x] `cargo test --workspace`
- [x] `cargo clippy --workspace --all-targets`

## Checklist

- [x] `CHANGELOG.md` updated under `[Unreleased]`
- [x] No secrets, credentials, or `.env` files included
- [x] No breaking changes
