### PR TITLE
fix(opencode): use AGENTS.md instead of OPENCODE.md for prompt rules

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+- use OpenCode correct global rules file path (`AGENTS.md` instead of `OPENCODE.md`)
 
 ## [6.1.1] - 2026-05-26
 

--- a/docs/DESIGN-DOC.md
+++ b/docs/DESIGN-DOC.md
@@ -94,7 +94,7 @@ src/
     mod.rs            Agent trait, registry, shared helpers, git hooks
     claude.rs         Claude Code: MCP in ~/.claude.json, hooks, permissions
     codex.rs          Codex CLI: MCP in ~/.codex/config.toml, AGENTS.md
-    opencode.rs       OpenCode: MCP in opencode.json, OPENCODE.md
+    opencode.rs       OpenCode: MCP in ~/.config/opencode/opencode.json, ~/.config/opencode/AGENTS.md
     gemini.rs         Gemini CLI: MCP in ~/.gemini/settings.json, GEMINI.md
 ```
 
@@ -338,7 +338,7 @@ graph TB
 
         PROMPT --> P1["Claude: ~/.claude/CLAUDE.md"]
         PROMPT --> P2["Codex: ~/.codex/AGENTS.md"]
-        PROMPT --> P3["OpenCode: OPENCODE.md"]
+        PROMPT --> P3["OpenCode: ~/.config/opencode/AGENTS.md"]
         PROMPT --> P4["Gemini: ~/.gemini/GEMINI.md"]
     end
 ```

--- a/src/agents/opencode.rs
+++ b/src/agents/opencode.rs
@@ -3,7 +3,7 @@
 //!
 //! Handles registration of the tokensave MCP server in `OpenCode`'s config
 //! file (`$HOME/.config/opencode/opencode.json` or `$XDG_CONFIG_HOME/opencode/opencode.json`),
-//! and prompt rules via `OPENCODE.md`. `OpenCode` has no hook system or
+//! and prompt rules via `$HOME/.config/opencode/AGENTS.md`. `OpenCode` has no hook system or
 //! declarative tool permissions — it uses interactive runtime approval.
 
 use std::io::Write;
@@ -101,9 +101,9 @@ fn opencode_config_path(home: &Path) -> std::path::PathBuf {
     home.join(".config/opencode/opencode.json")
 }
 
-/// Returns the path to the global OPENCODE.md prompt file.
+/// Returns the path to the global AGENTS.md prompt file.
 fn opencode_prompt_path(home: &Path) -> std::path::PathBuf {
-    let modern = home.join(".config/opencode/OPENCODE.md");
+    let modern = home.join(".config/opencode/AGENTS.md");
     if modern.exists() || home.join(".config/opencode").exists() {
         return modern;
     }
@@ -112,11 +112,11 @@ fn opencode_prompt_path(home: &Path) -> std::path::PathBuf {
         if xdg_path.starts_with(home) {
             let xdg_dir = xdg_path.join("opencode");
             if xdg_dir.exists() {
-                return xdg_dir.join("OPENCODE.md");
+                return xdg_dir.join("AGENTS.md");
             }
         }
     }
-    home.join("OPENCODE.md")
+    home.join("AGENTS.md")
 }
 
 // ---------------------------------------------------------------------------
@@ -153,7 +153,7 @@ fn install_mcp_server(config_path: &Path, tokensave_bin: &str) -> Result<()> {
     Ok(())
 }
 
-/// Append prompt rules to OPENCODE.md (idempotent).
+/// Append prompt rules to AGENTS.md (idempotent).
 fn install_prompt_rules(prompt_path: &Path) -> Result<()> {
     let marker = "## Prefer tokensave MCP tools";
     let existing = if prompt_path.exists() {
@@ -162,7 +162,7 @@ fn install_prompt_rules(prompt_path: &Path) -> Result<()> {
         String::new()
     };
     if existing.contains(marker) {
-        eprintln!("  OPENCODE.md already contains tokensave rules, skipping");
+        eprintln!("  AGENTS.md already contains tokensave rules, skipping");
         return Ok(());
     }
     let mut f = std::fs::OpenOptions::new()
@@ -170,7 +170,7 @@ fn install_prompt_rules(prompt_path: &Path) -> Result<()> {
         .append(true)
         .open(prompt_path)
         .map_err(|e| TokenSaveError::Config {
-            message: format!("failed to open OPENCODE.md: {e}"),
+            message: format!("failed to open AGENTS.md: {e}"),
         })?;
     write!(
         f,
@@ -241,7 +241,7 @@ fn uninstall_mcp_server(config_path: &Path) {
     }
 }
 
-/// Remove tokensave rules from OPENCODE.md.
+/// Remove tokensave rules from AGENTS.md.
 fn uninstall_prompt_rules(prompt_path: &Path) {
     if !prompt_path.exists() {
         return;
@@ -250,7 +250,7 @@ fn uninstall_prompt_rules(prompt_path: &Path) {
         return;
     };
     if !contents.contains("tokensave") {
-        eprintln!("  OPENCODE.md does not contain tokensave rules, skipping");
+        eprintln!("  AGENTS.md does not contain tokensave rules, skipping");
         return;
     }
     let marker = "## Prefer tokensave MCP tools";
@@ -322,7 +322,7 @@ fn doctor_check_config(dc: &mut DoctorCounters, home: &Path) {
     }
 }
 
-/// Check OPENCODE.md contains tokensave rules.
+/// Check AGENTS.md contains tokensave rules.
 fn doctor_check_prompt(dc: &mut DoctorCounters, home: &Path) {
     let prompt_path = opencode_prompt_path(home);
     if prompt_path.exists() {
@@ -330,13 +330,11 @@ fn doctor_check_prompt(dc: &mut DoctorCounters, home: &Path) {
             .unwrap_or_default()
             .contains("tokensave");
         if has_rules {
-            dc.pass("OPENCODE.md contains tokensave rules");
+            dc.pass("AGENTS.md contains tokensave rules");
         } else {
-            dc.fail(
-                "OPENCODE.md missing tokensave rules — run `tokensave install --agent opencode`",
-            );
+            dc.fail("AGENTS.md missing tokensave rules — run `tokensave install --agent opencode`");
         }
     } else {
-        dc.warn("OPENCODE.md does not exist");
+        dc.warn("AGENTS.md does not exist");
     }
 }

--- a/tests/opencode_agent_test.rs
+++ b/tests/opencode_agent_test.rs
@@ -29,11 +29,11 @@ fn opencode_config_path(home: &Path) -> std::path::PathBuf {
 
 fn opencode_prompt_path(home: &Path) -> std::path::PathBuf {
     // Mirrors the logic: if .config/opencode exists, use it
-    let modern = home.join(".config/opencode/OPENCODE.md");
+    let modern = home.join(".config/opencode/AGENTS.md");
     if modern.exists() || home.join(".config/opencode").exists() {
         return modern;
     }
-    home.join("OPENCODE.md")
+    home.join("AGENTS.md")
 }
 
 // ===========================================================================
@@ -80,16 +80,16 @@ fn test_install_creates_opencode_md_with_rules() {
     OpenCodeIntegration.install(&ctx).unwrap();
 
     let prompt_path = opencode_prompt_path(home);
-    assert!(prompt_path.exists(), "OPENCODE.md should be created");
+    assert!(prompt_path.exists(), "AGENTS.md should be created");
 
     let content = std::fs::read_to_string(&prompt_path).unwrap();
     assert!(
         content.contains("## Prefer tokensave MCP tools"),
-        "OPENCODE.md should contain the tokensave rules marker"
+        "AGENTS.md should contain the tokensave rules marker"
     );
     assert!(
         content.contains("tokensave_context"),
-        "OPENCODE.md should mention tokensave tools"
+        "AGENTS.md should mention tokensave tools"
     );
 }
 
@@ -165,11 +165,11 @@ fn test_install_preserves_existing_opencode_md_content() {
     let dir = TempDir::new().unwrap();
     let home = dir.path();
 
-    // Create OPENCODE.md with pre-existing content
+    // Create AGENTS.md with pre-existing content
     let config_dir = home.join(".config/opencode");
     std::fs::create_dir_all(&config_dir).unwrap();
     std::fs::write(
-        config_dir.join("OPENCODE.md"),
+        config_dir.join("AGENTS.md"),
         "## My Custom Rules\n\nAlways use TypeScript.\n",
     )
     .unwrap();
@@ -177,7 +177,7 @@ fn test_install_preserves_existing_opencode_md_content() {
     let ctx = make_ctx(home);
     OpenCodeIntegration.install(&ctx).unwrap();
 
-    let content = std::fs::read_to_string(config_dir.join("OPENCODE.md")).unwrap();
+    let content = std::fs::read_to_string(config_dir.join("AGENTS.md")).unwrap();
     assert!(
         content.contains("My Custom Rules"),
         "existing content should be preserved"
@@ -270,12 +270,12 @@ fn test_uninstall_removes_opencode_md_rules() {
 
     OpenCodeIntegration.uninstall(&ctx).unwrap();
 
-    // OPENCODE.md had only tokensave rules, should be removed
+    // AGENTS.md had only tokensave rules, should be removed
     if prompt_path.exists() {
         let content = std::fs::read_to_string(&prompt_path).unwrap();
         assert!(
             !content.contains("Prefer tokensave MCP tools"),
-            "OPENCODE.md should not contain tokensave rules after uninstall"
+            "AGENTS.md should not contain tokensave rules after uninstall"
         );
     }
 }
@@ -285,11 +285,11 @@ fn test_uninstall_preserves_other_opencode_md_content() {
     let dir = TempDir::new().unwrap();
     let home = dir.path();
 
-    // Create OPENCODE.md with pre-existing content
+    // Create AGENTS.md with pre-existing content
     let config_dir = home.join(".config/opencode");
     std::fs::create_dir_all(&config_dir).unwrap();
     std::fs::write(
-        config_dir.join("OPENCODE.md"),
+        config_dir.join("AGENTS.md"),
         "## My Custom Rules\n\nAlways use TypeScript.\n",
     )
     .unwrap();
@@ -298,8 +298,8 @@ fn test_uninstall_preserves_other_opencode_md_content() {
     OpenCodeIntegration.install(&ctx).unwrap();
     OpenCodeIntegration.uninstall(&ctx).unwrap();
 
-    let prompt_path = config_dir.join("OPENCODE.md");
-    assert!(prompt_path.exists(), "OPENCODE.md should still exist");
+    let prompt_path = config_dir.join("AGENTS.md");
+    assert!(prompt_path.exists(), "AGENTS.md should still exist");
     let content = std::fs::read_to_string(&prompt_path).unwrap();
     assert!(
         content.contains("My Custom Rules"),
@@ -412,7 +412,7 @@ fn test_healthcheck_detects_missing_serve_arg() {
     )
     .unwrap();
 
-    // Also create OPENCODE.md so the prompt check passes
+    // Also create AGENTS.md so the prompt check passes
     let prompt_path = opencode_prompt_path(home);
     std::fs::write(
         &prompt_path,
@@ -439,7 +439,7 @@ fn test_healthcheck_detects_missing_opencode_md() {
     let ctx = make_ctx(home);
     OpenCodeIntegration.install(&ctx).unwrap();
 
-    // Delete OPENCODE.md
+    // Delete AGENTS.md
     let prompt_path = opencode_prompt_path(home);
     std::fs::remove_file(&prompt_path).unwrap();
 
@@ -451,7 +451,7 @@ fn test_healthcheck_detects_missing_opencode_md() {
     OpenCodeIntegration.healthcheck(&mut dc, &hctx);
     assert!(
         dc.warnings > 0,
-        "healthcheck should warn about missing OPENCODE.md"
+        "healthcheck should warn about missing AGENTS.md"
     );
 }
 
@@ -462,7 +462,7 @@ fn test_healthcheck_detects_missing_tokensave_rules_in_opencode_md() {
     let ctx = make_ctx(home);
     OpenCodeIntegration.install(&ctx).unwrap();
 
-    // Overwrite OPENCODE.md without any mention of tokensave
+    // Overwrite AGENTS.md without any mention of tokensave
     let prompt_path = opencode_prompt_path(home);
     std::fs::write(
         &prompt_path,
@@ -478,7 +478,7 @@ fn test_healthcheck_detects_missing_tokensave_rules_in_opencode_md() {
     OpenCodeIntegration.healthcheck(&mut dc, &hctx);
     assert!(
         dc.issues > 0,
-        "healthcheck should detect missing tokensave rules in OPENCODE.md"
+        "healthcheck should detect missing tokensave rules in AGENTS.md"
     );
 }
 


### PR DESCRIPTION
## Summary

This PR sets the correct prompt file for open code

## Motivation

The current version creates or append token save rules at the global path `~/.config/opencode/OPENCODE.md` while the opencode documentation [clearly states](https://opencode.ai/docs/en/rules/#global)

> You can also have global rules in a `~/.config/opencode/AGENTS.md` file. This gets applied across all opencode sessions.

## Changes

- `src/agents/opencode.rs`: change to the file name
- `tests/opencode_agent_test.rs`: change the test to test the expected behaviour
- `docs/DESIGN-DOC.md`: change the file name

## Test plan

- [x] `cargo test` passes
- [x] `cargo clippy` has no new warnings
- [ ] Tested manually (describe below if applicable)


## Checklist

- [x] `CHANGELOG.md` updated (under `[Unreleased]` if no version bump)
- [x] No secrets, credentials, or `.env` files included
- [ ] Breaking changes documented (if any)
