### PR TITLE
refactor(kiro): use resource-backed steering

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+- **Kiro steering is loaded as a resource.** The Kiro installer now writes `~/.kiro/steering/tokensave.md`, loads it from the managed agent's `resources` list with an absolute `file://` URI, leaves the custom-agent `prompt` unset so Kiro's default prompt is preserved, keeps MCP approval policy out of `mcp.json`, and installs permissive `tools: ["*"]` plus `allowedTools: ["@builtin", "@tokensave"]` defaults for the managed agent.
+
 ## [6.1.0] - 2026-05-25
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -135,7 +135,7 @@ tokensave install --agent vibe            # Mistral Vibe
 tokensave install --agent zed             # Zed
 ```
 
-Each agent gets its MCP server registered in the native config format. Claude Code additionally gets a PreToolUse hook (blocks wasteful Explore agents), a UserPromptSubmit hook, a Stop hook, prompt rules in CLAUDE.md, and auto-allowed tool permissions. Kiro gets global MCP config, read-only tokensave auto-approval, AGENTS.md steering, and a tokensave-managed default agent with delegation guardrail hooks plus post-write sync; user-managed Kiro agents are preserved.
+Each agent gets its MCP server registered in the native config format. Claude Code additionally gets a PreToolUse hook (blocks wasteful Explore agents), a UserPromptSubmit hook, a Stop hook, prompt rules in CLAUDE.md, and auto-allowed tool permissions. Kiro gets global MCP config, `tokensave.md` steering loaded as a resource, and a tokensave-managed default agent with permissive built-in/tokensave tool approval, delegation guardrail hooks, and post-write sync; user-managed Kiro agents are preserved.
 
 All changes are idempotent -- safe to run again after upgrading. After agent setup, you'll be offered a global git post-commit hook.
 
@@ -779,7 +779,7 @@ tokensave works at the symbol level: functions, structs, fields, call edges, typ
 
 ### Broadest agent support
 
-14 AI coding agent integrations with per-agent native configuration formats. No other tool covers as many agents with as deep an integration. Claude Code gets hooks, prompt rules, and auto-allowed tool permissions. Kiro gets global MCP config, read-only tokensave auto-approval, AGENTS.md steering, a managed agent, and hooks for delegation guardrails plus post-write sync. Other agents get MCP server registration in their native config format.
+14 AI coding agent integrations with per-agent native configuration formats. No other tool covers as many agents with as deep an integration. Claude Code gets hooks, prompt rules, and auto-allowed tool permissions. Kiro gets global MCP config, `tokensave.md` steering loaded as a resource, a managed agent with permissive built-in/tokensave tool approval, and hooks for delegation guardrails plus post-write sync. Other agents get MCP server registration in their native config format.
 
 ### Multi-branch indexing
 

--- a/docs/KIRO-INTEGRATION.md
+++ b/docs/KIRO-INTEGRATION.md
@@ -14,9 +14,9 @@ so does not overwrite a user's existing custom default-agent choice.
 
 | File | Purpose |
 |---|---|
-| `~/.kiro/settings/mcp.json` | Registers the global `tokensave` MCP server with `command`, `args: ["serve"]`, `disabled: false`, and `autoApprove` for read-only `tokensave_*` tools. |
-| `~/.kiro/steering/AGENTS.md` | Adds a bounded global Kiro steering block that tells normal Kiro sessions to prefer tokensave MCP tools for codebase research. |
-| `~/.kiro/agents/tokensave.json` | Adds the tokensave-managed Kiro agent with hooks for delegation guardrails and post-write sync. |
+| `~/.kiro/settings/mcp.json` | Registers the global `tokensave` MCP server with `command`, `args: ["serve"]`, and `disabled: false`. Approval policy is left to the managed Kiro agent. |
+| `~/.kiro/steering/tokensave.md` | Adds global Kiro steering that tells normal Kiro sessions to prefer tokensave MCP tools for codebase research. |
+| `~/.kiro/agents/tokensave.json` | Adds the tokensave-managed Kiro agent with `tools: ["*"]`, `allowedTools: ["@builtin", "@tokensave"]`, hooks for delegation guardrails, post-write sync, and an absolute `resources` entry for `~/.kiro/steering/tokensave.md`. The agent leaves `prompt` unset so Kiro's default prompt is used. |
 | `~/.kiro/settings/cli.json` | Sets `chat.defaultAgent` to `tokensave` when the setting is absent or still points at Kiro's built-in default. |
 
 If a user already has `~/.kiro/agents/tokensave.json` and it is not the file
@@ -25,33 +25,34 @@ tokensave also does not point `chat.defaultAgent` at that user-managed file.
 If `chat.defaultAgent` already names another custom agent, install leaves that
 choice unchanged and prints a warning.
 
-Uninstall removes only the steering block bounded by tokensave's installed
-marker, the global MCP server entry, the tokensave-owned agent file, and
-`chat.defaultAgent` when it points at that owned agent. User-authored steering
-after the installed block remains in place.
+Uninstall removes only the `tokensave.md` steering block, the global MCP server entry,
+the tokensave-owned agent file, and `chat.defaultAgent` when it points at that
+owned agent. User-authored steering after the installed block remains in place.
 
 ## Tool approval defaults
 
-Kiro supports MCP-level `autoApprove`. The installed default uses it only for
-tools whose MCP annotation sets `readOnlyHint: true`.
+The tokensave-owned Kiro agent is intentionally permissive:
 
-Read-only graph, search, health, branch, body, and session-recall tools run
-without a prompt. Tools that can mutate files or local tokensave state remain
-available, but Kiro asks before using them. Today that means these tools are
-not auto-approved:
+```json
+{
+  "tools": ["*"],
+  "allowedTools": [
+    "@builtin",
+    "@tokensave"
+  ]
+}
+```
 
-- `tokensave_str_replace`
-- `tokensave_multi_str_replace`
-- `tokensave_insert_at`
-- `tokensave_ast_grep_rewrite`
-- `tokensave_session_start`
-- `tokensave_session_end`
-- `tokensave_record_decision`
-- `tokensave_record_code_area`
+`tools: ["*"]` keeps Kiro's built-in tools and configured MCP tools available.
+`allowedTools` pre-approves Kiro's built-in tools and all tools served by the
+`tokensave` MCP server, including mutating tokensave tools. This makes the
+managed agent useful as a working example users can copy into their own Kiro
+agents.
 
-This is intentionally more conservative than Claude Code's permission model.
-Kiro's MCP security model supports auto-approval, but default setup should only
-pre-approve frequent, read-only, limited-scope tools.
+The global `~/.kiro/settings/mcp.json` entry does not set MCP-level
+`autoApprove`. Ordinary Kiro sessions or other agents that only inherit the
+global MCP server keep Kiro's normal approval prompts unless users deliberately
+merge the managed agent's `allowedTools` policy.
 
 ## Workspace overrides
 
@@ -61,9 +62,7 @@ workspace `mcpServers.tokensave` entry takes precedence over the global
 
 `tokensave doctor --agent kiro` checks the current workspace for that override.
 It reports a problem when the workspace entry disables tokensave, omits the
-`serve` argument, or points at a different command than the global install. It
-also warns when the workspace entry shadows the global read-only `autoApprove`
-defaults.
+`serve` argument, or points at a different command than the global install.
 
 ## Default-agent judgement call
 
@@ -75,26 +74,33 @@ The install is intentionally conservative:
 - `~/.kiro/agents/tokensave.json` exists but is user-managed: leave it unchanged
   and do not select it as the default.
 
-Users can still select the tokensave agent manually later, or copy the hook
-mapping into their own agent configuration.
+Users can still select the tokensave agent manually later, or copy the hook and
+tool-policy mapping into their own agent configuration.
 
 ## Custom agents after setup
 
 Users can still create their own Kiro custom agents after running the default
-tokensave setup. Those agents can inherit the global MCP server by setting:
+tokensave setup. Those agents can inherit the global MCP server and the same
+permissive tool policy by merging:
 
 ```json
 {
-  "includeMcpJson": true
+  "includeMcpJson": true,
+  "tools": ["*"],
+  "allowedTools": [
+    "@builtin",
+    "@tokensave"
+  ]
 }
 ```
 
-For a global custom agent under `~/.kiro/agents/`, the installed steering file
-can also be referenced instead of copied:
+For a custom agent, the installed steering file can also be referenced instead
+of copied. Use an absolute resource URI for the global steering file so it does
+not resolve relative to the current project directory:
 
 ```json
 {
-  "prompt": "file://../steering/AGENTS.md"
+  "resources": ["file:///Users/<you>/.kiro/steering/tokensave.md"]
 }
 ```
 
@@ -127,10 +133,11 @@ independent implementation tasks.
 
 ## Deliberate non-defaults
 
-No `execute_bash`, `fs_write` pre-approval, shell post-hook, or `stop` hook is
-installed. Shell commands are too broad for default sync triggering, and Kiro's
-stop event should not be used for Claude-style accounting until Kiro's persisted
-session format is verified.
+No shell post-hook or `stop` hook is installed. The managed agent's tool
+approval policy is permissive, but default hook execution is still scoped to the
+known tokensave guardrail and sync events. Shell commands are too broad for
+default sync triggering, and Kiro's stop event should not be used for
+Claude-style accounting until Kiro's persisted session format is verified.
 
 Kiro-specific session accounting is also held back. Claude's stop hook parses
 Claude session transcripts; Kiro does not share that transcript format, so

--- a/docs/USER-GUIDE.md
+++ b/docs/USER-GUIDE.md
@@ -202,12 +202,14 @@ tokensave install --agent vibe        # Mistral Vibe
 
 Each agent gets an appropriate configuration: MCP server registration, tool permissions (where the agent supports them), and prompt rules in the agent's instruction file.
 
-Kiro setup registers tokensave in `~/.kiro/settings/mcp.json`, adds steering in
-`~/.kiro/steering/AGENTS.md`, and writes a tokensave-managed agent with hooks
-that block research delegation until tokensave MCP tools have been tried and
-sync the index after Kiro writes files. If you already have a different custom
-default agent or a user-managed `tokensave` agent, tokensave leaves it alone and
-prints a warning.
+Kiro setup registers tokensave in `~/.kiro/settings/mcp.json`, writes steering to
+`~/.kiro/steering/tokensave.md`, and writes a tokensave-managed agent that loads
+that steering as a resource while keeping Kiro's default prompt. The managed
+agent exposes all configured tools and pre-approves Kiro built-ins plus the
+tokensave MCP server, then adds hooks that block research delegation until
+tokensave MCP tools have been tried and sync the index after Kiro writes files.
+If you already have a different custom default agent or a user-managed
+`tokensave` agent, tokensave leaves it alone and prints a warning.
 
 The install is idempotent — safe to run again after upgrading tokensave. You'll also be offered the option to set up a global git post-commit hook (more on that below).
 

--- a/src/agents/kiro.rs
+++ b/src/agents/kiro.rs
@@ -1,8 +1,8 @@
 //! AWS Kiro agent integration.
 //!
 //! Handles registration of the tokensave MCP server in Kiro's shared global
-//! MCP config (`~/.kiro/settings/mcp.json`), adds global AGENTS.md steering
-//! (`~/.kiro/steering/AGENTS.md`), and installs a tokensave-managed Kiro
+//! MCP config (`~/.kiro/settings/mcp.json`), adds global tokensave steering
+//! (`~/.kiro/steering/tokensave.md`), and installs a tokensave-managed Kiro
 //! agent selected as the default when doing so does not overwrite a user's
 //! existing default-agent choice.
 //!
@@ -20,8 +20,7 @@ use crate::errors::{Result, TokenSaveError};
 
 use super::{
     backup_and_write_json, backup_config_file, load_json_file, load_json_file_strict,
-    read_only_tool_names, safe_write_json_file, tool_names, AgentIntegration, DoctorCounters,
-    HealthcheckContext, InstallContext,
+    safe_write_json_file, AgentIntegration, DoctorCounters, HealthcheckContext, InstallContext,
 };
 
 /// Kiro agent.
@@ -32,6 +31,9 @@ const PROMPT_END_MARKER: &str = "<!-- tokensave:kiro:end -->";
 const KIRO_AGENT_NAME: &str = "tokensave";
 const OWNED_AGENT_DESCRIPTION: &str =
     "Default Kiro agent with tokensave MCP tools and code-research guardrails.";
+const KIRO_AGENT_ALL_TOOLS: &str = "*";
+const KIRO_ALLOWED_BUILTIN_TOOLS: &str = "@builtin";
+const KIRO_ALLOWED_TOKENSAVE_TOOLS: &str = "@tokensave";
 const KIRO_PRE_TOOL_HOOK: &str = "hook-kiro-pre-tool-use";
 const KIRO_PROMPT_HOOK: &str = "hook-kiro-prompt-submit";
 const KIRO_POST_TOOL_HOOK: &str = "hook-kiro-post-tool-use";
@@ -62,7 +64,7 @@ fn managed_agent_path(home: &Path) -> PathBuf {
 }
 
 fn steering_path(home: &Path) -> PathBuf {
-    kiro_home(home).join("steering/AGENTS.md")
+    kiro_home(home).join("steering/tokensave.md")
 }
 
 fn workspace_mcp_config_path(project_path: &Path) -> PathBuf {
@@ -85,10 +87,10 @@ impl AgentIntegration for KiroIntegration {
         install_mcp_server(&mcp_path, &ctx.tokensave_bin)?;
 
         let steering = steering_path(&ctx.home);
-        install_prompt_rules(&steering)?;
+        install_steering_rules(&steering)?;
 
         let agent_path = managed_agent_path(&ctx.home);
-        let owns_agent = install_managed_agent(&agent_path, &ctx.tokensave_bin)?;
+        let owns_agent = install_managed_agent(&agent_path, &ctx.tokensave_bin, &steering)?;
 
         let cli_path = cli_config_path(&ctx.home);
         install_default_agent(&cli_path, owns_agent)?;
@@ -106,7 +108,7 @@ impl AgentIntegration for KiroIntegration {
 
     fn uninstall(&self, ctx: &InstallContext) -> Result<()> {
         uninstall_mcp_server(&mcp_config_path(&ctx.home));
-        uninstall_prompt_rules(&steering_path(&ctx.home));
+        remove_steering_rules(&steering_path(&ctx.home));
         let agent_path = managed_agent_path(&ctx.home);
         let owned_agent = is_owned_agent_file(&agent_path);
         uninstall_managed_agent(&agent_path);
@@ -160,30 +162,50 @@ fn mcp_server_entry(tokensave_bin: &str) -> serde_json::Value {
     json!({
         "command": tokensave_bin,
         "args": ["serve"],
-        "disabled": false,
-        "autoApprove": read_only_tool_names()
+        "disabled": false
     })
-}
-
-fn mutating_tool_names() -> Vec<String> {
-    let read_only: std::collections::HashSet<String> = read_only_tool_names().into_iter().collect();
-    tool_names()
-        .into_iter()
-        .filter(|name| !read_only.contains(name))
-        .collect()
 }
 
 fn hook_command(tokensave_bin: &str, subcommand: &str) -> String {
     format!("{tokensave_bin} {subcommand}")
 }
 
-fn managed_agent_config(tokensave_bin: &str) -> serde_json::Value {
+fn file_resource_uri(path: &Path) -> String {
+    let path = path.to_string_lossy().replace('\\', "/");
+    let path = percent_encode_file_uri_path(&path);
+    if path.starts_with('/') {
+        format!("file://{path}")
+    } else {
+        format!("file:///{path}")
+    }
+}
+
+fn percent_encode_file_uri_path(path: &str) -> String {
+    const HEX: &[u8; 16] = b"0123456789ABCDEF";
+    let mut encoded = String::with_capacity(path.len());
+    for byte in path.bytes() {
+        match byte {
+            b'A'..=b'Z' | b'a'..=b'z' | b'0'..=b'9' | b'/' | b':' | b'-' | b'.' | b'_' | b'~' => {
+                encoded.push(byte as char);
+            }
+            _ => {
+                encoded.push('%');
+                encoded.push(HEX[(byte >> 4) as usize] as char);
+                encoded.push(HEX[(byte & 0x0F) as usize] as char);
+            }
+        }
+    }
+    encoded
+}
+
+fn managed_agent_config(tokensave_bin: &str, steering_path: &Path) -> serde_json::Value {
     json!({
         "name": KIRO_AGENT_NAME,
         "description": OWNED_AGENT_DESCRIPTION,
         "includeMcpJson": true,
-        "prompt": "file://../steering/AGENTS.md",
-        "tools": ["*"],
+        "resources": [file_resource_uri(steering_path)],
+        "tools": [KIRO_AGENT_ALL_TOOLS],
+        "allowedTools": [KIRO_ALLOWED_BUILTIN_TOOLS, KIRO_ALLOWED_TOKENSAVE_TOOLS],
         "hooks": {
             "userPromptSubmit": [
                 {
@@ -244,7 +266,7 @@ fn install_mcp_server(path: &Path, tokensave_bin: &str) -> Result<()> {
 /// Returns true when tokensave owns the resulting agent file. A pre-existing
 /// user-managed `tokensave.json` is preserved and returns false so the default
 /// agent selector is not pointed at a file whose policy tokensave does not own.
-fn install_managed_agent(path: &Path, tokensave_bin: &str) -> Result<bool> {
+fn install_managed_agent(path: &Path, tokensave_bin: &str, steering_path: &Path) -> Result<bool> {
     if path.exists() && !is_owned_agent_file(path) {
         eprintln!(
             "  {} already exists and is user-managed, leaving unchanged",
@@ -254,7 +276,7 @@ fn install_managed_agent(path: &Path, tokensave_bin: &str) -> Result<bool> {
     }
 
     let backup = backup_config_file(path)?;
-    let config = managed_agent_config(tokensave_bin);
+    let config = managed_agent_config(tokensave_bin, steering_path);
     safe_write_json_file(path, &config, backup.as_deref())?;
     eprintln!(
         "\x1b[32m✔\x1b[0m Wrote tokensave Kiro agent to {}",
@@ -349,8 +371,8 @@ fn ensure_child_object(config: &mut serde_json::Value, key: &str, path: &Path) -
     }
 }
 
-/// Append global AGENTS.md steering for default Kiro sessions.
-fn install_prompt_rules(path: &Path) -> Result<()> {
+/// Add tokensave's global steering resource for default Kiro sessions.
+fn install_steering_rules(path: &Path) -> Result<()> {
     let existing = if path.exists() {
         std::fs::read_to_string(path).unwrap_or_default()
     } else {
@@ -358,24 +380,12 @@ fn install_prompt_rules(path: &Path) -> Result<()> {
     };
     if existing.contains(PROMPT_MARKER) {
         if existing.contains(PROMPT_END_MARKER) {
-            eprintln!("  Kiro AGENTS.md already contains tokensave rules, skipping");
+            eprintln!("  Kiro steering already contains tokensave rules, skipping");
             return Ok(());
         }
-        if let Some(range) = legacy_prompt_block_range(&existing) {
-            let mut updated = existing;
-            updated.replace_range(range, &prompt_rules_text());
-            std::fs::write(path, updated).map_err(|e| TokenSaveError::Config {
-                message: format!("failed to write {}: {e}", path.display()),
-            })?;
-            eprintln!(
-                "\x1b[32m✔\x1b[0m Updated tokensave rules in {}",
-                path.display()
-            );
-        } else {
-            eprintln!(
-                "  Kiro AGENTS.md contains legacy or edited tokensave rules without an end marker, leaving unchanged"
-            );
-        }
+        eprintln!(
+            "  Kiro steering contains tokensave rules without an owned end marker, leaving unchanged"
+        );
         return Ok(());
     }
     if let Some(parent) = path.parent() {
@@ -390,7 +400,12 @@ fn install_prompt_rules(path: &Path) -> Result<()> {
         .map_err(|e| TokenSaveError::Config {
             message: format!("failed to open {}: {e}", path.display()),
         })?;
-    write!(f, "\n{}\n", prompt_rules_text()).map_err(|e| TokenSaveError::Config {
+    let separator = if existing.trim().is_empty() {
+        ""
+    } else {
+        "\n\n"
+    };
+    writeln!(f, "{}{}", separator, prompt_rules_text()).map_err(|e| TokenSaveError::Config {
         message: format!("failed to write {}: {e}", path.display()),
     })?;
     eprintln!(
@@ -466,7 +481,7 @@ fn uninstall_mcp_server(path: &Path) {
     }
 }
 
-fn uninstall_prompt_rules(path: &Path) {
+fn remove_steering_rules(path: &Path) {
     if !path.exists() {
         return;
     }
@@ -474,12 +489,12 @@ fn uninstall_prompt_rules(path: &Path) {
         return;
     };
     if !contents.contains(PROMPT_MARKER) {
-        eprintln!("  Kiro AGENTS.md does not contain tokensave rules, skipping");
+        eprintln!("  Kiro steering does not contain tokensave rules, skipping");
         return;
     }
     let Some(range) = tokensave_prompt_block_range(&contents) else {
         eprintln!(
-            "  Kiro AGENTS.md contains tokensave rules without an owned end marker; leaving unchanged"
+            "  Kiro steering contains tokensave rules without an owned end marker; leaving unchanged"
         );
         return;
     };
@@ -585,25 +600,9 @@ fn is_owned_agent_config(config: &serde_json::Value) -> bool {
 
 fn tokensave_prompt_block_range(contents: &str) -> Option<Range<usize>> {
     let start = contents.find(PROMPT_MARKER)?;
-    if let Some(end_marker) = contents[start..].find(PROMPT_END_MARKER) {
-        let end = start + end_marker + PROMPT_END_MARKER.len();
-        return Some(start..end);
-    }
-    legacy_prompt_block_range(contents)
-}
-
-fn legacy_prompt_block_range(contents: &str) -> Option<Range<usize>> {
-    let start = contents.find(PROMPT_MARKER)?;
-    let after_marker = start + PROMPT_MARKER.len();
-    let end = contents[after_marker..]
-        .find("\n## ")
-        .map_or(contents.len(), |pos| after_marker + pos);
-    let candidate = &contents[start..end];
-    if candidate.trim() == prompt_rules_text_without_end_marker() {
-        Some(start..end)
-    } else {
-        None
-    }
+    let end_marker = contents[start..].find(PROMPT_END_MARKER)?;
+    let end = start + end_marker + PROMPT_END_MARKER.len();
+    Some(start..end)
 }
 
 // ---------------------------------------------------------------------------
@@ -657,48 +656,6 @@ fn doctor_check_mcp_config(dc: &mut DoctorCounters, home: &Path) -> Option<serde
         dc.fail("MCP server is disabled -- run `tokensave install --agent kiro`");
     } else {
         dc.pass("MCP server is enabled");
-    }
-
-    let expected = read_only_tool_names();
-    let approved_count = server
-        .get("autoApprove")
-        .and_then(|v| v.as_array())
-        .map_or(0, |arr| {
-            expected
-                .iter()
-                .filter(|name| arr.iter().any(|v| v.as_str() == Some(name.as_str())))
-                .count()
-        });
-    if approved_count >= expected.len() {
-        dc.pass(&format!(
-            "All {} read-only tokensave tools auto-approved",
-            expected.len()
-        ));
-    } else {
-        dc.warn(&format!(
-            "{approved_count}/{} read-only tokensave tools auto-approved -- run `tokensave install --agent kiro` to update",
-            expected.len()
-        ));
-    }
-
-    let auto_approve = server.get("autoApprove").and_then(|v| v.as_array());
-    if let Some(auto_approve) = auto_approve {
-        let has_broad = auto_approve.iter().any(|v| v.as_str() == Some("*"));
-        let mutating_approved: Vec<String> = mutating_tool_names()
-            .into_iter()
-            .filter(|name| {
-                auto_approve
-                    .iter()
-                    .any(|v| v.as_str() == Some(name.as_str()))
-            })
-            .collect();
-        if has_broad || !mutating_approved.is_empty() {
-            dc.warn(
-                "Kiro MCP autoApprove includes mutating tokensave tools -- run `tokensave install --agent kiro` to restore read-only defaults",
-            );
-        } else {
-            dc.pass("Kiro MCP autoApprove excludes mutating tokensave tools");
-        }
     }
 
     Some(server_value.clone())
@@ -770,37 +727,6 @@ fn doctor_check_workspace_mcp_override(
         }
     }
 
-    let expected = read_only_tool_names();
-    let approved_count = server
-        .get("autoApprove")
-        .and_then(|v| v.as_array())
-        .map_or(0, |arr| {
-            expected
-                .iter()
-                .filter(|name| arr.iter().any(|v| v.as_str() == Some(name.as_str())))
-                .count()
-        });
-    if approved_count < expected.len() {
-        dc.warn(&format!(
-            "Workspace Kiro MCP tokensave entry auto-approves {approved_count}/{} read-only tools and shadows the global install",
-            expected.len()
-        ));
-    }
-
-    if let Some(auto_approve) = server.get("autoApprove").and_then(|v| v.as_array()) {
-        let has_broad = auto_approve.iter().any(|v| v.as_str() == Some("*"));
-        let mutating_approved = mutating_tool_names().into_iter().any(|name| {
-            auto_approve
-                .iter()
-                .any(|v| v.as_str() == Some(name.as_str()))
-        });
-        if has_broad || mutating_approved {
-            dc.warn(
-                "Workspace Kiro MCP tokensave entry auto-approves mutating tools and shadows the global install",
-            );
-        }
-    }
-
     if compatible {
         dc.pass(&format!(
             "Workspace Kiro MCP tokensave override in {} is compatible",
@@ -812,18 +738,20 @@ fn doctor_check_workspace_mcp_override(
 fn doctor_check_steering(dc: &mut DoctorCounters, home: &Path) {
     let path = steering_path(home);
     if !path.exists() {
-        dc.warn("~/.kiro/steering/AGENTS.md does not exist");
+        dc.warn("~/.kiro/steering/tokensave.md does not exist");
         return;
     }
-    let has_rules = std::fs::read_to_string(&path)
-        .unwrap_or_default()
-        .contains(PROMPT_MARKER);
-    if has_rules {
-        dc.pass("Kiro global AGENTS.md contains tokensave rules");
-    } else {
+    let contents = std::fs::read_to_string(&path).unwrap_or_default();
+    if !contents.contains(PROMPT_MARKER) {
         dc.fail(
-            "Kiro global AGENTS.md missing tokensave rules -- run `tokensave install --agent kiro`",
+            "Kiro global tokensave.md missing tokensave rules -- run `tokensave install --agent kiro`",
         );
+    } else if tokensave_prompt_block_range(&contents).is_none() {
+        dc.fail(
+            "Kiro global tokensave.md contains tokensave rules without an owned end marker -- remove the stale block and run `tokensave install --agent kiro`",
+        );
+    } else {
+        dc.pass("Kiro global tokensave.md contains tokensave rules");
     }
 }
 
@@ -858,23 +786,22 @@ fn doctor_check_managed_agent(dc: &mut DoctorCounters, home: &Path) {
         dc.fail("Kiro tokensave agent missing includeMcpJson=true -- run `tokensave install --agent kiro`");
     }
 
-    if config
-        .get("tools")
-        .and_then(|v| v.as_array())
-        .is_some_and(|arr| arr.iter().any(|v| v.as_str() == Some("*")))
-    {
-        dc.pass("Kiro tokensave agent keeps default tool access");
-    } else {
-        dc.warn("Kiro tokensave agent tools list may not include all default Kiro tools");
-    }
+    doctor_check_agent_tools(dc, &config);
+    doctor_check_agent_allowed_tools(dc, &config);
 
-    if config.get("prompt").and_then(serde_json::Value::as_str)
-        == Some("file://../steering/AGENTS.md")
+    let expected_resource = file_resource_uri(&steering_path(home));
+    if config
+        .get("resources")
+        .and_then(|v| v.as_array())
+        .is_some_and(|arr| {
+            arr.iter()
+                .any(|v| v.as_str() == Some(expected_resource.as_str()))
+        })
     {
-        dc.pass("Kiro tokensave agent references global steering");
+        dc.pass("Kiro tokensave agent loads global steering as a resource");
     } else {
         dc.fail(
-            "Kiro tokensave agent prompt should reference global steering -- run `tokensave install --agent kiro`",
+            "Kiro tokensave agent missing global steering resource -- run `tokensave install --agent kiro`",
         );
     }
 
@@ -910,6 +837,43 @@ fn doctor_check_managed_agent(dc: &mut DoctorCounters, home: &Path) {
         KIRO_POST_TOOL_HOOK,
         KIRO_SYNC_HOOK_TIMEOUT_MS,
     );
+}
+
+fn doctor_check_agent_tools(dc: &mut DoctorCounters, config: &serde_json::Value) {
+    if json_array_contains_str(config, "tools", KIRO_AGENT_ALL_TOOLS) {
+        dc.pass("Kiro tokensave agent exposes all configured tools");
+    } else {
+        dc.warn(
+            "Kiro tokensave agent tools list is not permissive -- run `tokensave install --agent kiro`",
+        );
+    }
+}
+
+fn doctor_check_agent_allowed_tools(dc: &mut DoctorCounters, config: &serde_json::Value) {
+    let required = [KIRO_ALLOWED_BUILTIN_TOOLS, KIRO_ALLOWED_TOKENSAVE_TOOLS];
+    let missing: Vec<&str> = required
+        .iter()
+        .copied()
+        .filter(|tool| !json_array_contains_str(config, "allowedTools", tool))
+        .collect();
+
+    if missing.is_empty() {
+        dc.pass("Kiro tokensave agent pre-approves built-in and tokensave tools");
+    } else {
+        dc.warn(
+            "Kiro tokensave agent allowedTools is not permissive -- run `tokensave install --agent kiro`",
+        );
+        for tool in missing {
+            dc.info(&format!("missing allowedTools entry: {tool}"));
+        }
+    }
+}
+
+fn json_array_contains_str(config: &serde_json::Value, field: &str, expected: &str) -> bool {
+    config
+        .get(field)
+        .and_then(|v| v.as_array())
+        .is_some_and(|arr| arr.iter().any(|v| v.as_str() == Some(expected)))
 }
 
 fn doctor_check_agent_hook(

--- a/tests/kiro_agent_test.rs
+++ b/tests/kiro_agent_test.rs
@@ -3,8 +3,7 @@ use std::path::Path;
 
 use tempfile::TempDir;
 use tokensave::agents::{
-    read_only_tool_names, tool_names, AgentIntegration, DoctorCounters, HealthcheckContext,
-    InstallContext, KiroIntegration,
+    AgentIntegration, DoctorCounters, HealthcheckContext, InstallContext, KiroIntegration,
 };
 
 fn make_ctx(home: &Path) -> InstallContext {
@@ -17,6 +16,34 @@ fn make_ctx(home: &Path) -> InstallContext {
 
 fn read_json(path: &Path) -> serde_json::Value {
     serde_json::from_str(&std::fs::read_to_string(path).unwrap()).unwrap()
+}
+
+fn file_resource_uri(path: &Path) -> String {
+    let path = path.to_string_lossy().replace('\\', "/");
+    let path = percent_encode_file_uri_path(&path);
+    if path.starts_with('/') {
+        format!("file://{path}")
+    } else {
+        format!("file:///{path}")
+    }
+}
+
+fn percent_encode_file_uri_path(path: &str) -> String {
+    const HEX: &[u8; 16] = b"0123456789ABCDEF";
+    let mut encoded = String::with_capacity(path.len());
+    for byte in path.bytes() {
+        match byte {
+            b'A'..=b'Z' | b'a'..=b'z' | b'0'..=b'9' | b'/' | b':' | b'-' | b'.' | b'_' | b'~' => {
+                encoded.push(byte as char);
+            }
+            _ => {
+                encoded.push('%');
+                encoded.push(HEX[(byte >> 4) as usize] as char);
+                encoded.push(HEX[(byte & 0x0F) as usize] as char);
+            }
+        }
+    }
+    encoded
 }
 
 fn assert_hook(
@@ -62,31 +89,16 @@ fn test_install_creates_global_mcp_steering_agent_and_default() {
         &[serde_json::json!("serve")]
     );
     assert_eq!(server["disabled"], serde_json::json!(false));
-
-    let auto_approve = server["autoApprove"].as_array().unwrap();
     assert!(
-        !auto_approve.iter().any(|v| v.as_str() == Some("*")),
-        "autoApprove should not broadly allow every tokensave tool"
+        server.get("autoApprove").is_none(),
+        "global MCP config should leave approval policy to the managed Kiro agent"
     );
-    for tool in read_only_tool_names() {
-        assert!(
-            auto_approve
-                .iter()
-                .any(|v| v.as_str() == Some(tool.as_str())),
-            "autoApprove should include {tool}"
-        );
-    }
-    for tool in mutating_tool_names() {
-        assert!(
-            !auto_approve
-                .iter()
-                .any(|v| v.as_str() == Some(tool.as_str())),
-            "autoApprove should not include mutating tool {tool}"
-        );
-    }
 
-    let steering_path = home.join(".kiro/steering/AGENTS.md");
-    assert!(steering_path.exists(), "global Kiro AGENTS.md should exist");
+    let steering_path = home.join(".kiro/steering/tokensave.md");
+    assert!(
+        steering_path.exists(),
+        "global Kiro tokensave.md should exist"
+    );
     let steering = std::fs::read_to_string(&steering_path).unwrap();
     assert!(steering.contains("## Prefer tokensave MCP tools"));
     assert!(steering.contains("delegate"));
@@ -96,13 +108,29 @@ fn test_install_creates_global_mcp_steering_agent_and_default() {
     let agent = read_json(&agent_path);
     assert_eq!(agent["name"].as_str(), Some("tokensave"));
     assert_eq!(agent["includeMcpJson"].as_bool(), Some(true));
-    assert_eq!(
-        agent["prompt"].as_str(),
-        Some("file://../steering/AGENTS.md")
+    assert!(
+        agent.get("prompt").is_none(),
+        "managed agent should leave prompt unset so Kiro's default prompt is used"
+    );
+    let steering_resource = file_resource_uri(&steering_path);
+    assert!(
+        agent["resources"]
+            .as_array()
+            .unwrap()
+            .iter()
+            .any(|v| v.as_str() == Some(steering_resource.as_str())),
+        "managed agent should load global tokensave steering as an absolute resource"
     );
     assert_eq!(
         agent["tools"].as_array().unwrap(),
         &[serde_json::json!("*")]
+    );
+    assert_eq!(
+        agent["allowedTools"].as_array().unwrap(),
+        &[
+            serde_json::json!("@builtin"),
+            serde_json::json!("@tokensave")
+        ]
     );
     assert_hook(
         &agent,
@@ -170,27 +198,32 @@ fn test_install_and_uninstall_preserve_existing_steering_content() {
     let home = dir.path();
     let ctx = make_ctx(home);
 
-    let steering_path = home.join(".kiro/steering/AGENTS.md");
-    std::fs::create_dir_all(steering_path.parent().unwrap()).unwrap();
+    let user_steering_path = home.join(".kiro/steering/team.md");
+    std::fs::create_dir_all(user_steering_path.parent().unwrap()).unwrap();
     std::fs::write(
-        &steering_path,
+        &user_steering_path,
         "## Existing Kiro guidance\n\nKeep this user-authored guidance.\n",
     )
     .unwrap();
 
     KiroIntegration.install(&ctx).unwrap();
 
-    let installed = std::fs::read_to_string(&steering_path).unwrap();
-    assert!(installed.contains("## Existing Kiro guidance"));
-    assert!(installed.contains("Keep this user-authored guidance."));
+    let user_steering = std::fs::read_to_string(&user_steering_path).unwrap();
+    assert!(user_steering.contains("## Existing Kiro guidance"));
+    assert!(user_steering.contains("Keep this user-authored guidance."));
+    assert!(!user_steering.contains("## Prefer tokensave MCP tools"));
+
+    let tokensave_steering_path = home.join(".kiro/steering/tokensave.md");
+    let installed = std::fs::read_to_string(&tokensave_steering_path).unwrap();
     assert!(installed.contains("## Prefer tokensave MCP tools"));
 
     KiroIntegration.uninstall(&ctx).unwrap();
 
-    let uninstalled = std::fs::read_to_string(&steering_path).unwrap();
+    let uninstalled = std::fs::read_to_string(&user_steering_path).unwrap();
     assert!(uninstalled.contains("## Existing Kiro guidance"));
     assert!(uninstalled.contains("Keep this user-authored guidance."));
     assert!(!uninstalled.contains("## Prefer tokensave MCP tools"));
+    assert!(!tokensave_steering_path.exists());
 }
 
 #[test]
@@ -201,7 +234,7 @@ fn test_uninstall_preserves_user_steering_after_tokensave_block() {
 
     KiroIntegration.install(&ctx).unwrap();
 
-    let steering_path = home.join(".kiro/steering/AGENTS.md");
+    let steering_path = home.join(".kiro/steering/tokensave.md");
     std::fs::OpenOptions::new()
         .append(true)
         .open(&steering_path)
@@ -214,28 +247,6 @@ fn test_uninstall_preserves_user_steering_after_tokensave_block() {
     let uninstalled = std::fs::read_to_string(&steering_path).unwrap();
     assert!(uninstalled.contains("User guidance appended after setup without a new heading."));
     assert!(!uninstalled.contains("## Prefer tokensave MCP tools"));
-}
-
-#[test]
-fn test_uninstall_leaves_edited_legacy_steering_without_end_marker() {
-    let dir = TempDir::new().unwrap();
-    let home = dir.path();
-    let ctx = make_ctx(home);
-
-    let steering_path = home.join(".kiro/steering/AGENTS.md");
-    std::fs::create_dir_all(steering_path.parent().unwrap()).unwrap();
-    std::fs::write(
-        &steering_path,
-        "## Prefer tokensave MCP tools\n\nLegacy tokensave guidance edited by the user.\n\
-User guidance under the same heading.\n",
-    )
-    .unwrap();
-
-    KiroIntegration.uninstall(&ctx).unwrap();
-
-    let uninstalled = std::fs::read_to_string(&steering_path).unwrap();
-    assert!(uninstalled.contains("Legacy tokensave guidance edited by the user."));
-    assert!(uninstalled.contains("User guidance under the same heading."));
 }
 
 #[test]
@@ -267,7 +278,7 @@ fn test_uninstall_removes_tokensave_and_preserves_other_mcp_servers() {
         "uninstall should remove tokensave default agent"
     );
     let steering =
-        std::fs::read_to_string(home.join(".kiro/steering/AGENTS.md")).unwrap_or_default();
+        std::fs::read_to_string(home.join(".kiro/steering/tokensave.md")).unwrap_or_default();
     assert!(!steering.contains("## Prefer tokensave MCP tools"));
 }
 
@@ -382,6 +393,65 @@ fn test_healthcheck_clean_install_has_no_issues_or_warnings() {
 }
 
 #[test]
+fn test_healthcheck_fails_when_steering_lacks_owned_end_marker() {
+    let dir = TempDir::new().unwrap();
+    let home = dir.path();
+    let ctx = make_ctx(home);
+
+    KiroIntegration.install(&ctx).unwrap();
+
+    let steering_path = home.join(".kiro/steering/tokensave.md");
+    std::fs::write(
+        &steering_path,
+        "## Prefer tokensave MCP tools\n\nEdited tokensave guidance without ownership marker.\n",
+    )
+    .unwrap();
+
+    let mut dc = DoctorCounters::new();
+    let hctx = HealthcheckContext {
+        home: home.to_path_buf(),
+        project_path: home.to_path_buf(),
+    };
+    KiroIntegration.healthcheck(&mut dc, &hctx);
+
+    assert!(
+        dc.issues > 0,
+        "Kiro doctor should fail when tokensave.md has tokensave rules that install/uninstall cannot own"
+    );
+}
+
+#[test]
+fn test_healthcheck_warns_when_agent_tool_policy_is_not_permissive() {
+    let dir = TempDir::new().unwrap();
+    let home = dir.path();
+    let ctx = make_ctx(home);
+
+    KiroIntegration.install(&ctx).unwrap();
+
+    let agent_path = home.join(".kiro/agents/tokensave.json");
+    let mut agent = read_json(&agent_path);
+    agent["tools"] = serde_json::json!(["@tokensave"]);
+    agent["allowedTools"] = serde_json::json!(["@builtin"]);
+    std::fs::write(&agent_path, serde_json::to_string_pretty(&agent).unwrap()).unwrap();
+
+    let mut dc = DoctorCounters::new();
+    let hctx = HealthcheckContext {
+        home: home.to_path_buf(),
+        project_path: home.to_path_buf(),
+    };
+    KiroIntegration.healthcheck(&mut dc, &hctx);
+
+    assert_eq!(
+        dc.issues, 0,
+        "Kiro doctor should treat restrictive tool policy as drift, not broken MCP setup"
+    );
+    assert!(
+        dc.warnings >= 2,
+        "Kiro doctor should warn about both tools and allowedTools drift"
+    );
+}
+
+#[test]
 fn test_healthcheck_fails_when_workspace_mcp_disables_tokensave() {
     let home_dir = TempDir::new().unwrap();
     let project_dir = TempDir::new().unwrap();
@@ -441,12 +511,4 @@ fn test_healthcheck_fails_when_workspace_mcp_shadows_global_command() {
         dc.issues > 0,
         "workspace Kiro MCP override with a different command should be unhealthy"
     );
-}
-
-fn mutating_tool_names() -> Vec<String> {
-    let read_only: std::collections::HashSet<String> = read_only_tool_names().into_iter().collect();
-    tool_names()
-        .into_iter()
-        .filter(|name| !read_only.contains(name))
-        .collect()
 }


### PR DESCRIPTION
## Summary

- Follow-up to #77 now that first-class Kiro support has shipped.
- Switch the managed tokensave Kiro agent to leave `prompt` unset and reference global steering through `~/.kiro/steering/tokensave.md` as a resource.
- Keep the global Kiro MCP config focused on server registration, with tool approval policy owned by the managed custom agent.
- Tighten install, uninstall, and doctor behavior around owned steering, user-managed agents, workspace MCP overrides, hooks, and tool policy drift.
- Update Kiro docs, README/user guide references, changelog, and focused integration tests.

## Notes

- Targets `master` as a stable follow-up to PR #77.
- Includes an `[Unreleased]` `CHANGELOG.md` entry per `CONTRIBUTING.md`.

## Verification

- `cargo fmt --check`
- `cargo test`
- `cargo clippy --workspace --all-targets`