### PR TITLE
[Proposal] Use older Linux for better backward compatibility.

### DIFF
--- a/.github/workflows/release-beta.yml
+++ b/.github/workflows/release-beta.yml
@@ -39,12 +39,12 @@ jobs:
             bottle_tag: arm64_sonoma
             archive: tar.gz
           - name: x86_64-linux
-            runner: ubuntu-latest
+            runner: ubuntu-22.04
             target: x86_64-unknown-linux-gnu
             bottle_tag: x86_64_linux
             archive: tar.gz
           - name: aarch64-linux
-            runner: ubuntu-24.04-arm
+            runner: ubuntu-22.04-arm
             target: aarch64-unknown-linux-gnu
             archive: tar.gz
           - name: x86_64-windows

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -28,12 +28,12 @@ jobs:
             bottle_tag: arm64_sonoma
             archive: tar.gz
           - name: x86_64-linux
-            runner: ubuntu-latest
+            runner: ubuntu-22.04
             target: x86_64-unknown-linux-gnu
             bottle_tag: x86_64_linux
             archive: tar.gz
           - name: aarch64-linux
-            runner: ubuntu-24.04-arm
+            runner: ubuntu-22.04-arm
             target: aarch64-unknown-linux-gnu
             archive: tar.gz
           - name: x86_64-windows


### PR DESCRIPTION




## Summary

Since the binaries are built on newer version, their libc version is not compatible with older linux distros. Closing the gap by using slightly older version of Linux in order to provide better backward compatibility.

## Motivation

Failure example when running on ubuntu 22.04:
```
.../linux/arm64/tokensave: /lib/aarch64-linux-gnu/libc.so.6: version `GLIBC_2.39' not found (required by ...)
```