### PR TITLE
feat(install): add --git-hook flag to skip the post-commit hook prompt

### DIFF
--- a/README.md
+++ b/README.md
@@ -133,6 +133,8 @@ tokensave install --agent opencode        # OpenCode
 tokensave install --agent roo-code        # Roo Code
 tokensave install --agent vibe            # Mistral Vibe
 tokensave install --agent zed             # Zed
+tokensave install --git-hook yes           # auto-install the global post-commit hook (no prompt)
+tokensave install --git-hook no            # skip the post-commit hook (no prompt)
 ```
 
 Each agent gets its MCP server registered in the native config format. Claude Code additionally gets a PreToolUse hook (blocks wasteful Explore agents), a UserPromptSubmit hook, a Stop hook, prompt rules in CLAUDE.md, and auto-allowed tool permissions. Kiro gets global MCP config, `tokensave.md` steering loaded as a resource, and a tokensave-managed default agent with permissive built-in/tokensave tool approval, delegation guardrail hooks, and post-write sync; user-managed Kiro agents are preserved.

--- a/docs/USER-GUIDE.md
+++ b/docs/USER-GUIDE.md
@@ -200,6 +200,15 @@ tokensave install --agent kimi        # Moonshot Kimi CLI
 tokensave install --agent vibe        # Mistral Vibe
 ```
 
+You can also pre-decide the global git `post-commit` hook prompt — useful in
+bash scripts and onboarding playbooks where a `read_line` would otherwise block:
+
+```bash
+tokensave install --git-hook yes   # install the hook without asking
+tokensave install --git-hook no    # skip the hook without asking
+tokensave install --git-hook default  # preserve the interactive prompt (default when flag is omitted)
+```
+
 Each agent gets an appropriate configuration: MCP server registration, tool permissions (where the agent supports them), and prompt rules in the agent's instruction file.
 
 Kiro setup registers tokensave in `~/.kiro/settings/mcp.json`, writes steering to
@@ -302,6 +311,8 @@ Run `tokensave sync` whenever you want. It's incremental and fast.
 ### Post-commit hook
 
 During `tokensave install`, you'll be offered a global git `post-commit` hook. If you accept, tokensave will automatically sync in the background after every git commit across all your repos. The hook is a no-op in repos that don't have a `.tokensave/` directory.
+
+If you're scripting the install (CI, dotfiles bootstrap, onboarding playbook), pass `--git-hook yes` to install the hook without prompting, or `--git-hook no` to skip it. Omitting the flag preserves the interactive prompt.
 
 You can also set it up manually:
 

--- a/src/agents/mod.rs
+++ b/src/agents/mod.rs
@@ -23,6 +23,8 @@ pub mod zed;
 
 use std::path::{Path, PathBuf};
 
+use clap::ValueEnum;
+
 use crate::errors::Result;
 use crate::errors::TokenSaveError;
 use crate::mcp::tools::get_tool_definitions;
@@ -914,6 +916,20 @@ pub fn write_toml_file(path: &Path, value: &toml::Value) -> Result<()> {
 // Git post-commit hook
 // ---------------------------------------------------------------------------
 
+/// Whether `tokensave install` should install the global git `post-commit`
+/// hook, and if so, whether to ask the user interactively or act
+/// non-interactively. The `Default` variant preserves the previous
+/// behavior: prompt on a TTY, silently skip on a non-TTY.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, ValueEnum)]
+pub enum GitHookMode {
+    /// Preserve today's behavior — prompt on a TTY, silently skip otherwise.
+    Default,
+    /// Install the hook without asking, even on a TTY.
+    Yes,
+    /// Skip the hook install entirely, without asking.
+    No,
+}
+
 /// The marker comment used to identify tokensave's section in a hook script.
 const HOOK_MARKER: &str = "# tokensave: auto-sync";
 
@@ -926,11 +942,52 @@ fn post_commit_snippet(tokensave_bin: &str) -> String {
     )
 }
 
+/// Action decided by [`decide_hook_action`]: what the caller should do
+/// given the user-supplied mode and the current state of the global
+/// `post-commit` hook file.
+#[derive(Debug, PartialEq, Eq)]
+pub(crate) enum HookAction {
+    /// Hook is already installed (marker present) — nothing to do. The
+    /// caller may still print an informational message.
+    AlreadyInstalled,
+    /// Skip the install entirely (mode `No`, or default-mode non-TTY).
+    Skip,
+    /// Show the interactive prompt and act on the answer.
+    Prompt,
+    /// Install the hook now (no prompt).
+    Install,
+}
+
+/// Pure decision: figure out what to do for the global post-commit hook
+/// given the requested mode and the hook file's current contents (`None`
+/// when the file does not exist or could not be read). The caller
+/// handles all I/O.
+pub(crate) fn decide_hook_action(mode: GitHookMode, hook_contents: Option<&str>) -> HookAction {
+    if let Some(contents) = hook_contents {
+        if contents.contains(HOOK_MARKER) {
+            return HookAction::AlreadyInstalled;
+        }
+    }
+
+    match mode {
+        GitHookMode::Default => {
+            if atty_stdin() {
+                HookAction::Prompt
+            } else {
+                HookAction::Skip
+            }
+        }
+        GitHookMode::Yes => HookAction::Install,
+        GitHookMode::No => HookAction::Skip,
+    }
+}
+
 /// If a global git `post-commit` hook is not already set up for tokensave,
 /// interactively asks the user whether to install one. Silently succeeds if
 /// the hook is already present, if stdin is not a terminal, or if the user
-/// declines.
-pub fn offer_git_post_commit_hook(tokensave_bin: &str) {
+/// declines. The `mode` argument lets the caller pre-decide the answer so
+/// scripted installs do not have to drive an interactive prompt.
+pub fn offer_git_post_commit_hook(tokensave_bin: &str, mode: GitHookMode) {
     let Some(home) = home_dir() else { return };
 
     // Determine the global hooks directory by reading core.hooksPath from
@@ -944,33 +1001,45 @@ pub fn offer_git_post_commit_hook(tokensave_bin: &str) {
 
     let hook_path = hooks_dir.join("post-commit");
 
-    // Check if already installed.
-    if hook_path.exists() {
-        if let Ok(contents) = std::fs::read_to_string(&hook_path) {
-            if contents.contains(HOOK_MARKER) {
-                eprintln!("  Global git post-commit hook already contains tokensave, skipping");
-                return;
-            }
+    // Read existing contents once so the decision is pure and the
+    // install path can append without re-reading.
+    let existing_contents: Option<String> = if hook_path.exists() {
+        std::fs::read_to_string(&hook_path).ok()
+    } else {
+        None
+    };
+
+    match decide_hook_action(mode, existing_contents.as_deref()) {
+        HookAction::AlreadyInstalled => {
+            eprintln!("  Global git post-commit hook already contains tokensave, skipping");
+            return;
         }
+        HookAction::Skip => {
+            // Mode `No` (or default-mode non-TTY). Stay quiet — script
+            // callers asked for no output here.
+            return;
+        }
+        HookAction::Prompt => {}
+        HookAction::Install => {}
     }
 
-    // Only prompt on a real terminal.
-    if !atty_stdin() {
-        return;
-    }
+    // If we reach this point, we are either prompting (TTY, default
+    // mode) or installing unconditionally (mode `Yes`). For the
+    // prompting branch, ask and bail if the user declines.
+    if matches!(mode, GitHookMode::Default) {
+        eprintln!();
+        eprint!(
+            "Install a global git post-commit hook to auto-run \x1b[1mtokensave sync\x1b[0m after each commit? [y/N] "
+        );
 
-    eprintln!();
-    eprint!(
-        "Install a global git post-commit hook to auto-run \x1b[1mtokensave sync\x1b[0m after each commit? [y/N] "
-    );
-
-    let mut answer = String::new();
-    if std::io::stdin().read_line(&mut answer).is_err() {
-        return;
-    }
-    if !matches!(answer.trim(), "y" | "Y" | "yes" | "Yes") {
-        eprintln!("  Skipped git post-commit hook");
-        return;
+        let mut answer = String::new();
+        if std::io::stdin().read_line(&mut answer).is_err() {
+            return;
+        }
+        if !matches!(answer.trim(), "y" | "Y" | "yes" | "Yes") {
+            eprintln!("  Skipped git post-commit hook");
+            return;
+        }
     }
 
     // Create the hooks directory if needed.
@@ -1329,6 +1398,71 @@ mod git_hook_tests {
     fn expand_tilde_no_tilde() {
         let home = Path::new("/home/test");
         assert_eq!(expand_tilde("/abs/path", home), "/abs/path");
+    }
+
+    #[test]
+    fn decide_hook_action_yes_installs_when_file_missing() {
+        assert_eq!(
+            decide_hook_action(GitHookMode::Yes, None),
+            HookAction::Install
+        );
+    }
+
+    #[test]
+    fn decide_hook_action_yes_installs_when_file_exists_without_marker() {
+        let contents = "#!/bin/sh\necho hello\n";
+        assert_eq!(
+            decide_hook_action(GitHookMode::Yes, Some(contents)),
+            HookAction::Install
+        );
+    }
+
+    #[test]
+    fn decide_hook_action_yes_reports_already_installed_when_marker_present() {
+        let contents = "#!/bin/sh\n# tokensave: auto-sync\n/usr/bin/tokensave sync\n";
+        assert_eq!(
+            decide_hook_action(GitHookMode::Yes, Some(contents)),
+            HookAction::AlreadyInstalled
+        );
+    }
+
+    #[test]
+    fn decide_hook_action_no_skips_even_when_file_missing() {
+        assert_eq!(
+            decide_hook_action(GitHookMode::No, None),
+            HookAction::Skip
+        );
+    }
+
+    #[test]
+    fn decide_hook_action_no_still_reports_already_installed() {
+        // The user explicitly opted out of changes, but we should still
+        // report that the hook is already in place rather than silently
+        // skipping. Caller prints the message.
+        let contents = "# tokensave: auto-sync\nfoo\n";
+        assert_eq!(
+            decide_hook_action(GitHookMode::No, Some(contents)),
+            HookAction::AlreadyInstalled
+        );
+    }
+
+    #[test]
+    fn decide_hook_action_default_skips_when_file_missing() {
+        // On a non-TTY the default mode silently skips. We cannot
+        // guarantee whether `atty_stdin()` is true or false in a test
+        // process, so assert that the result is one of the two valid
+        // outcomes.
+        let action = decide_hook_action(GitHookMode::Default, None);
+        assert!(matches!(action, HookAction::Skip | HookAction::Prompt));
+    }
+
+    #[test]
+    fn decide_hook_action_default_already_installed_wins_over_tty() {
+        let contents = "# tokensave: auto-sync\nfoo\n";
+        assert_eq!(
+            decide_hook_action(GitHookMode::Default, Some(contents)),
+            HookAction::AlreadyInstalled
+        );
     }
 
     /// Helper: parse from a string directly (avoids file I/O in tests).

--- a/src/agents/mod.rs
+++ b/src/agents/mod.rs
@@ -963,20 +963,13 @@ pub(crate) enum HookAction {
 /// when the file does not exist or could not be read). The caller
 /// handles all I/O.
 pub(crate) fn decide_hook_action(mode: GitHookMode, hook_contents: Option<&str>) -> HookAction {
-    if let Some(contents) = hook_contents {
-        if contents.contains(HOOK_MARKER) {
-            return HookAction::AlreadyInstalled;
-        }
+    if hook_contents.is_some_and(|c| c.contains(HOOK_MARKER)) {
+        return HookAction::AlreadyInstalled;
     }
 
     match mode {
-        GitHookMode::Default => {
-            if atty_stdin() {
-                HookAction::Prompt
-            } else {
-                HookAction::Skip
-            }
-        }
+        GitHookMode::Default if atty_stdin() => HookAction::Prompt,
+        GitHookMode::Default => HookAction::Skip,
         GitHookMode::Yes => HookAction::Install,
         GitHookMode::No => HookAction::Skip,
     }
@@ -1428,10 +1421,7 @@ mod git_hook_tests {
 
     #[test]
     fn decide_hook_action_no_skips_even_when_file_missing() {
-        assert_eq!(
-            decide_hook_action(GitHookMode::No, None),
-            HookAction::Skip
-        );
+        assert_eq!(decide_hook_action(GitHookMode::No, None), HookAction::Skip);
     }
 
     #[test]

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -4,6 +4,13 @@ fn agent_value_parser() -> PossibleValuesParser {
     PossibleValuesParser::new(tokensave::agents::available_integrations())
 }
 
+/// Whether `tokensave install` should offer to install the global git
+/// `post-commit` hook, and if so, whether to ask interactively or act
+/// non-interactively. Re-exported from `tokensave::agents::GitHookMode`
+/// so the enum lives in one place and both the CLI parser and the
+/// install dispatch see the same definition.
+pub use tokensave::agents::GitHookMode;
+
 /// Code intelligence for Rust codebases.
 #[derive(Parser)]
 #[command(
@@ -85,6 +92,12 @@ pub enum Commands {
         /// Agent to configure (auto-detects if omitted)
         #[arg(long, value_parser = agent_value_parser())]
         agent: Option<String>,
+        /// Whether to install a global git `post-commit` hook that runs
+        /// `tokensave sync` after each commit. `default` preserves the
+        /// interactive prompt (or silent skip on non-TTY). `yes` installs
+        /// the hook without asking; `no` skips it without asking.
+        #[arg(long, value_enum, default_value_t = GitHookMode::Default)]
+        git_hook: GitHookMode,
     },
     /// Refresh settings for all already-installed agents
     Reinstall,

--- a/src/main.rs
+++ b/src/main.rs
@@ -538,7 +538,7 @@ async fn run(cli: Cli) -> tokensave::errors::Result<()> {
         Commands::Tool { name, args } => {
             tool_command::run(name, args).await?;
         }
-        Commands::Install { agent } => {
+        Commands::Install { agent, git_hook } => {
             let home = tokensave::agents::home_dir().ok_or_else(|| {
                 tokensave::errors::TokenSaveError::Config {
                     message: "could not determine home directory".to_string(),
@@ -620,7 +620,7 @@ async fn run(cli: Cli) -> tokensave::errors::Result<()> {
             user_cfg.last_installed_version = env!("CARGO_PKG_VERSION").to_string();
             user_cfg.save();
 
-            tokensave::agents::offer_git_post_commit_hook(&tokensave_bin);
+            tokensave::agents::offer_git_post_commit_hook(&tokensave_bin, git_hook);
         }
         Commands::Reinstall => {
             let home = tokensave::agents::home_dir().ok_or_else(|| {
@@ -1103,6 +1103,7 @@ mod startup_tests {
     fn explicit_agent_config_commands_skip_agent_install_maintenance() {
         assert!(should_skip_agent_install_maintenance(&Commands::Install {
             agent: Some("kiro".to_string()),
+            git_hook: tokensave::agents::GitHookMode::Default,
         }));
         assert!(should_skip_agent_install_maintenance(&Commands::Reinstall));
         assert!(should_skip_agent_install_maintenance(


### PR DESCRIPTION
## Summary

`tokensave install` ends every run by interactively asking whether to install a global git `post-commit` hook. That `read_line` blocks bash scripts (CI, dotfiles bootstrap, onboarding playbooks) and on a non-TTY stdin the function silently skipped the install — neither is what a scripted install wants.

Add `--git-hook <default|yes|no>` so the caller can pre-decide the answer:

- `yes` — install the hook without prompting, even on a TTY.
- `no`  — skip the install entirely, without prompting.
- `default` (or omitting the flag) — preserve today's behavior: prompt on a TTY, silently skip on a non-TTY.

The decision logic is extracted into a pure `decide_hook_action` helper covered by 7 new unit tests.

## Usage

```bash
tokensave install --git-hook yes   # install the hook without asking
tokensave install --git-hook no    # skip the hook without asking
tokensave install                  # today's behavior: prompt on TTY
```

## Test plan

- [x] `cargo build` clean (no warnings)
- [x] `cargo test --lib agents::git_hook_tests` — 19/19 pass (12 existing + 7 new)
- [x] `cargo test --bin tokensave startup_tests` — 4/4 pass
- [x] `tokensave install --help` shows the new flag with all three values

Note: there is a pre-existing failure in `mcp::tools::handlers::tests::test_tool_definitions_have_annotations` on master that is unrelated to this change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)