### PR TITLE
F* language support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+- F\* language support (`.fst` / `.fsti`).
+
 ## [6.1.3] - 2026-06-04
 
 ### Fixed

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -31,7 +31,7 @@ default = ["full"]
 lite = []
 
 medium = ["lang-dart", "lang-pascal", "lang-php", "lang-ruby", "lang-bash", "lang-protobuf", "lang-powershell", "lang-nix", "lang-vbnet"]
-full = ["medium", "lang-lua", "lang-zig", "lang-objc", "lang-perl", "lang-batch", "lang-fortran", "lang-cobol", "lang-msbasic2", "lang-gwbasic", "lang-qbasic", "lang-dockerfile", "lang-glsl", "lang-wgsl", "lang-hlsl", "lang-metal", "lang-markdown", "lang-r", "lang-sql", "lang-julia", "lang-haskell", "lang-ocaml", "lang-clojure", "lang-erlang", "lang-elixir", "lang-fsharp", "lang-quint", "lang-toml", "lang-lean"]
+full = ["medium", "lang-lua", "lang-zig", "lang-objc", "lang-perl", "lang-batch", "lang-fortran", "lang-cobol", "lang-msbasic2", "lang-gwbasic", "lang-qbasic", "lang-dockerfile", "lang-glsl", "lang-wgsl", "lang-hlsl", "lang-metal", "lang-markdown", "lang-r", "lang-sql", "lang-julia", "lang-haskell", "lang-ocaml", "lang-clojure", "lang-erlang", "lang-elixir", "lang-fsharp", "lang-fstar", "lang-quint", "lang-toml", "lang-lean"]
 
 # Language features (all grammars provided by tokensave-large-treesitters)
 lang-dart = []
@@ -68,6 +68,7 @@ lang-clojure = []
 lang-erlang = []
 lang-elixir = []
 lang-fsharp = []
+lang-fstar = []
 lang-quint = []
 lang-toml = []
 lang-lean = []

--- a/README.md
+++ b/README.md
@@ -710,6 +710,7 @@ Always compiled. The smallest binary for the most popular languages, plus Svelte
 | Erlang | `.erl`, `.hrl` | `lang-erlang` |
 | Elixir | `.ex`, `.exs` | `lang-elixir` |
 | F# | `.fs`, `.fsi`, `.fsx` | `lang-fsharp` |
+| F* | `.fst`, `.fsti` | `lang-fstar` |
 | Quint | `.qnt` | `lang-quint` |
 | TOML | `.toml` | `lang-toml` |
 | Lean | `.lean` | `lang-lean` |

--- a/src/db/queries.rs
+++ b/src/db/queries.rs
@@ -3203,7 +3203,7 @@ mod tests {
         assert_eq!(display_language_for_path("foo.tsx"), "TypeScript");
         assert_eq!(display_language_for_path("foo.cs"), "C#");
         assert_eq!(display_language_for_path("foo.fst"), "F*");
-        assert_eq!(display_language_for_path("a/b/Foo.fsti"), "F*");
+        assert_eq!(display_language_for_path("foo.fsti"), "F*");
         assert_eq!(display_language_for_path("foo.cpp"), "C++");
         assert_eq!(display_language_for_path("Dockerfile"), "Dockerfile");
         assert_eq!(

--- a/src/db/queries.rs
+++ b/src/db/queries.rs
@@ -2968,6 +2968,7 @@ fn display_language_for_path(path: &str) -> &'static str {
         "cpp" | "cc" | "cxx" | "hpp" | "hxx" | "hh" => "C++",
         "cs" => "C#",
         "fs" | "fsi" | "fsx" => "F#",
+        "fst" | "fsti" => "F*",
         "rb" => "Ruby",
         "php" => "PHP",
         "dart" => "Dart",
@@ -3201,6 +3202,8 @@ mod tests {
         assert_eq!(display_language_for_path("foo.pyi"), "Python");
         assert_eq!(display_language_for_path("foo.tsx"), "TypeScript");
         assert_eq!(display_language_for_path("foo.cs"), "C#");
+        assert_eq!(display_language_for_path("foo.fst"), "F*");
+        assert_eq!(display_language_for_path("a/b/Foo.fsti"), "F*");
         assert_eq!(display_language_for_path("foo.cpp"), "C++");
         assert_eq!(display_language_for_path("Dockerfile"), "Dockerfile");
         assert_eq!(

--- a/src/extraction/fstar_extractor.rs
+++ b/src/extraction/fstar_extractor.rs
@@ -169,7 +169,11 @@ fn classify_head(line: &str) -> Head {
     let mut saw_prefix = false;
     loop {
         if s.is_empty() {
-            return if saw_prefix { Head::AttrOnly } else { Head::NotDecl };
+            return if saw_prefix {
+                Head::AttrOnly
+            } else {
+                Head::NotDecl
+            };
         }
         // Attribute group: `[@@ ... ]` or `[@ ... ]` (single-line span only;
         // multi-line attributes continue on indented lines, which never reach
@@ -973,12 +977,7 @@ fn instance_class(rest: &str) -> Option<String> {
 /// no implementation). For everything else the signature is the text up to the
 /// definitional `=`, so a `let`-defined lemma keeps its `: Lemma (requires …)
 /// (ensures …)` but drops the proof term.
-fn build_signature(
-    blank_lines: &[&str],
-    start: usize,
-    end: usize,
-    kw: DeclKw,
-) -> Option<String> {
+fn build_signature(blank_lines: &[&str], start: usize, end: usize, kw: DeclKw) -> Option<String> {
     // Generous cap: real Lemma specs are well under this; guards against a
     // pathological run-on.
     const MAX: usize = 800;
@@ -1030,7 +1029,10 @@ fn find_def_eq_pos(blank_lines: &[&str], start: usize, end: usize) -> Option<(us
                 _ => {}
             }
             if depth == 0 && c == '=' {
-                let next = line[byte_off + c.len_utf8()..].chars().next().unwrap_or(' ');
+                let next = line[byte_off + c.len_utf8()..]
+                    .chars()
+                    .next()
+                    .unwrap_or(' ');
                 if !is_op_char(prev) && !is_op_char(next) {
                     return Some((line_idx, byte_off));
                 }
@@ -1314,7 +1316,11 @@ fn blank_comments_and_strings(source: &str) -> String {
                     continue;
                 }
                 if c == '*' && next == ')' {
-                    st = if depth == 1 { St::Normal } else { St::Block(depth - 1) };
+                    st = if depth == 1 {
+                        St::Normal
+                    } else {
+                        St::Block(depth - 1)
+                    };
                     out.push(' ');
                     out.push(' ');
                     i += 2;

--- a/src/extraction/fstar_extractor.rs
+++ b/src/extraction/fstar_extractor.rs
@@ -1,0 +1,1361 @@
+//! Hand-written F* (`.fst` / `.fsti`) source extractor.
+//!
+//! F* has no maintained, complete tree-sitter grammar, and the F# grammar does
+//! not parse F*-specific syntax (refinement types, effects, `Lemma`, `val`
+//! declarations, typeclasses, `calc`, `eliminate`/`introduce`, the `#push-options`
+//! family of pragmas, …). Rather than bolt an incomplete grammar onto the build,
+//! this extractor parses F* directly with a light, declaration-level scanner.
+//!
+//! A top-level declaration starts in column 0. Bodies, however, are *not*
+//! required to be indented — `let f x =\nif b then x else y` and even a
+//! column-0 local `let y = e in …` are both legal F*. So we cannot treat
+//! "column 0" alone as "new declaration". Instead the scanner tracks, across
+//! lines, the bracket depth (`()`/`[]`/`{}`/`begin`…`end`), the local
+//! `let`…`in` balance, and whether the previous line ended on a continuation
+//! token (an operator char, an open bracket, `=`, `->`, `in`, `then`, `with`,
+//! …). A column-0 declaration keyword only opens a *new* declaration when none
+//! of those say "the previous declaration's term is still open" — so a
+//! column-0 `let y = e in` inside a body is correctly read as a local binding,
+//! not a top-level `let`. Term-level constructs (`calc`, `eliminate`,
+//! `introduce`, match arms) are likewise absorbed into the enclosing body.
+//!
+//! The set of top-level declaration keywords and qualifiers mirrors the F* menhir
+//! grammar (`FStarC.Parser.Parse.mly`) and lexer (`FStarC.Parser.LexFStar.ml`):
+//!
+//! * `module M.N`              → [`NodeKind::Module`] (becomes the file's scope)
+//! * `module A = M.N` / `open` / `include` / `friend` → `Uses` edge
+//! * `let` / `and` / `val`     → [`NodeKind::Function`]
+//! * `type t = { … }`          → [`NodeKind::Struct`] + [`NodeKind::Field`]
+//! * `type t = | A | B`        → [`NodeKind::Enum`] + [`NodeKind::EnumVariant`]
+//! * `type t = …`              → [`NodeKind::TypeAlias`]
+//! * `class c = { … }`         → [`NodeKind::Trait`] + [`NodeKind::Field`] (methods)
+//! * `instance i : c = { … }`  → [`NodeKind::Impl`]
+//! * `exception E`             → [`NodeKind::Struct`]
+//! * `assume X : phi`          → [`NodeKind::Const`]
+//! * `effect` / `new_effect` / `layered_effect` → [`NodeKind::TypeAlias`]
+//! * `#set-options` / `#push-options` / `#pop-options` / … → ignored (no node)
+
+use std::time::{Instant, SystemTime, UNIX_EPOCH};
+
+use crate::types::{
+    generate_node_id, Edge, EdgeKind, ExtractionResult, Node, NodeKind, UnresolvedRef, Visibility,
+};
+
+pub struct FStarExtractor;
+
+/// F* operator characters (`FStarC.Parser.LexFStar.op_char`).
+fn is_op_char(c: char) -> bool {
+    matches!(
+        c,
+        '!' | '$'
+            | '%'
+            | '&'
+            | '*'
+            | '+'
+            | '-'
+            | '.'
+            | '<'
+            | '>'
+            | '='
+            | '?'
+            | '^'
+            | '|'
+            | '~'
+            | ':'
+            | '@'
+            | '#'
+            | '\\'
+            | '/'
+    )
+}
+
+/// Characters that may appear in an F* identifier (after the first).
+fn is_ident_char(c: char) -> bool {
+    c.is_ascii_alphanumeric() || c == '_' || c == '\''
+}
+
+/// Returns the leading identifier word of `s` and the remainder.
+fn next_word(s: &str) -> (&str, &str) {
+    let s = s.trim_start();
+    let end = s.find(|c: char| !is_ident_char(c)).unwrap_or(s.len());
+    (&s[..end], &s[end..])
+}
+
+/// Leading dotted module path (e.g. `FStar.List.Tot`).
+fn leading_dotted(s: &str) -> String {
+    let s = s.trim_start();
+    let end = s
+        .find(|c: char| !(is_ident_char(c) || c == '.'))
+        .unwrap_or(s.len());
+    s[..end].to_string()
+}
+
+/// Qualifiers that may precede a declaration keyword
+/// (`FStarC.Parser.Parse.qualifier`). `assume` is handled separately because it
+/// is also a standalone declaration.
+fn is_qualifier(w: &str) -> bool {
+    matches!(
+        w,
+        "inline_for_extraction"
+            | "unfold"
+            | "inline"
+            | "irreducible"
+            | "noextract"
+            | "total"
+            | "private"
+            | "noeq"
+            | "unopteq"
+            | "new"
+            | "logic"
+            | "opaque"
+            | "reifiable"
+            | "reflectable"
+            | "abstract"
+            | "unfoldable"
+    )
+}
+
+/// Top-level declaration keywords (`FStarC.Parser.Parse.rawDecl` / `decl`).
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum DeclKw {
+    Module,
+    Open,
+    Include,
+    Friend,
+    Type,
+    Let,
+    And,
+    Val,
+    Class,
+    Instance,
+    Effect,
+    Exception,
+    Assume,
+}
+
+fn decl_keyword(w: &str) -> Option<DeclKw> {
+    Some(match w {
+        "module" => DeclKw::Module,
+        "open" => DeclKw::Open,
+        "include" => DeclKw::Include,
+        "friend" => DeclKw::Friend,
+        "type" => DeclKw::Type,
+        "let" => DeclKw::Let,
+        "and" => DeclKw::And,
+        "val" => DeclKw::Val,
+        "class" => DeclKw::Class,
+        "instance" => DeclKw::Instance,
+        "effect" | "new_effect" | "layered_effect" => DeclKw::Effect,
+        "exception" => DeclKw::Exception,
+        "assume" => DeclKw::Assume,
+        _ => return None,
+    })
+}
+
+/// Result of classifying a column-0 source line.
+enum Head {
+    /// A declaration: keyword plus the text following it on the start line.
+    Decl(DeclKw, String),
+    /// Only attributes / qualifiers — a prefix to the following declaration.
+    AttrOnly,
+    /// Anything else (pragma, closing brace, doc comment, continuation, …).
+    NotDecl,
+}
+
+/// Classifies a (column-0) line, stripping leading attribute groups (`[@@ … ]`)
+/// and qualifiers to find the declaration keyword.
+fn classify_head(line: &str) -> Head {
+    let mut s = line.trim_start();
+    let mut saw_prefix = false;
+    loop {
+        if s.is_empty() {
+            return if saw_prefix { Head::AttrOnly } else { Head::NotDecl };
+        }
+        // Attribute group: `[@@ ... ]` or `[@ ... ]` (single-line span only;
+        // multi-line attributes continue on indented lines, which never reach
+        // this column-0 classifier).
+        if s.starts_with("[@") {
+            saw_prefix = true;
+            match s.find(']') {
+                Some(i) => {
+                    s = s[i + 1..].trim_start();
+                    continue;
+                }
+                None => return Head::AttrOnly,
+            }
+        }
+        let (w, rest) = next_word(s);
+        if w.is_empty() {
+            // Starts with a non-identifier, non-attribute char (`#`, `}`, `|`,
+            // `(`, …): not a declaration head.
+            return Head::NotDecl;
+        }
+        if w == "assume" {
+            // `assume val`/`assume new`/… → `assume` is a qualifier; otherwise
+            // `assume Name : phi` is itself a declaration.
+            let nrest = rest.trim_start();
+            let (w2, _) = next_word(nrest);
+            if w2 != "assume" && decl_keyword(w2).is_some() {
+                saw_prefix = true;
+                s = nrest;
+                continue;
+            }
+            return Head::Decl(DeclKw::Assume, nrest.to_string());
+        }
+        if let Some(kw) = decl_keyword(w) {
+            return Head::Decl(kw, rest.trim_start().to_string());
+        }
+        if is_qualifier(w) {
+            saw_prefix = true;
+            s = rest.trim_start();
+            continue;
+        }
+        return Head::NotDecl;
+    }
+}
+
+/// Extracts the name bound by a `let` / `val` / `and` / `instance` /
+/// `assume` declaration. Handles `rec`, operator names (`( ++ )`, `( =~ )`),
+/// and plain identifiers. Returns `None` for non-name patterns (tuples, …).
+fn extract_value_name(rest: &str) -> Option<String> {
+    let mut s = rest.trim_start();
+    let (w, r) = next_word(s);
+    if w == "rec" {
+        s = r.trim_start();
+    }
+    let s = s.trim_start();
+    if let Some(op) = operator_name(s) {
+        return Some(op);
+    }
+    let (name, _) = next_word(s);
+    (!name.is_empty()).then(|| name.to_string())
+}
+
+/// If `s` begins with a parenthesised operator, returns the operator symbol.
+/// Handles plain symbolic operators (`( ++ )`, `( =~ )`) as well as F*
+/// "let/and operators" — a `let`/`and`/`match`/`if`/`exists`/`forall` keyword
+/// immediately followed by operator chars (`( let? )`, `( let:: )`,
+/// `( and* )`, `( match? )`), which the F* lexer tokenises as a single
+/// operator. Returns `None` for value patterns like `(x, y)`.
+fn operator_name(s: &str) -> Option<String> {
+    let s = s.trim_start();
+    if !s.starts_with('(') {
+        return None;
+    }
+    let close = s.find(')')?;
+    let inner = s[1..close].trim();
+    if inner.is_empty() {
+        return None;
+    }
+    // Plain symbolic operator.
+    if inner.chars().all(|c| is_op_char(c) || c == ' ') {
+        return Some(inner.chars().filter(|c| !c.is_whitespace()).collect());
+    }
+    // Binding operator: keyword prefix + operator chars.
+    for kw in ["let", "and", "match", "if", "exists", "forall"] {
+        if let Some(rest) = inner.strip_prefix(kw) {
+            let rest = rest.trim_start();
+            if !rest.is_empty() && rest.chars().all(|c| is_op_char(c) || c == ' ') {
+                let ops: String = rest.chars().filter(|c| !c.is_whitespace()).collect();
+                return Some(format!("{kw}{ops}"));
+            }
+        }
+    }
+    None
+}
+
+/// Extracts the name introduced by `type` / `class` / `effect` / `exception`.
+fn extract_type_name(rest: &str) -> Option<String> {
+    let s = rest.trim_start();
+    if let Some(op) = operator_name(s) {
+        return Some(op);
+    }
+    let (name, _) = next_word(s);
+    (!name.is_empty()).then(|| name.to_string())
+}
+
+/// A located declaration discovered in the first scanning pass.
+struct DeclStart {
+    kw: DeclKw,
+    /// Line of the declaration keyword.
+    line: usize,
+    /// First line of the leading attribute/qualifier block (== `line` when none).
+    attr_start: usize,
+    /// Text following the keyword on the keyword line.
+    rest: String,
+}
+
+struct ExtractionState {
+    nodes: Vec<Node>,
+    edges: Vec<Edge>,
+    unresolved_refs: Vec<UnresolvedRef>,
+    file_path: String,
+    timestamp: u64,
+    /// `(qualified_prefix, parent_id)` — top is the active scope.
+    scope: Vec<(String, String)>,
+}
+
+impl ExtractionState {
+    fn parent_id(&self) -> String {
+        self.scope
+            .last()
+            .map(|(_, id)| id.clone())
+            .unwrap_or_default()
+    }
+
+    fn parent_qn(&self) -> String {
+        self.scope
+            .last()
+            .map_or_else(|| self.file_path.clone(), |(qn, _)| qn.clone())
+    }
+
+    #[allow(clippy::too_many_arguments)]
+    fn emit_node(
+        &mut self,
+        kind: NodeKind,
+        name: &str,
+        start_line: usize,
+        attr_start: usize,
+        end_line: usize,
+        signature: Option<String>,
+        docstring: Option<String>,
+        visibility: Visibility,
+    ) -> String {
+        let qualified_name = format!("{}::{}", self.parent_qn(), name);
+        let id = generate_node_id(&self.file_path, &kind, name, start_line as u32);
+        let parent_id = self.parent_id();
+        self.nodes.push(Node {
+            id: id.clone(),
+            kind,
+            name: name.to_string(),
+            qualified_name,
+            file_path: self.file_path.clone(),
+            start_line: start_line as u32,
+            attrs_start_line: attr_start as u32,
+            end_line: end_line as u32,
+            start_column: 0,
+            end_column: 0,
+            signature,
+            docstring,
+            visibility,
+            is_async: false,
+            branches: 0,
+            loops: 0,
+            returns: 0,
+            max_nesting: 0,
+            unsafe_blocks: 0,
+            unchecked_calls: 0,
+            assertions: 0,
+            updated_at: self.timestamp,
+            parent_id: None,
+        });
+        if !parent_id.is_empty() {
+            self.edges.push(Edge {
+                source: parent_id,
+                target: id.clone(),
+                kind: EdgeKind::Contains,
+                line: Some(start_line as u32),
+            });
+        }
+        id
+    }
+
+    /// Emits a `Uses` edge to a (possibly external) module path.
+    fn emit_uses(&mut self, target_path: &str, line: usize) {
+        if target_path.is_empty() {
+            return;
+        }
+        let target_id = generate_node_id(target_path, &NodeKind::File, target_path, 0);
+        let source = self.parent_id();
+        if source.is_empty() {
+            return;
+        }
+        self.edges.push(Edge {
+            source,
+            target: target_id,
+            kind: EdgeKind::Uses,
+            line: Some(line as u32),
+        });
+    }
+}
+
+impl FStarExtractor {
+    pub fn extract_fstar(file_path: &str, source: &str) -> ExtractionResult {
+        let start = Instant::now();
+        let timestamp = SystemTime::now()
+            .duration_since(UNIX_EPOCH)
+            .unwrap_or_default()
+            .as_secs();
+
+        let raw_lines: Vec<&str> = source.split('\n').collect();
+        let blanked = blank_comments_and_strings(source);
+        let blank_lines: Vec<&str> = blanked.split('\n').collect();
+        let total = raw_lines.len();
+
+        let file_id = generate_node_id(file_path, &NodeKind::File, file_path, 0);
+        let mut state = ExtractionState {
+            nodes: vec![Node {
+                id: file_id.clone(),
+                kind: NodeKind::File,
+                name: file_path.to_string(),
+                qualified_name: file_path.to_string(),
+                file_path: file_path.to_string(),
+                start_line: 0,
+                attrs_start_line: 0,
+                end_line: total.saturating_sub(1) as u32,
+                start_column: 0,
+                end_column: 0,
+                signature: None,
+                docstring: None,
+                visibility: Visibility::Pub,
+                is_async: false,
+                branches: 0,
+                loops: 0,
+                returns: 0,
+                max_nesting: 0,
+                unsafe_blocks: 0,
+                unchecked_calls: 0,
+                assertions: 0,
+                updated_at: timestamp,
+                parent_id: None,
+            }],
+            edges: Vec::new(),
+            unresolved_refs: Vec::new(),
+            file_path: file_path.to_string(),
+            timestamp,
+            scope: vec![(file_path.to_string(), file_id)],
+        };
+
+        // Pass 1: discover every top-level declaration.
+        let decls = collect_decls(&blank_lines);
+
+        // Pass 2: emit nodes and edges.
+        let mut prev_type = false; // was the previous decl a `type`? (for `and`)
+        for (i, d) in decls.iter().enumerate() {
+            let body_end = decl_end(&decls, i, &blank_lines);
+            let docstring = collect_docstring(&raw_lines, d.attr_start);
+            let visibility = if head_is_private(&raw_lines, d.attr_start, d.line) {
+                Visibility::Private
+            } else {
+                Visibility::Pub
+            };
+
+            let effective = if d.kw == DeclKw::And {
+                if prev_type {
+                    DeclKw::Type
+                } else {
+                    DeclKw::Let
+                }
+            } else {
+                d.kw
+            };
+            prev_type = effective == DeclKw::Type;
+
+            // Full signature: for F*, the spec (requires/ensures/decreases,
+            // refinement types) is the important part, not just the name.
+            let signature = build_signature(&blank_lines, d.line, body_end, effective);
+
+            match effective {
+                DeclKw::Module => {
+                    handle_module(&mut state, d, total);
+                }
+                DeclKw::Open | DeclKw::Include | DeclKw::Friend => {
+                    let target = leading_dotted(&d.rest);
+                    state.emit_uses(&target, d.line);
+                }
+                DeclKw::Let | DeclKw::Val => {
+                    if let Some(name) = extract_value_name(&d.rest) {
+                        state.emit_node(
+                            NodeKind::Function,
+                            &name,
+                            d.line,
+                            d.attr_start,
+                            body_end,
+                            signature,
+                            docstring,
+                            visibility,
+                        );
+                    }
+                }
+                DeclKw::Type => {
+                    handle_type(
+                        &mut state,
+                        d,
+                        body_end,
+                        &blank_lines,
+                        signature,
+                        docstring,
+                        visibility,
+                        NodeKind::Struct,
+                    );
+                }
+                DeclKw::Class => {
+                    handle_type(
+                        &mut state,
+                        d,
+                        body_end,
+                        &blank_lines,
+                        signature,
+                        docstring,
+                        visibility,
+                        NodeKind::Trait,
+                    );
+                }
+                DeclKw::Instance => {
+                    if let Some(name) = extract_value_name(&d.rest) {
+                        let id = state.emit_node(
+                            NodeKind::Impl,
+                            &name,
+                            d.line,
+                            d.attr_start,
+                            body_end,
+                            signature,
+                            docstring,
+                            visibility,
+                        );
+                        // Record the implemented class (the head of the type
+                        // after `:`) as an unresolved `Implements` reference.
+                        if let Some(class) = instance_class(&d.rest) {
+                            state.unresolved_refs.push(UnresolvedRef {
+                                from_node_id: id,
+                                reference_name: class,
+                                reference_kind: EdgeKind::Implements,
+                                line: d.line as u32,
+                                column: 0,
+                                file_path: state.file_path.clone(),
+                            });
+                        }
+                    }
+                }
+                DeclKw::Effect => {
+                    if let Some(name) = extract_type_name(&d.rest) {
+                        state.emit_node(
+                            NodeKind::TypeAlias,
+                            &name,
+                            d.line,
+                            d.attr_start,
+                            body_end,
+                            signature,
+                            docstring,
+                            visibility,
+                        );
+                    }
+                }
+                DeclKw::Exception => {
+                    if let Some(name) = extract_type_name(&d.rest) {
+                        state.emit_node(
+                            NodeKind::Struct,
+                            &name,
+                            d.line,
+                            d.attr_start,
+                            body_end,
+                            signature,
+                            docstring,
+                            visibility,
+                        );
+                    }
+                }
+                DeclKw::Assume => {
+                    if let Some(name) = extract_value_name(&d.rest) {
+                        state.emit_node(
+                            NodeKind::Const,
+                            &name,
+                            d.line,
+                            d.attr_start,
+                            body_end,
+                            signature,
+                            docstring,
+                            visibility,
+                        );
+                    }
+                }
+                DeclKw::And => unreachable!("And resolved to Let/Type above"),
+            }
+        }
+
+        let mut result = ExtractionResult {
+            nodes: state.nodes,
+            edges: state.edges,
+            unresolved_refs: state.unresolved_refs,
+            errors: Vec::new(),
+            duration_ms: start.elapsed().as_millis() as u64,
+        };
+        result.sanitize();
+        result
+    }
+}
+
+/// Handles `module M.N` (declares the file scope) and `module A = M.N` (an
+/// abbreviation, emitted as a `Uses` edge).
+fn handle_module(state: &mut ExtractionState, d: &DeclStart, total: usize) {
+    let rest = d.rest.trim();
+    if rest.contains('=') {
+        // `module A = M.N` or `module _ = M.N` → import-like.
+        let rhs = rest.split_once('=').map_or("", |x| x.1);
+        let target = leading_dotted(rhs);
+        state.emit_uses(&target, d.line);
+        return;
+    }
+    let name = leading_dotted(rest);
+    if name.is_empty() {
+        return;
+    }
+    // The top-level module becomes the enclosing scope for the rest of the
+    // file (it has no `end`), mirroring how the file is one module.
+    let id = state.emit_node(
+        NodeKind::Module,
+        &name,
+        d.line,
+        d.attr_start,
+        total.saturating_sub(1),
+        Some(format!("module {name}")),
+        None,
+        Visibility::Pub,
+    );
+    let qn = format!("{}::{}", state.file_path, name);
+    state.scope.push((qn, id));
+}
+
+/// Handles a `type` or `class` declaration: distinguishes records (→ `Struct` /
+/// `Trait` with `Field` children), variants (→ `Enum` with `EnumVariant`
+/// children), and abbreviations (→ `TypeAlias`).
+#[allow(clippy::too_many_arguments)]
+fn handle_type(
+    state: &mut ExtractionState,
+    d: &DeclStart,
+    body_end: usize,
+    blank_lines: &[&str],
+    signature: Option<String>,
+    docstring: Option<String>,
+    visibility: Visibility,
+    record_kind: NodeKind,
+) {
+    let Some(name) = extract_type_name(&d.rest) else {
+        return;
+    };
+
+    let chars = scan_span(blank_lines, d.line, body_end);
+    let shape = classify_type_shape(&chars);
+
+    let kind = match shape {
+        TypeShape::Record(_) => record_kind,
+        TypeShape::Variant => NodeKind::Enum,
+        TypeShape::Alias => NodeKind::TypeAlias,
+    };
+
+    let parent = state.emit_node(
+        kind,
+        &name,
+        d.line,
+        d.attr_start,
+        body_end,
+        signature,
+        docstring,
+        visibility,
+    );
+    let parent_qn = format!("{}::{}", state.parent_qn(), name);
+
+    match shape {
+        TypeShape::Record(open_idx) => {
+            for (field_name, field_line) in record_fields(&chars, open_idx) {
+                emit_child(
+                    state,
+                    NodeKind::Field,
+                    &field_name,
+                    field_line,
+                    &parent,
+                    &parent_qn,
+                );
+            }
+        }
+        TypeShape::Variant => {
+            for (ctor_name, ctor_line) in variant_constructors(&chars) {
+                emit_child(
+                    state,
+                    NodeKind::EnumVariant,
+                    &ctor_name,
+                    ctor_line,
+                    &parent,
+                    &parent_qn,
+                );
+            }
+        }
+        TypeShape::Alias => {}
+    }
+}
+
+/// Emits a child node (field / variant) parented to `parent`.
+fn emit_child(
+    state: &mut ExtractionState,
+    kind: NodeKind,
+    name: &str,
+    line: usize,
+    parent_id: &str,
+    parent_qn: &str,
+) {
+    let id = generate_node_id(&state.file_path, &kind, name, line as u32);
+    state.nodes.push(Node {
+        id: id.clone(),
+        kind,
+        name: name.to_string(),
+        qualified_name: format!("{parent_qn}::{name}"),
+        file_path: state.file_path.clone(),
+        start_line: line as u32,
+        attrs_start_line: line as u32,
+        end_line: line as u32,
+        start_column: 0,
+        end_column: 0,
+        signature: None,
+        docstring: None,
+        visibility: Visibility::Pub,
+        is_async: false,
+        branches: 0,
+        loops: 0,
+        returns: 0,
+        max_nesting: 0,
+        unsafe_blocks: 0,
+        unchecked_calls: 0,
+        assertions: 0,
+        updated_at: state.timestamp,
+        parent_id: None,
+    });
+    state.edges.push(Edge {
+        source: parent_id.to_string(),
+        target: id,
+        kind: EdgeKind::Contains,
+        line: Some(line as u32),
+    });
+}
+
+#[derive(Clone, Copy)]
+enum TypeShape {
+    /// Record body; carries the index (into the scanned char vec) of the `{`.
+    Record(usize),
+    Variant,
+    Alias,
+}
+
+/// Determines whether a `type` / `class` definition is a record, a variant, or
+/// a plain abbreviation, by inspecting the text after the definitional `=`.
+fn classify_type_shape(chars: &[(usize, char)]) -> TypeShape {
+    // `class c = { … }` always has `=`; an `=`-less `type t` is abstract.
+    let Some(eq) = find_def_eq(chars) else {
+        return TypeShape::Alias;
+    };
+    // First meaningful char after `=`, skipping whitespace and an attribute
+    // group (`[@@ … ]`) that can precede a record body.
+    let mut i = eq + 1;
+    loop {
+        i = skip_ws(chars, i);
+        if i < chars.len() && chars[i].1 == '[' {
+            // Skip a `[ … ]` attribute group.
+            i = skip_bracketed(chars, i);
+            continue;
+        }
+        break;
+    }
+    if i < chars.len() && chars[i].1 == '{' {
+        return TypeShape::Record(i);
+    }
+    // Variant if there is a top-level `|` anywhere in the definition.
+    if has_top_level_bar(&chars[eq + 1..]) {
+        return TypeShape::Variant;
+    }
+    TypeShape::Alias
+}
+
+fn skip_ws(chars: &[(usize, char)], mut i: usize) -> usize {
+    while i < chars.len() && chars[i].1.is_whitespace() {
+        i += 1;
+    }
+    i
+}
+
+/// Skips a balanced `[ … ]` group starting at `i` (which is the `[`).
+fn skip_bracketed(chars: &[(usize, char)], i: usize) -> usize {
+    let mut depth = 0i32;
+    let mut j = i;
+    while j < chars.len() {
+        match chars[j].1 {
+            '[' => depth += 1,
+            ']' => {
+                depth -= 1;
+                if depth == 0 {
+                    return j + 1;
+                }
+            }
+            _ => {}
+        }
+        j += 1;
+    }
+    j
+}
+
+/// Finds the definitional `=` (a standalone `=`, not part of `==`, `:=`, `=~`,
+/// `<=`, …) at bracket depth 0.
+fn find_def_eq(chars: &[(usize, char)]) -> Option<usize> {
+    let mut depth = 0i32;
+    let mut prev = ' ';
+    for (idx, &(_, c)) in chars.iter().enumerate() {
+        match c {
+            '(' | '[' | '{' => depth += 1,
+            ')' | ']' | '}' => depth -= 1,
+            _ => {}
+        }
+        if depth == 0 && c == '=' {
+            let next = chars.get(idx + 1).map_or(' ', |&(_, c)| c);
+            if !is_op_char(prev) && !is_op_char(next) {
+                return Some(idx);
+            }
+        }
+        prev = c;
+    }
+    None
+}
+
+fn has_top_level_bar(chars: &[(usize, char)]) -> bool {
+    let mut depth = 0i32;
+    for &(_, c) in chars {
+        match c {
+            '(' | '[' | '{' => depth += 1,
+            ')' | ']' | '}' => depth -= 1,
+            '|' if depth == 0 => return true,
+            _ => {}
+        }
+    }
+    false
+}
+
+/// Extracts `(name, line)` for each field of a record body. `open_idx` is the
+/// position of the opening `{` in `chars`.
+fn record_fields(chars: &[(usize, char)], open_idx: usize) -> Vec<(String, usize)> {
+    let mut fields = Vec::new();
+    let mut depth = 0i32;
+    let mut seg: Vec<(usize, char)> = Vec::new();
+    let mut i = open_idx;
+    while i < chars.len() {
+        let (_, c) = chars[i];
+        match c {
+            '{' | '(' | '[' => {
+                depth += 1;
+                if depth > 1 {
+                    seg.push(chars[i]);
+                }
+            }
+            '}' | ')' | ']' => {
+                depth -= 1;
+                if depth == 0 {
+                    // End of the record body.
+                    if let Some(f) = parse_field(&seg) {
+                        fields.push(f);
+                    }
+                    break;
+                }
+                seg.push(chars[i]);
+            }
+            ';' if depth == 1 => {
+                if let Some(f) = parse_field(&seg) {
+                    fields.push(f);
+                }
+                seg.clear();
+            }
+            _ if depth >= 1 => seg.push(chars[i]),
+            _ => {}
+        }
+        i += 1;
+    }
+    fields
+}
+
+/// Parses a single record-field segment (`name : type`). Returns `None` for
+/// segments that are not field declarations (no `:`).
+fn parse_field(seg: &[(usize, char)]) -> Option<(String, usize)> {
+    let s: String = seg.iter().map(|&(_, c)| c).collect();
+    if !s.contains(':') {
+        return None;
+    }
+    // Find first non-whitespace, skipping a leading attribute group.
+    let mut i = skip_ws(seg, 0);
+    if i < seg.len() && seg[i].1 == '[' {
+        i = skip_bracketed(seg, i);
+        i = skip_ws(seg, i);
+    }
+    if i >= seg.len() {
+        return None;
+    }
+    let field_line = seg[i].0;
+    let rest: String = seg[i..].iter().map(|&(_, c)| c).collect();
+    let name = if let Some(op) = operator_name(rest.trim_start()) {
+        op
+    } else {
+        next_word(&rest).0.to_string()
+    };
+    (!name.is_empty()).then_some((name, field_line))
+}
+
+/// Extracts `(name, line)` for each constructor of a variant type.
+fn variant_constructors(chars: &[(usize, char)]) -> Vec<(String, usize)> {
+    let Some(eq) = find_def_eq(chars) else {
+        return Vec::new();
+    };
+    let region = &chars[eq + 1..];
+    let mut ctors = Vec::new();
+    let mut depth = 0i32;
+    let mut seg: Vec<(usize, char)> = Vec::new();
+    for &(ln, c) in region {
+        match c {
+            '(' | '[' | '{' => {
+                depth += 1;
+                seg.push((ln, c));
+            }
+            ')' | ']' | '}' => {
+                depth -= 1;
+                seg.push((ln, c));
+            }
+            '|' if depth == 0 => {
+                push_ctor(&mut ctors, &seg);
+                seg.clear();
+            }
+            _ => seg.push((ln, c)),
+        }
+    }
+    push_ctor(&mut ctors, &seg);
+    ctors
+}
+
+fn push_ctor(ctors: &mut Vec<(String, usize)>, seg: &[(usize, char)]) {
+    let mut i = skip_ws(seg, 0);
+    if i < seg.len() && seg[i].1 == '[' {
+        i = skip_bracketed(seg, i);
+        i = skip_ws(seg, i);
+    }
+    if i >= seg.len() {
+        return;
+    }
+    let ctor_line = seg[i].0;
+    let rest: String = seg[i..].iter().map(|&(_, c)| c).collect();
+    let name = next_word(&rest).0.to_string();
+    // Constructors start with an upper-case letter; skip anything else
+    // (e.g. an attribute leftover or a doc fragment).
+    if name.chars().next().is_some_and(|c| c.is_ascii_uppercase()) {
+        ctors.push((name, ctor_line));
+    }
+}
+
+/// The implemented class of an `instance name : Class args = …` declaration:
+/// the head identifier of the type after the first top-level `:`.
+fn instance_class(rest: &str) -> Option<String> {
+    let chars: Vec<(usize, char)> = rest.char_indices().map(|(_, c)| (0, c)).collect();
+    let mut depth = 0i32;
+    for (idx, &(_, c)) in chars.iter().enumerate() {
+        match c {
+            '(' | '[' | '{' => depth += 1,
+            ')' | ']' | '}' => depth -= 1,
+            ':' if depth == 0 => {
+                let after: String = chars[idx + 1..].iter().map(|&(_, c)| c).collect();
+                let name = leading_dotted(after.trim_start());
+                // Take the last component of a dotted class path.
+                let short = name.rsplit('.').next().unwrap_or(&name).to_string();
+                return (!short.is_empty()).then_some(short);
+            }
+            _ => {}
+        }
+    }
+    None
+}
+
+/// Builds a declaration's signature — the part that matters for F*: binders,
+/// the return type, and (crucially) the `requires`/`ensures`/`decreases`
+/// specification and any refinement types. Comments are stripped (we read the
+/// blanked text) and whitespace is normalised to single spaces.
+///
+/// For `val`/`assume`/`exception` the whole declaration is signature (there is
+/// no implementation). For everything else the signature is the text up to the
+/// definitional `=`, so a `let`-defined lemma keeps its `: Lemma (requires …)
+/// (ensures …)` but drops the proof term.
+fn build_signature(
+    blank_lines: &[&str],
+    start: usize,
+    end: usize,
+    kw: DeclKw,
+) -> Option<String> {
+    // Generous cap: real Lemma specs are well under this; guards against a
+    // pathological run-on.
+    const MAX: usize = 800;
+    let cut = match kw {
+        DeclKw::Val | DeclKw::Assume | DeclKw::Exception => None,
+        _ => find_def_eq_pos(blank_lines, start, end),
+    };
+    let end = end.min(blank_lines.len().saturating_sub(1));
+    let mut buf = String::new();
+    for line_idx in start..=end {
+        let line = blank_lines.get(line_idx).copied().unwrap_or("");
+        match cut {
+            Some((cl, col)) if line_idx == cl => {
+                buf.push(' ');
+                buf.push_str(&line[..col.min(line.len())]);
+                break;
+            }
+            _ => {
+                buf.push(' ');
+                buf.push_str(line);
+            }
+        }
+    }
+    let sig = buf.split_whitespace().collect::<Vec<_>>().join(" ");
+    if sig.is_empty() {
+        return None;
+    }
+    if sig.chars().count() > MAX {
+        let mut s: String = sig.chars().take(MAX).collect();
+        s.push('…');
+        Some(s)
+    } else {
+        Some(sig)
+    }
+}
+
+/// `(line, byte-column)` of the definitional `=` (a standalone `=`, not part of
+/// `==`/`:=`/`<=`/`=~`/…) at bracket depth 0 within `[start, end]`.
+fn find_def_eq_pos(blank_lines: &[&str], start: usize, end: usize) -> Option<(usize, usize)> {
+    let end = end.min(blank_lines.len().saturating_sub(1));
+    let mut depth = 0i32;
+    let mut prev = ' ';
+    for line_idx in start..=end {
+        let line = blank_lines.get(line_idx).copied().unwrap_or("");
+        for (byte_off, c) in line.char_indices() {
+            match c {
+                '(' | '[' | '{' => depth += 1,
+                ')' | ']' | '}' => depth = (depth - 1).max(0),
+                _ => {}
+            }
+            if depth == 0 && c == '=' {
+                let next = line[byte_off + c.len_utf8()..].chars().next().unwrap_or(' ');
+                if !is_op_char(prev) && !is_op_char(next) {
+                    return Some((line_idx, byte_off));
+                }
+            }
+            prev = c;
+        }
+        prev = ' '; // a line break separates operator tokens
+    }
+    None
+}
+
+/// Flattens span lines `[start, end]` into `(abs_line, char)` pairs, inserting a
+/// newline marker between lines (tagged with the line it terminates).
+fn scan_span(blank_lines: &[&str], start: usize, end: usize) -> Vec<(usize, char)> {
+    let mut v = Vec::new();
+    let end = end.min(blank_lines.len().saturating_sub(1));
+    for (offset, line) in blank_lines[start..=end].iter().enumerate() {
+        let abs = start + offset;
+        for c in line.chars() {
+            v.push((abs, c));
+        }
+        v.push((abs, '\n'));
+    }
+    v
+}
+
+/// Pass 1: walk every line, grouping leading attribute/qualifier blocks with the
+/// declaration they precede.
+///
+/// A column-0 declaration keyword only opens a new declaration when the previous
+/// declaration's term has closed — tracked via bracket depth, the local
+/// `let`…`in` balance, and whether the last line ended on a continuation token.
+/// This distinguishes a top-level `let` from a column-0 local `let … in` (F*
+/// does not require bodies to be indented).
+fn collect_decls(blank_lines: &[&str]) -> Vec<DeclStart> {
+    let mut decls = Vec::new();
+    let mut pending_attr: Option<usize> = None;
+    let mut depth: i32 = 0; // (), [], {}, begin/end
+    let mut let_in: i32 = 0; // unclosed local `let`s awaiting `in`
+    let mut cont = false; // previous non-blank line ended on a continuation token
+
+    for (i, line) in blank_lines.iter().enumerate() {
+        let trimmed_end = line.trim_end();
+        if trimmed_end.trim_start().is_empty() {
+            // Blank line: attributes attach contiguously, so a gap clears them.
+            // It does not close an open term (a blank line inside a body is fine).
+            pending_attr = None;
+            continue;
+        }
+        let is_col0 = !trimmed_end.starts_with(char::is_whitespace);
+        // The previous declaration's term is still open if brackets are unbalanced,
+        // a local `let` awaits its `in`, or the last line ended mid-term.
+        let body_open = depth > 0 || let_in > 0 || cont;
+
+        // Text whose tokens feed the running counters: for a brand-new declaration
+        // we skip the leading keyword (so a top-level `let` is not counted as a
+        // pending local `let`); otherwise the whole (blanked) line.
+        let mut scan_text: String = trimmed_end.trim_start().to_string();
+
+        if is_col0 && !body_open {
+            match classify_head(trimmed_end) {
+                Head::Decl(kw, rest) => {
+                    let attr_start = pending_attr.take().unwrap_or(i);
+                    let_in = 0;
+                    // `rest` is the line with the keyword (and qualifiers) removed.
+                    scan_text.clone_from(&rest);
+                    decls.push(DeclStart {
+                        kw,
+                        line: i,
+                        attr_start,
+                        rest,
+                    });
+                }
+                Head::AttrOnly => {
+                    if pending_attr.is_none() {
+                        pending_attr = Some(i);
+                    }
+                }
+                Head::NotDecl => {
+                    pending_attr = None;
+                }
+            }
+        }
+
+        update_counters(&scan_text, &mut depth, &mut let_in);
+        cont = ends_with_continuation(&scan_text);
+    }
+    decls
+}
+
+/// Updates bracket depth and the local `let`…`in` balance from one line's tokens
+/// (operating on the comment/string-blanked text).
+fn update_counters(text: &str, depth: &mut i32, let_in: &mut i32) {
+    let mut word = String::new();
+    for c in text.chars() {
+        if is_ident_char(c) {
+            word.push(c);
+            continue;
+        }
+        apply_word(&word, c, depth, let_in);
+        word.clear();
+        match c {
+            '(' | '[' | '{' => *depth += 1,
+            ')' | ']' | '}' => *depth = (*depth - 1).max(0),
+            _ => {}
+        }
+    }
+    apply_word(&word, ' ', depth, let_in);
+}
+
+/// Applies a single identifier word to the bracket / `let`…`in` counters.
+/// `delim` is the character that terminated the word; a keyword immediately
+/// followed by an operator char (e.g. `let?`, `and*`) is a binding-operator
+/// token, not the keyword, so it is not counted.
+fn apply_word(w: &str, delim: char, depth: &mut i32, let_in: &mut i32) {
+    if is_op_char(delim) {
+        return;
+    }
+    match w {
+        "begin" => *depth += 1,
+        "end" => *depth = (*depth - 1).max(0),
+        "let" => *let_in += 1,
+        "in" => *let_in = (*let_in - 1).max(0),
+        _ => {}
+    }
+}
+
+/// Whether a (blanked) line ends on a token that requires the term to continue
+/// on the following line — an operator char, an open bracket / separator, or a
+/// continuation keyword. Used so a column-0 keyword that follows such a line is
+/// treated as a continuation rather than a new declaration.
+fn ends_with_continuation(text: &str) -> bool {
+    let t = text.trim_end();
+    let Some(last) = t.chars().last() else {
+        return false;
+    };
+    if is_op_char(last) || matches!(last, '(' | '[' | '{' | ',' | ';') {
+        return true;
+    }
+    // Trailing run of identifier characters (empty if `last` is e.g. `)`).
+    let mut rev: Vec<char> = t.chars().rev().take_while(|c| is_ident_char(*c)).collect();
+    rev.reverse();
+    let last_word: String = rev.into_iter().collect();
+    matches!(
+        last_word.as_str(),
+        "then"
+            | "else"
+            | "with"
+            | "begin"
+            | "fun"
+            | "match"
+            | "if"
+            | "in"
+            | "of"
+            | "requires"
+            | "ensures"
+            | "decreases"
+            | "let"
+            | "and"
+            | "when"
+            | "returns"
+            | "by"
+            | "forall"
+            | "exists"
+    )
+}
+
+/// Last line of declaration `i`'s body: the line before the next declaration's
+/// attribute block, with trailing blank lines trimmed.
+fn decl_end(decls: &[DeclStart], i: usize, blank_lines: &[&str]) -> usize {
+    let raw_end = if i + 1 < decls.len() {
+        decls[i + 1].attr_start.saturating_sub(1)
+    } else {
+        blank_lines.len().saturating_sub(1)
+    };
+    let mut end = raw_end.max(decls[i].line);
+    while end > decls[i].line {
+        let l = blank_lines.get(end).map_or("", |s| s.trim());
+        if l.is_empty() {
+            end -= 1;
+        } else {
+            break;
+        }
+    }
+    end
+}
+
+/// Collects a contiguous block of `///` doc-comment lines directly above
+/// `attr_start`, returning them joined (markers stripped).
+fn collect_docstring(raw_lines: &[&str], attr_start: usize) -> Option<String> {
+    let mut lines: Vec<String> = Vec::new();
+    let mut idx = attr_start;
+    while idx > 0 {
+        idx -= 1;
+        let t = raw_lines.get(idx).map_or("", |s| s.trim());
+        if let Some(rest) = t.strip_prefix("///") {
+            lines.push(rest.trim().to_string());
+        } else {
+            break;
+        }
+    }
+    if lines.is_empty() {
+        return None;
+    }
+    lines.reverse();
+    Some(lines.join("\n"))
+}
+
+/// Whether the declaration carries a `private` qualifier (scanning the attribute
+/// block through the keyword line).
+fn head_is_private(raw_lines: &[&str], attr_start: usize, kw_line: usize) -> bool {
+    (attr_start..=kw_line).any(|i| {
+        raw_lines
+            .get(i)
+            .is_some_and(|l| l.split(|c: char| !is_ident_char(c)).any(|w| w == "private"))
+    })
+}
+
+/// Replaces the contents of comments (`(* … *)`, nested; and `// …`) and string
+/// literals with spaces, preserving newlines and overall line structure so the
+/// structural scanner never trips over braces, `=`, `|` or `;` inside them.
+fn blank_comments_and_strings(source: &str) -> String {
+    #[derive(PartialEq)]
+    enum St {
+        Normal,
+        Line,
+        Block(u32),
+        Str,
+    }
+    let mut out = String::with_capacity(source.len());
+    let mut st = St::Normal;
+    let chars: Vec<char> = source.chars().collect();
+    let mut i = 0;
+    while i < chars.len() {
+        let c = chars[i];
+        let next = chars.get(i + 1).copied().unwrap_or('\0');
+        match st {
+            St::Normal => {
+                if c == '(' && next == '*' {
+                    st = St::Block(1);
+                    out.push(' ');
+                    out.push(' ');
+                    i += 2;
+                    continue;
+                }
+                if c == '/' && next == '/' {
+                    st = St::Line;
+                    out.push(' ');
+                    out.push(' ');
+                    i += 2;
+                    continue;
+                }
+                if c == '"' {
+                    st = St::Str;
+                    out.push(' ');
+                    i += 1;
+                    continue;
+                }
+                out.push(c);
+                i += 1;
+            }
+            St::Line => {
+                if c == '\n' {
+                    st = St::Normal;
+                    out.push('\n');
+                } else {
+                    out.push(' ');
+                }
+                i += 1;
+            }
+            St::Block(depth) => {
+                if c == '(' && next == '*' {
+                    st = St::Block(depth + 1);
+                    out.push(' ');
+                    out.push(' ');
+                    i += 2;
+                    continue;
+                }
+                if c == '*' && next == ')' {
+                    st = if depth == 1 { St::Normal } else { St::Block(depth - 1) };
+                    out.push(' ');
+                    out.push(' ');
+                    i += 2;
+                    continue;
+                }
+                out.push(if c == '\n' { '\n' } else { ' ' });
+                i += 1;
+            }
+            St::Str => {
+                if c == '\\' {
+                    // Escaped char: blank both, but preserve a newline if the
+                    // escape is at end of line (shouldn't normally happen).
+                    out.push(' ');
+                    if next == '\n' {
+                        out.push('\n');
+                    } else {
+                        out.push(' ');
+                    }
+                    i += 2;
+                    continue;
+                }
+                if c == '"' {
+                    st = St::Normal;
+                    out.push(' ');
+                    i += 1;
+                    continue;
+                }
+                out.push(if c == '\n' { '\n' } else { ' ' });
+                i += 1;
+            }
+        }
+    }
+    out
+}
+
+impl crate::extraction::LanguageExtractor for FStarExtractor {
+    fn extensions(&self) -> &[&str] {
+        &["fst", "fsti"]
+    }
+
+    fn language_name(&self) -> &'static str {
+        "F*"
+    }
+
+    fn extract(&self, file_path: &str, source: &str) -> ExtractionResult {
+        Self::extract_fstar(file_path, source)
+    }
+}

--- a/src/extraction/fstar_extractor.rs
+++ b/src/extraction/fstar_extractor.rs
@@ -1284,8 +1284,12 @@ fn blank_comments_and_strings(source: &str) -> String {
                     continue;
                 }
                 if c == '"' {
+                    // Preserve the quote characters (blank only the interior) so
+                    // a string-valued RHS like `let x = "y"` doesn't collapse to
+                    // a trailing `=` and look like an unterminated declaration
+                    // that swallows the following declaration.
                     st = St::Str;
-                    out.push(' ');
+                    out.push('"');
                     i += 1;
                     continue;
                 }
@@ -1334,7 +1338,7 @@ fn blank_comments_and_strings(source: &str) -> String {
                 }
                 if c == '"' {
                     st = St::Normal;
-                    out.push(' ');
+                    out.push('"');
                     i += 1;
                     continue;
                 }

--- a/src/extraction/mod.rs
+++ b/src/extraction/mod.rs
@@ -54,6 +54,8 @@ mod erlang_extractor;
 mod fortran_extractor;
 #[cfg(feature = "lang-fsharp")]
 mod fsharp_extractor;
+#[cfg(feature = "lang-fstar")]
+mod fstar_extractor;
 #[cfg(feature = "lang-glsl")]
 mod glsl_extractor;
 #[cfg(feature = "lang-gwbasic")]
@@ -149,6 +151,8 @@ pub use erlang_extractor::ErlangExtractor;
 pub use fortran_extractor::FortranExtractor;
 #[cfg(feature = "lang-fsharp")]
 pub use fsharp_extractor::FSharpExtractor;
+#[cfg(feature = "lang-fstar")]
+pub use fstar_extractor::FStarExtractor;
 #[cfg(feature = "lang-glsl")]
 pub use glsl_extractor::GlslExtractor;
 #[cfg(feature = "lang-gwbasic")]
@@ -315,6 +319,8 @@ impl LanguageRegistry {
         extractors.push(Box::new(ElixirExtractor));
         #[cfg(feature = "lang-fsharp")]
         extractors.push(Box::new(FSharpExtractor));
+        #[cfg(feature = "lang-fstar")]
+        extractors.push(Box::new(FStarExtractor));
         #[cfg(feature = "lang-lean")]
         extractors.push(Box::new(LeanExtractor));
         #[cfg(feature = "lang-toml")]

--- a/tests/fixtures/sample.fst
+++ b/tests/fixtures/sample.fst
@@ -1,0 +1,137 @@
+/// Comprehensive F* fixture for the tokensave extractor.
+///
+/// This file is a *syntactic* fixture — it exercises every construct the
+/// extractor understands and is deliberately not meant to typecheck.
+module Sample.Comprehensive
+
+open FStar.Mul
+include FStar.Tactics.V2
+module L = FStar.List.Tot.Base
+
+#set-options "--max_fuel 1 --max_ifuel 0 --z3rlimit 20"
+
+(* A block comment with a ) stray ( paren and a "quote" — must be ignored. *)
+
+/// A record type.
+type point = { x : int; y : int }
+
+/// An inductive type with several constructor shapes.
+type shape =
+  | Circle : radius:nat -> shape
+  | Rect of nat & nat
+  | Origin
+
+/// Mutually recursive inductive types.
+type tree =
+  | Leaf
+  | Branch of forest
+and forest =
+  | Nil
+  | Cons of tree & forest
+
+/// A parameterised type abbreviation.
+type predicate (a:Type) = a -> bool
+
+/// A typeclass: one [@@@no_method] field and one published method.
+class addable (a:Type) = {
+  [@@@no_method] zero : a;
+  add : a -> a -> a;
+}
+
+/// An instance of the typeclass.
+instance addable_int : addable int = {
+  zero = 0;
+  add = (fun x y -> x + y);
+}
+
+/// A definition that requires a resolved typeclass instance.
+let sum_with (#a:Type) {| d : addable a |} (x y : a) : a = d.add x y
+
+/// Record value construction via let (not a record *type*).
+let origin : point = { x = 0; y = 0 }
+
+/// A val declaration with no body.
+val is_zero : int -> bool
+
+/// A refinement-typed val.
+val abs : x:int -> y:int{y >= 0 /\ (y = x \/ y = -x)}
+
+/// A plain definition.
+let negate (x:int) : int = -x
+
+/// An unfold definition.
+unfold
+let twice (n:int) : int = n + n
+
+/// An irreducible definition.
+irreducible
+let magic : int = 42
+
+/// An inline_for_extraction, private definition.
+inline_for_extraction
+private
+let bump (n:int) : int = n + 1
+
+/// A lemma with requires / ensures / decreases.
+let rec fact_pos (n:nat) : Lemma (requires n >= 0) (ensures factorial n >= 1) (decreases n) =
+  if n = 0 then () else fact_pos (n - 1)
+
+/// A Pure definition with requires / ensures / decreases.
+let rec divmod (x:nat) (y:pos) : Pure nat (requires x >= 0) (ensures fun r -> r >= 0) (decreases x) =
+  if x < y then 0 else 1 + divmod (x - y) y
+
+/// A Tot definition with a decreases clause.
+let rec countdown (n:nat) : Tot nat (decreases n) =
+  if n = 0 then 0 else countdown (n - 1)
+
+/// A symbolic operator.
+let ( +^ ) (a b : int) : int = a + b
+
+/// A monadic binding operator.
+let ( let? ) (x : option 'a) (f : 'a -> option 'b) : option 'b =
+  match x with
+  | Some v -> f v
+  | None -> None
+
+/// Mutually recursive functions.
+let rec even (n:nat) : bool = if n = 0 then true else odd (n - 1)
+and odd (n:nat) : bool = if n = 0 then false else even (n - 1)
+
+/// An exception.
+exception Out_of_bounds
+
+/// An effect abbreviation.
+effect Id (a:Type) = Pure a (requires True) (ensures (fun _ -> True))
+
+/// A string literal carrying braces and parens must not be read as a record.
+let banner : string = "menu { open ( close ) }"
+
+/// A proof body using a local let, introduce/eliminate and calc — no phantom nodes.
+let comm_proof (x y : int) : Lemma (x + y == y + x) =
+  let z = x + y in
+  introduce exists (w:int). w == z
+  with z
+  and ();
+  calc (==) {
+    x + y;
+    == { () }
+    y + x;
+  }
+
+/// A lemma whose spec nests a local `let ... in` and an inline comment with stray parens.
+let spec_let (x : int) : Lemma (* note: ) ( mismatched *) (requires (let p = x > 0 in p)) (ensures x >= 0) =
+  ()
+
+#push-options "--z3rlimit 50 --split_queries no"
+/// Verified under pushed options.
+let heavy (a : int) : Lemma (requires a > 0) (ensures a * a > 0) = ()
+#pop-options
+
+/// An assume val axiom (the `val` keyword wins; this is a Function).
+assume val excluded_middle (p:Type0) : Lemma (p \/ ~p)
+
+/// A monadic let in a body (uses the let? operator defined above).
+let try_add (a b : option int) : option int =
+  let? x = a in
+  let? y = b in
+  Some (x + y)

--- a/tests/fstar_extraction_test.rs
+++ b/tests/fstar_extraction_test.rs
@@ -45,7 +45,12 @@ fn find_kind<'a>(result: &'a ExtractionResult, name: &str, kind: NodeKind) -> &'
         .nodes
         .iter()
         .find(|n| n.name == name && n.kind == kind)
-        .unwrap_or_else(|| panic!("{kind:?} {name} not found; have: {:?}", names_of_all(result)))
+        .unwrap_or_else(|| {
+            panic!(
+                "{kind:?} {name} not found; have: {:?}",
+                names_of_all(result)
+            )
+        })
 }
 
 fn sig(result: &ExtractionResult, name: &str) -> String {
@@ -141,14 +146,21 @@ fn type_like_sets_are_exact() {
     );
     assert_eq!(
         names_of(&r, NodeKind::Enum),
-        vec!["forest".to_string(), "shape".to_string(), "tree".to_string()]
+        vec![
+            "forest".to_string(),
+            "shape".to_string(),
+            "tree".to_string()
+        ]
     );
     assert_eq!(
         names_of(&r, NodeKind::TypeAlias),
         vec!["Id".to_string(), "predicate".to_string()]
     );
     assert_eq!(names_of(&r, NodeKind::Trait), vec!["addable".to_string()]);
-    assert_eq!(names_of(&r, NodeKind::Impl), vec!["addable_int".to_string()]);
+    assert_eq!(
+        names_of(&r, NodeKind::Impl),
+        vec!["addable_int".to_string()]
+    );
     assert_eq!(
         names_of(&r, NodeKind::Module),
         vec!["Sample.Comprehensive".to_string()]
@@ -195,7 +207,10 @@ fn inductive_type_is_enum_with_constructors() {
     let r = sample();
     assert_eq!(find(&r, "shape").kind, NodeKind::Enum);
     for v in ["Circle", "Rect", "Origin"] {
-        assert_eq!(find_kind(&r, v, NodeKind::EnumVariant).kind, NodeKind::EnumVariant);
+        assert_eq!(
+            find_kind(&r, v, NodeKind::EnumVariant).kind,
+            NodeKind::EnumVariant
+        );
         assert!(contains_edge(&r, "shape", v));
     }
 }
@@ -236,7 +251,11 @@ fn instance_is_impl_with_resolved_implements_edge() {
 fn definition_requiring_typeclass_binder() {
     let r = sample();
     assert_eq!(find(&r, "sum_with").kind, NodeKind::Function);
-    assert!(sig(&r, "sum_with").contains("{| d : addable a |}"), "{}", sig(&r, "sum_with"));
+    assert!(
+        sig(&r, "sum_with").contains("{| d : addable a |}"),
+        "{}",
+        sig(&r, "sum_with")
+    );
 }
 
 // ---------------------------------------------------------------------------
@@ -381,7 +400,10 @@ fn proof_body_with_calc_introduce_eliminate_has_no_phantom_nodes() {
     assert!(!funcs.contains(&"z".to_string()));
     assert!(!funcs.contains(&"w".to_string()));
     // Signature is the spec, not the proof term.
-    assert_eq!(sig(&r, "comm_proof"), "let comm_proof (x y : int) : Lemma (x + y == y + x)");
+    assert_eq!(
+        sig(&r, "comm_proof"),
+        "let comm_proof (x y : int) : Lemma (x + y == y + x)"
+    );
 }
 
 #[test]
@@ -389,7 +411,10 @@ fn local_let_in_and_inline_comment_inside_spec() {
     let s = sig(&sample(), "spec_let");
     assert!(s.contains("requires (let p = x > 0 in p)"), "{s}");
     assert!(s.contains("ensures x >= 0"), "{s}");
-    assert!(!s.contains("mismatched"), "comment leaked into signature: {s}");
+    assert!(
+        !s.contains("mismatched"),
+        "comment leaked into signature: {s}"
+    );
 }
 
 #[test]
@@ -407,12 +432,18 @@ fn monadic_let_in_body_is_not_a_top_level_decl() {
     let r = sample();
     let n = find(&r, "try_add");
     assert_eq!(n.kind, NodeKind::Function);
-    assert_eq!(sig(&r, "try_add"), "let try_add (a b : option int) : option int");
+    assert_eq!(
+        sig(&r, "try_add"),
+        "let try_add (a b : option int) : option int"
+    );
 }
 
 #[test]
 fn doc_comment_is_captured_as_docstring() {
-    let d = find(&sample(), "point").docstring.clone().unwrap_or_default();
+    let d = find(&sample(), "point")
+        .docstring
+        .clone()
+        .unwrap_or_default();
     assert!(d.contains("record type"), "docstring was: {d:?}");
 }
 
@@ -425,5 +456,8 @@ fn multiline_decl_span_covers_full_spec() {
     let r = sample();
     // `fact_pos` spans its keyword line through the multi-line spec/body.
     let n = find(&r, "fact_pos");
-    assert!(n.end_line > n.start_line, "span did not cover the spec/body");
+    assert!(
+        n.end_line > n.start_line,
+        "span did not cover the spec/body"
+    );
 }

--- a/tests/fstar_extraction_test.rs
+++ b/tests/fstar_extraction_test.rs
@@ -1,9 +1,18 @@
-use tokensave::extraction::FStarExtractor;
-use tokensave::extraction::LanguageExtractor;
+//! F* extractor tests.
+//!
+//! All assertions run against a single fixture, `tests/fixtures/sample.fst`,
+//! which exercises every construct the extractor understands. The fixture is
+//! embedded at compile time with `include_str!` (no runtime file I/O, resolved
+//! relative to this source file).
+
+use tokensave::extraction::{FStarExtractor, LanguageExtractor};
 use tokensave::types::*;
 
-fn extract(source: &str) -> ExtractionResult {
-    FStarExtractor.extract("Demo.fst", source)
+/// The comprehensive F* fixture, embedded at compile time.
+const SAMPLE: &str = include_str!("fixtures/sample.fst");
+
+fn sample() -> ExtractionResult {
+    FStarExtractor.extract("Demo.fst", SAMPLE)
 }
 
 fn names_of(result: &ExtractionResult, kind: NodeKind) -> Vec<String> {
@@ -17,6 +26,10 @@ fn names_of(result: &ExtractionResult, kind: NodeKind) -> Vec<String> {
     v
 }
 
+fn names_of_all(result: &ExtractionResult) -> Vec<String> {
+    result.nodes.iter().map(|n| n.name.clone()).collect()
+}
+
 fn find<'a>(result: &'a ExtractionResult, name: &str) -> &'a Node {
     result
         .nodes
@@ -25,8 +38,18 @@ fn find<'a>(result: &'a ExtractionResult, name: &str) -> &'a Node {
         .unwrap_or_else(|| panic!("node {name} not found; have: {:?}", names_of_all(result)))
 }
 
-fn names_of_all(result: &ExtractionResult) -> Vec<String> {
-    result.nodes.iter().map(|n| n.name.clone()).collect()
+/// A node looked up by both name and kind (names like `add`/`x` are reused
+/// across kinds, e.g. a field vs a function).
+fn find_kind<'a>(result: &'a ExtractionResult, name: &str, kind: NodeKind) -> &'a Node {
+    result
+        .nodes
+        .iter()
+        .find(|n| n.name == name && n.kind == kind)
+        .unwrap_or_else(|| panic!("{kind:?} {name} not found; have: {:?}", names_of_all(result)))
+}
+
+fn sig(result: &ExtractionResult, name: &str) -> String {
+    find(result, name).signature.clone().unwrap_or_default()
 }
 
 fn contains_edge(result: &ExtractionResult, src: &str, tgt: &str) -> bool {
@@ -38,8 +61,17 @@ fn contains_edge(result: &ExtractionResult, src: &str, tgt: &str) -> bool {
         .any(|e| e.source == s.id && e.target == t.id && e.kind == EdgeKind::Contains)
 }
 
+fn implements(result: &ExtractionResult, impl_name: &str, class: &str) -> bool {
+    let n = find(result, impl_name);
+    result.unresolved_refs.iter().any(|r| {
+        r.from_node_id == n.id
+            && r.reference_kind == EdgeKind::Implements
+            && r.reference_name == class
+    })
+}
+
 // ---------------------------------------------------------------------------
-// Basic metadata
+// Extractor metadata (no source needed)
 // ---------------------------------------------------------------------------
 
 #[test]
@@ -54,257 +86,130 @@ fn language_name_is_fstar() {
 
 #[test]
 fn empty_file_produces_only_file_node() {
-    let result = extract("");
+    let result = FStarExtractor.extract("Demo.fst", "");
     assert_eq!(result.nodes.len(), 1);
     assert_eq!(result.nodes[0].kind, NodeKind::File);
     assert!(result.errors.is_empty());
 }
 
 // ---------------------------------------------------------------------------
-// Module, open, include, module abbreviations
+// The fixture parses cleanly and yields exactly the expected symbol sets.
+// These two tests are the backstop against phantom nodes from proof-body sugar.
 // ---------------------------------------------------------------------------
 
 #[test]
-fn module_declaration_is_module_and_scopes_children() {
-    let source = "module FStar.Demo\n\nlet x = 1\n";
-    let result = extract(source);
-    let m = find(&result, "FStar.Demo");
+fn fixture_extracts_without_errors() {
+    assert!(sample().errors.is_empty(), "errors: {:?}", sample().errors);
+}
+
+#[test]
+fn function_set_is_exact_no_phantoms() {
+    let r = sample();
+    let mut expected = vec![
+        "sum_with",
+        "origin",
+        "is_zero",
+        "abs",
+        "negate",
+        "twice",
+        "magic",
+        "bump",
+        "fact_pos",
+        "divmod",
+        "countdown",
+        "+^",
+        "let?",
+        "even",
+        "odd",
+        "banner",
+        "comm_proof",
+        "spec_let",
+        "heavy",
+        "excluded_middle",
+        "try_add",
+    ];
+    expected.sort_unstable();
+    assert_eq!(names_of(&r, NodeKind::Function), expected);
+}
+
+#[test]
+fn type_like_sets_are_exact() {
+    let r = sample();
+    assert_eq!(
+        names_of(&r, NodeKind::Struct),
+        vec!["Out_of_bounds".to_string(), "point".to_string()]
+    );
+    assert_eq!(
+        names_of(&r, NodeKind::Enum),
+        vec!["forest".to_string(), "shape".to_string(), "tree".to_string()]
+    );
+    assert_eq!(
+        names_of(&r, NodeKind::TypeAlias),
+        vec!["Id".to_string(), "predicate".to_string()]
+    );
+    assert_eq!(names_of(&r, NodeKind::Trait), vec!["addable".to_string()]);
+    assert_eq!(names_of(&r, NodeKind::Impl), vec!["addable_int".to_string()]);
+    assert_eq!(
+        names_of(&r, NodeKind::Module),
+        vec!["Sample.Comprehensive".to_string()]
+    );
+}
+
+// ---------------------------------------------------------------------------
+// Module, open / include / friend, module abbreviations
+// ---------------------------------------------------------------------------
+
+#[test]
+fn module_is_file_scope_and_parents_children() {
+    let r = sample();
+    let m = find(&r, "Sample.Comprehensive");
     assert_eq!(m.kind, NodeKind::Module);
-    assert_eq!(m.qualified_name, "Demo.fst::FStar.Demo");
-    // `x` is parented to the module, not the file.
-    assert!(contains_edge(&result, "FStar.Demo", "x"));
-    let x = find(&result, "x");
-    assert_eq!(x.qualified_name, "Demo.fst::FStar.Demo::x");
+    assert!(contains_edge(&r, "Sample.Comprehensive", "point"));
+    assert!(contains_edge(&r, "Sample.Comprehensive", "fact_pos"));
 }
 
 #[test]
-fn open_emits_uses_edge() {
-    let source = "module M\nopen FStar.List.Tot\nlet x = 1\n";
-    let result = extract(source);
-    let uses: Vec<_> = result
-        .edges
-        .iter()
-        .filter(|e| e.kind == EdgeKind::Uses)
-        .collect();
-    assert_eq!(uses.len(), 1);
-}
-
-#[test]
-fn open_with_restriction_emits_single_uses_edge() {
-    let source = "module M\nopen FStar.Fin { fin }\nlet x = 1\n";
-    let result = extract(source);
-    let uses = result
-        .edges
-        .iter()
-        .filter(|e| e.kind == EdgeKind::Uses)
-        .count();
-    assert_eq!(uses, 1);
-}
-
-#[test]
-fn module_abbreviation_emits_uses_edge_not_module_node() {
-    let source = "module M\nmodule CE = FStar.Algebra.CommMonoid.Equiv\nlet x = 1\n";
-    let result = extract(source);
-    // Only one Module node (the file module M).
-    assert_eq!(names_of(&result, NodeKind::Module), vec!["M".to_string()]);
-    let uses = result
-        .edges
-        .iter()
-        .filter(|e| e.kind == EdgeKind::Uses)
-        .count();
-    assert_eq!(uses, 1);
-}
-
-#[test]
-fn include_and_friend_emit_uses_edges() {
-    let source = "module M\ninclude FStar.A\nfriend FStar.B\nlet x = 1\n";
-    let result = extract(source);
-    let uses = result
-        .edges
-        .iter()
-        .filter(|e| e.kind == EdgeKind::Uses)
-        .count();
-    assert_eq!(uses, 2);
+fn open_include_and_abbrev_emit_three_uses_edges() {
+    // `open FStar.Mul`, `include FStar.Tactics.V2`, `module L = FStar...`.
+    let r = sample();
+    let uses = r.edges.iter().filter(|e| e.kind == EdgeKind::Uses).count();
+    assert_eq!(uses, 3, "expected open + include + abbrev");
+    // The abbreviation does not create a Module node.
+    assert!(!r.nodes.iter().any(|n| n.name == "L"));
 }
 
 // ---------------------------------------------------------------------------
-// let / val / and
-// ---------------------------------------------------------------------------
-
-#[test]
-fn let_is_function() {
-    let source = "module M\nlet square (n:int) : int = n * n\n";
-    let result = extract(source);
-    assert!(names_of(&result, NodeKind::Function).contains(&"square".to_string()));
-}
-
-#[test]
-fn val_is_function() {
-    let source = "module M\nval foo (a b : int) : Lemma (a + b == b + a)\n";
-    let result = extract(source);
-    assert!(names_of(&result, NodeKind::Function).contains(&"foo".to_string()));
-}
-
-#[test]
-fn let_rec_skips_rec_keyword() {
-    let source = "module M\nlet rec fact (n:nat) : nat = if n = 0 then 1 else n * fact (n - 1)\n";
-    let result = extract(source);
-    let funcs = names_of(&result, NodeKind::Function);
-    assert!(funcs.contains(&"fact".to_string()));
-    assert!(!funcs.contains(&"rec".to_string()));
-}
-
-#[test]
-fn operator_let_uses_operator_symbol_as_name() {
-    let source = "module M\nlet ( ++ ) x y = x + y\nlet ( =~ ) a b = a == b\n";
-    let result = extract(source);
-    let funcs = names_of(&result, NodeKind::Function);
-    assert!(funcs.contains(&"++".to_string()), "have: {funcs:?}");
-    assert!(funcs.contains(&"=~".to_string()), "have: {funcs:?}");
-}
-
-#[test]
-fn mutually_recursive_and_creates_two_functions() {
-    let source = "module M\n\
-                  let rec even (n:nat) : bool = if n = 0 then true else odd (n - 1)\n\
-                  and odd (n:nat) : bool = if n = 0 then false else even (n - 1)\n";
-    let result = extract(source);
-    let funcs = names_of(&result, NodeKind::Function);
-    assert!(funcs.contains(&"even".to_string()));
-    assert!(funcs.contains(&"odd".to_string()));
-}
-
-#[test]
-fn multiline_val_then_let_are_distinct() {
-    let source = "module M\n\
-                  val eq_mult_one (a b:int) : Lemma\n\
-                  \x20 (requires a * b = 1)\n\
-                  \x20 (ensures (a = 1 /\\ b = 1) \\/ (a = -1 /\\ b = -1))\n\
-                  let eq_mult_one a b = ()\n";
-    let result = extract(source);
-    // Two functions named eq_mult_one (the val and the let), no phantom nodes
-    // from the indented requires/ensures lines.
-    let funcs: Vec<_> = result
-        .nodes
-        .iter()
-        .filter(|n| n.kind == NodeKind::Function && n.name == "eq_mult_one")
-        .collect();
-    assert_eq!(funcs.len(), 2, "have: {:?}", names_of_all(&result));
-}
-
-// ---------------------------------------------------------------------------
-// Records, variants, type aliases
+// Types: records, inductives, mutual recursion, abbreviations
 // ---------------------------------------------------------------------------
 
 #[test]
 fn record_type_is_struct_with_fields() {
-    let source = "module M\n\
-                  type point = {\n\
-                  \x20 x : int;\n\
-                  \x20 y : int;\n\
-                  }\n";
-    let result = extract(source);
-    assert_eq!(names_of(&result, NodeKind::Struct), vec!["point".to_string()]);
-    assert_eq!(
-        names_of(&result, NodeKind::Field),
-        vec!["x".to_string(), "y".to_string()]
-    );
-    assert!(contains_edge(&result, "point", "x"));
-    assert!(contains_edge(&result, "point", "y"));
+    let r = sample();
+    assert_eq!(find(&r, "point").kind, NodeKind::Struct);
+    assert!(contains_edge(&r, "point", "x"));
+    assert!(contains_edge(&r, "point", "y"));
 }
 
 #[test]
-fn record_with_params_and_function_fields() {
-    let source = "module M\n\
-                  noeq\n\
-                  type bijection (a b : Type) = {\n\
-                  \x20 right : a -> GTot b;\n\
-                  \x20 left  : b -> GTot a;\n\
-                  \x20 left_right : x:a -> squash (left (right x) == x);\n\
-                  }\n";
-    let result = extract(source);
-    assert_eq!(
-        names_of(&result, NodeKind::Struct),
-        vec!["bijection".to_string()]
-    );
-    let fields = names_of(&result, NodeKind::Field);
-    assert_eq!(
-        fields,
-        vec![
-            "left".to_string(),
-            "left_right".to_string(),
-            "right".to_string()
-        ]
-    );
+fn inductive_type_is_enum_with_constructors() {
+    let r = sample();
+    assert_eq!(find(&r, "shape").kind, NodeKind::Enum);
+    for v in ["Circle", "Rect", "Origin"] {
+        assert_eq!(find_kind(&r, v, NodeKind::EnumVariant).kind, NodeKind::EnumVariant);
+        assert!(contains_edge(&r, "shape", v));
+    }
 }
 
 #[test]
-fn record_body_brace_on_next_line() {
-    let source = "module M\n\
-                  type t =\n\
-                  {\n\
-                  \x20 a : int;\n\
-                  \x20 b : bool;\n\
-                  }\n";
-    let result = extract(source);
-    assert_eq!(names_of(&result, NodeKind::Struct), vec!["t".to_string()]);
-    assert_eq!(
-        names_of(&result, NodeKind::Field),
-        vec!["a".to_string(), "b".to_string()]
-    );
+fn mutually_recursive_types_via_and() {
+    let r = sample();
+    assert_eq!(find(&r, "tree").kind, NodeKind::Enum);
+    assert_eq!(find(&r, "forest").kind, NodeKind::Enum); // introduced by `and`
 }
 
 #[test]
-fn variant_type_is_enum_with_constructors() {
-    let source = "module M\n\
-                  type color =\n\
-                  \x20 | Red\n\
-                  \x20 | Green\n\
-                  \x20 | Blue\n";
-    let result = extract(source);
-    assert_eq!(names_of(&result, NodeKind::Enum), vec!["color".to_string()]);
-    assert_eq!(
-        names_of(&result, NodeKind::EnumVariant),
-        vec!["Blue".to_string(), "Green".to_string(), "Red".to_string()]
-    );
-    assert!(contains_edge(&result, "color", "Red"));
-}
-
-#[test]
-fn variant_with_constructor_args() {
-    let source = "module M\n\
-                  type tree =\n\
-                  \x20 | Leaf\n\
-                  \x20 | Node of tree * int * tree\n";
-    let result = extract(source);
-    assert_eq!(
-        names_of(&result, NodeKind::EnumVariant),
-        vec!["Leaf".to_string(), "Node".to_string()]
-    );
-}
-
-#[test]
-fn type_alias_is_type_alias() {
-    let source = "module M\ntype nat32 = x:int{x >= 0 /\\ x < 4_294_967_296}\n";
-    let result = extract(source);
-    assert_eq!(
-        names_of(&result, NodeKind::TypeAlias),
-        vec!["nat32".to_string()]
-    );
-    // A refinement brace must not be mistaken for a record.
-    assert!(names_of(&result, NodeKind::Struct).is_empty());
-    assert!(names_of(&result, NodeKind::Field).is_empty());
-}
-
-#[test]
-fn mutually_recursive_types_with_and() {
-    let source = "module M\n\
-                  type even = | EZ | ES of odd\n\
-                  and odd = | OS of even\n";
-    let result = extract(source);
-    let enums = names_of(&result, NodeKind::Enum);
-    assert!(enums.contains(&"even".to_string()));
-    assert!(enums.contains(&"odd".to_string()));
+fn type_abbreviation_is_type_alias() {
+    assert_eq!(find(&sample(), "predicate").kind, NodeKind::TypeAlias);
 }
 
 // ---------------------------------------------------------------------------
@@ -312,779 +217,213 @@ fn mutually_recursive_types_with_and() {
 // ---------------------------------------------------------------------------
 
 #[test]
-fn class_is_trait_with_method_fields() {
-    let source = "module M\n\
-                  class additive a = {\n\
-                  \x20 zero : a;\n\
-                  \x20 plus : a -> a -> a;\n\
-                  }\n";
-    let result = extract(source);
-    assert_eq!(
-        names_of(&result, NodeKind::Trait),
-        vec!["additive".to_string()]
-    );
-    assert_eq!(
-        names_of(&result, NodeKind::Field),
-        vec!["plus".to_string(), "zero".to_string()]
-    );
-    assert!(contains_edge(&result, "additive", "zero"));
+fn class_is_trait_with_published_and_no_method_fields() {
+    let r = sample();
+    assert_eq!(find(&r, "addable").kind, NodeKind::Trait);
+    // Both the `[@@@no_method]` field and the published method are extracted.
+    assert!(contains_edge(&r, "addable", "zero"));
+    assert!(contains_edge(&r, "addable", "add"));
 }
 
 #[test]
-fn instance_is_impl() {
-    let source = "module M\n\
-                  instance add_int : additive int = {\n\
-                  \x20 zero = 0;\n\
-                  \x20 plus = (+);\n\
-                  }\n";
-    let result = extract(source);
-    assert_eq!(
-        names_of(&result, NodeKind::Impl),
-        vec!["add_int".to_string()]
-    );
-    // The instance body assignments must not become fields.
-    assert!(names_of(&result, NodeKind::Field).is_empty());
+fn instance_is_impl_with_resolved_implements_edge() {
+    let r = sample();
+    assert_eq!(find(&r, "addable_int").kind, NodeKind::Impl);
+    assert!(implements(&r, "addable_int", "addable"));
 }
 
 #[test]
-fn instance_records_implements_reference() {
-    let source = "module M\ninstance add_int : additive int = { zero = 0; plus = (+); }\n";
-    let result = extract(source);
-    let impl_node = find(&result, "add_int");
-    assert!(result
-        .unresolved_refs
-        .iter()
-        .any(|r| r.from_node_id == impl_node.id
-            && r.reference_kind == EdgeKind::Implements
-            && r.reference_name == "additive"));
+fn definition_requiring_typeclass_binder() {
+    let r = sample();
+    assert_eq!(find(&r, "sum_with").kind, NodeKind::Function);
+    assert!(sig(&r, "sum_with").contains("{| d : addable a |}"), "{}", sig(&r, "sum_with"));
 }
 
 // ---------------------------------------------------------------------------
-// exception / assume / effect
+// let / val / qualifiers / record value
 // ---------------------------------------------------------------------------
 
 #[test]
-fn exception_is_struct() {
-    let source = "module M\nexception NotFound\nexception Bad of string\n";
-    let result = extract(source);
-    let structs = names_of(&result, NodeKind::Struct);
-    assert!(structs.contains(&"NotFound".to_string()));
-    assert!(structs.contains(&"Bad".to_string()));
+fn record_value_let_is_a_function_not_a_type() {
+    let r = sample();
+    let origin = find(&r, "origin");
+    assert_eq!(origin.kind, NodeKind::Function);
+    // Signature stops at `=`; the `{ x = 0; y = 0 }` literal is the body.
+    assert_eq!(sig(&r, "origin"), "let origin : point");
 }
 
 #[test]
-fn assume_val_is_function() {
-    let source = "module M\nassume val opaque_fn (x:int) : int\n";
-    let result = extract(source);
-    assert!(names_of(&result, NodeKind::Function).contains(&"opaque_fn".to_string()));
+fn val_declaration_is_a_function() {
+    let r = sample();
+    assert_eq!(find(&r, "is_zero").kind, NodeKind::Function);
+    assert_eq!(sig(&r, "is_zero"), "val is_zero : int -> bool");
 }
 
 #[test]
-fn assume_declaration_is_const() {
-    let source = "module M\nassume Axiom1 : 1 + 1 == 2\n";
-    let result = extract(source);
-    assert!(names_of(&result, NodeKind::Const).contains(&"Axiom1".to_string()));
+fn refinement_type_preserved_in_val_signature() {
+    let s = sig(&sample(), "abs");
+    assert!(s.contains("y:int{y >= 0"), "{s}");
 }
 
 #[test]
-fn effect_abbreviation_is_type_alias() {
-    let source = "module M\neffect St (a:Type) = ST a (fun _ -> True) (fun _ _ _ -> True)\n";
-    let result = extract(source);
-    assert!(names_of(&result, NodeKind::TypeAlias).contains(&"St".to_string()));
-}
-
-// ---------------------------------------------------------------------------
-// Qualifiers and attributes
-// ---------------------------------------------------------------------------
-
-#[test]
-fn private_qualifier_sets_visibility() {
-    let source = "module M\nprivate let helper x = x + 1\n";
-    let result = extract(source);
-    let helper = find(&result, "helper");
-    assert_eq!(helper.visibility, Visibility::Private);
-}
-
-#[test]
-fn attribute_block_above_decl_is_attrs_start() {
-    let source = "module M\n\
-                  [@@erasable]\n\
-                  noeq\n\
-                  type t = { a : int; }\n";
-    let result = extract(source);
-    let t = find(&result, "t");
-    assert_eq!(t.kind, NodeKind::Struct);
-    // attrs_start_line points at the `[@@erasable]` line (index 1).
-    assert_eq!(t.attrs_start_line, 1);
-    assert!(t.start_line > t.attrs_start_line);
-}
-
-#[test]
-fn inline_for_extraction_qualifier_does_not_break_name() {
-    let source = "module M\ninline_for_extraction\nlet f x = x\n";
-    let result = extract(source);
-    assert!(names_of(&result, NodeKind::Function).contains(&"f".to_string()));
-}
-
-#[test]
-fn doc_comment_is_captured() {
-    let source = "module M\n/// This is a helper.\n/// Second line.\nlet helper x = x\n";
-    let result = extract(source);
-    let helper = find(&result, "helper");
-    assert_eq!(
-        helper.docstring.as_deref(),
-        Some("This is a helper.\nSecond line.")
-    );
-}
-
-// ---------------------------------------------------------------------------
-// Pragmas / directives are ignored
-// ---------------------------------------------------------------------------
-
-#[test]
-fn set_and_push_options_pragmas_are_ignored() {
-    let source = "module M\n\
-                  #set-options \"--max_fuel 1 --z3rlimit 50\"\n\
-                  #push-options \"--split_queries no\"\n\
-                  let lemma_x () : Lemma (True) = ()\n\
-                  #pop-options\n\
-                  #restart-solver\n";
-    let result = extract(source);
-    assert!(result.errors.is_empty());
-    // The pragma strings (which contain no decl keywords) yield no nodes.
-    let funcs = names_of(&result, NodeKind::Function);
-    assert_eq!(funcs, vec!["lemma_x".to_string()]);
-}
-
-// ---------------------------------------------------------------------------
-// Term-level constructs inside bodies must not produce phantom nodes
-// ---------------------------------------------------------------------------
-
-#[test]
-fn calc_block_inside_let_yields_only_outer_function() {
-    let source = "module M\n\
-                  let proof (x:int) : Lemma (x + 0 == x) =\n\
-                  \x20 calc (==) {\n\
-                  \x20   x + 0;\n\
-                  \x20   == { () }\n\
-                  \x20   x;\n\
-                  \x20 }\n";
-    let result = extract(source);
-    let funcs = names_of(&result, NodeKind::Function);
-    assert_eq!(funcs, vec!["proof".to_string()]);
-    // The `{ ... }` of the calc block must not be parsed as a record.
-    assert!(names_of(&result, NodeKind::Field).is_empty());
-}
-
-#[test]
-fn eliminate_introduce_inside_let_yields_only_outer_function() {
-    let source = "module M\n\
-                  let divides_transitive a b c =\n\
-                  \x20 eliminate exists q1. b == q1 * a\n\
-                  \x20 returns a `divides` c\n\
-                  \x20 with _pf.\n\
-                  \x20   introduce exists q. c == q * a\n\
-                  \x20   with (q1 * q2)\n\
-                  \x20   and ()\n";
-    let result = extract(source);
-    let funcs = names_of(&result, NodeKind::Function);
-    assert_eq!(funcs, vec!["divides_transitive".to_string()]);
-}
-
-#[test]
-fn local_let_in_is_not_a_top_level_function() {
-    let source = "module M\n\
-                  let outer x =\n\
-                  \x20 let y = x + 1 in\n\
-                  \x20 let z = y * 2 in\n\
-                  \x20 z\n";
-    let result = extract(source);
-    let funcs = names_of(&result, NodeKind::Function);
-    assert_eq!(funcs, vec!["outer".to_string()]);
-    assert!(!funcs.contains(&"y".to_string()));
-    assert!(!funcs.contains(&"z".to_string()));
-}
-
-#[test]
-fn record_literal_in_let_body_is_not_a_record_type() {
-    // A `let` whose value is a record literal (with its closing brace in
-    // column 0) must not create a Struct or Field nodes.
-    let source = "module M\n\
-                  let mk : point =\n\
-                  {\n\
-                  \x20 x = 1;\n\
-                  \x20 y = 2;\n\
-                  }\n";
-    let result = extract(source);
-    assert!(names_of(&result, NodeKind::Struct).is_empty());
-    assert!(names_of(&result, NodeKind::Field).is_empty());
-    assert!(names_of(&result, NodeKind::Function).contains(&"mk".to_string()));
-}
-
-#[test]
-fn comments_do_not_confuse_parser() {
-    let source = "module M\n\
-                  (* type fake = { a : int; } *)\n\
-                  let real x = x // let alsofake = 1\n\
-                  (* nested (* comment *) still comment *)\n\
-                  let real2 x = x\n";
-    let result = extract(source);
-    let funcs = names_of(&result, NodeKind::Function);
-    assert_eq!(funcs, vec!["real".to_string(), "real2".to_string()]);
-    assert!(names_of(&result, NodeKind::Struct).is_empty());
-}
-
-#[test]
-fn string_with_braces_does_not_confuse_record_detection() {
-    let source = "module M\nlet msg = \"a record { x : int }\"\n";
-    let result = extract(source);
-    assert!(names_of(&result, NodeKind::Function).contains(&"msg".to_string()));
-    assert!(names_of(&result, NodeKind::Struct).is_empty());
-}
-
-// ---------------------------------------------------------------------------
-// A larger, realistic file
-// ---------------------------------------------------------------------------
-
-#[test]
-fn realistic_file_extracts_expected_symbols() {
-    let source = "module FStar.Demo\n\
-                  \n\
-                  open FStar.List.Tot\n\
-                  module L = FStar.List.Tot.Base\n\
-                  \n\
-                  /// A typeclass for addition.\n\
-                  class additive a = {\n\
-                  \x20 zero : a;\n\
-                  \x20 plus : a -> a -> a;\n\
-                  }\n\
-                  \n\
-                  instance add_int : additive int = {\n\
-                  \x20 zero = 0;\n\
-                  \x20 plus = (+);\n\
-                  }\n\
-                  \n\
-                  type color = | Red | Green | Blue\n\
-                  \n\
-                  noeq\n\
-                  type pair (a b : Type) = {\n\
-                  \x20 fst : a;\n\
-                  \x20 snd : b;\n\
-                  }\n\
-                  \n\
-                  #set-options \"--z3rlimit 20\"\n\
-                  \n\
-                  val add_comm (a b : int) : Lemma (a + b == b + a)\n\
-                  let add_comm a b = ()\n\
-                  \n\
-                  let rec sum (l : list int) : int =\n\
-                  \x20 match l with\n\
-                  \x20 | [] -> 0\n\
-                  \x20 | hd :: tl -> hd + sum tl\n";
-    let result = extract(source);
-    assert!(result.errors.is_empty(), "errors: {:?}", result.errors);
-
-    assert_eq!(
-        names_of(&result, NodeKind::Module),
-        vec!["FStar.Demo".to_string()]
-    );
-    assert_eq!(
-        names_of(&result, NodeKind::Trait),
-        vec!["additive".to_string()]
-    );
-    assert_eq!(
-        names_of(&result, NodeKind::Impl),
-        vec!["add_int".to_string()]
-    );
-    assert_eq!(names_of(&result, NodeKind::Enum), vec!["color".to_string()]);
-    assert_eq!(names_of(&result, NodeKind::Struct), vec!["pair".to_string()]);
-
-    let funcs = names_of(&result, NodeKind::Function);
-    assert!(funcs.contains(&"add_comm".to_string()));
-    assert!(funcs.contains(&"sum".to_string()));
-
-    // Two Uses edges: open + module abbreviation.
-    let uses = result
-        .edges
-        .iter()
-        .filter(|e| e.kind == EdgeKind::Uses)
-        .count();
-    assert_eq!(uses, 2);
-
-    // Everything is parented under the module.
-    assert!(contains_edge(&result, "FStar.Demo", "additive"));
-    assert!(contains_edge(&result, "FStar.Demo", "sum"));
-}
-
-// ---------------------------------------------------------------------------
-// Signatures must capture the spec (requires / ensures / decreases / refinements)
-// ---------------------------------------------------------------------------
-
-#[test]
-fn val_signature_includes_requires_and_ensures() {
-    let source = "module M\n\
-                  val eq_mult_one (a b:int) : Lemma\n\
-                  \x20 (requires a * b = 1)\n\
-                  \x20 (ensures (a = 1 /\\ b = 1) \\/ (a = -1 /\\ b = -1))\n";
-    let result = extract(source);
-    let f = find(&result, "eq_mult_one");
-    let sig = f.signature.as_deref().unwrap_or("");
-    assert!(sig.contains("requires a * b = 1"), "signature was: {sig}");
-    assert!(sig.contains("ensures"), "signature was: {sig}");
-    assert!(sig.contains("Lemma"), "signature was: {sig}");
-}
-
-#[test]
-fn let_lemma_signature_has_spec_but_not_proof_body() {
-    let source = "module M\n\
-                  let lemma_pos (x:int)\n\
-                  \x20 : Lemma (requires x > 0) (ensures x >= 0)\n\
-                  \x20 = assert (x >= 0)\n";
-    let result = extract(source);
-    let f = find(&result, "lemma_pos");
-    let sig = f.signature.as_deref().unwrap_or("");
-    assert!(sig.contains("requires x > 0"), "signature was: {sig}");
-    assert!(sig.contains("ensures x >= 0"), "signature was: {sig}");
-    // The proof term after `=` must NOT be part of the signature.
-    assert!(!sig.contains("assert"), "signature leaked the body: {sig}");
-}
-
-#[test]
-fn refinement_type_is_preserved_in_signature() {
-    let source = "module M\nval to_nat (x:int) : y:int{y >= 0 /\\ y >= x}\n";
-    let result = extract(source);
-    let f = find(&result, "to_nat");
-    let sig = f.signature.as_deref().unwrap_or("");
-    assert!(sig.contains("y >= 0"), "signature was: {sig}");
-    assert!(sig.contains("{"), "refinement braces dropped: {sig}");
-}
-
-#[test]
-fn decreases_clause_preserved_in_signature() {
-    let source = "module M\n\
-                  let rec ackermann (m n:nat) : Tot nat (decreases %[m; n]) =\n\
-                  \x20 if m = 0 then n + 1 else 0\n";
-    let result = extract(source);
-    let f = find(&result, "ackermann");
-    let sig = f.signature.as_deref().unwrap_or("");
-    assert!(sig.contains("decreases"), "signature was: {sig}");
-    assert!(!sig.contains("if m = 0"), "signature leaked the body: {sig}");
-}
-
-#[test]
-fn tot_effect_with_decreases_is_captured() {
-    // A non-lemma recursive function with a `Tot _ (decreases _)` annotation.
-    let source = "module M\n\
-                  let rec fp_enum_from (p:int{p > 1}) (lo:nat{lo <= p})\n\
-                  \x20 : Tot (list (fp p)) (decreases (p - lo))\n\
-                  \x20 = if lo = p then [] else mk lo :: fp_enum_from p (lo + 1)\n";
-    let result = extract(source);
-    let sig = find(&result, "fp_enum_from").signature.clone().unwrap_or_default();
-    assert!(sig.contains("Tot (list (fp p))"), "signature was: {sig}");
-    assert!(sig.contains("decreases (p - lo)"), "signature was: {sig}");
-    assert!(!sig.contains("if lo = p"), "signature leaked the body: {sig}");
-}
-
-#[test]
-fn pure_effect_with_requires_ensures_is_captured() {
-    // A non-lemma function with `Pure _ (requires _) (ensures _)`.
-    let source = "module M\n\
-                  let fp_inv_member (p:int{is_prime p}) (x: fp p)\n\
-                  \x20 : Pure (fp p) (requires x <> 0) (ensures fun y -> y <> 0)\n\
-                  \x20 = compute_inverse p x\n";
-    let result = extract(source);
-    let sig = find(&result, "fp_inv_member").signature.clone().unwrap_or_default();
-    assert!(sig.contains("Pure (fp p)"), "signature was: {sig}");
-    assert!(sig.contains("requires x <> 0"), "signature was: {sig}");
-    assert!(sig.contains("ensures fun y -> y <> 0"), "signature was: {sig}");
-    assert!(!sig.contains("compute_inverse"), "signature leaked the body: {sig}");
-}
-
-#[test]
-fn stateful_effect_signature_is_captured() {
-    // Stack/ST style effect with pre/post predicates (no `requires`/`ensures`
-    // keywords) is still part of the type and captured verbatim.
-    let source = "module M\n\
-                  let push (x:int) : Stack unit (fun _ -> True) (fun h0 _ h1 -> modifies !{} h0 h1)\n\
-                  \x20 = ()\n";
-    let result = extract(source);
-    let sig = find(&result, "push").signature.clone().unwrap_or_default();
-    assert!(sig.contains("Stack unit"), "signature was: {sig}");
-    assert!(sig.contains("modifies"), "signature was: {sig}");
-}
-
-#[test]
-fn local_let_in_inside_lemma_spec_is_kept_and_cut_correctly() {
-    // The `=` inside `let z = x + y` lives inside `Lemma ( ... )` (depth >= 1),
-    // so it must NOT be taken as the body separator. The whole spec is kept,
-    // the proof term is dropped, and no phantom `z` node appears.
-    let source =
-        "module M\nlet test (x y: t) : Lemma (let z = x + y in some_prop z) = proof_term\n";
-    let result = extract(source);
-    let funcs = names_of(&result, NodeKind::Function);
-    assert_eq!(funcs, vec!["test".to_string()], "phantom node? {funcs:?}");
-    let sig = find(&result, "test").signature.clone().unwrap_or_default();
-    assert!(
-        sig.contains("Lemma (let z = x + y in some_prop z)"),
-        "signature was: {sig}"
-    );
-    assert!(!sig.contains("proof_term"), "signature leaked the body: {sig}");
-}
-
-#[test]
-fn multiline_local_let_in_inside_spec_with_col0_equals() {
-    // Same, but the spec spans lines and the body `=` sits in column 0 — it is
-    // still the definitional `=` (depth 0) and the cut point.
-    let source = "module M\n\
-                  let test (x y: t) : Lemma (let z = x + y in\n\
-                  some_prop z)\n\
-                  = proof_term\n";
-    let result = extract(source);
-    let funcs = names_of(&result, NodeKind::Function);
-    assert_eq!(funcs, vec!["test".to_string()], "phantom node? {funcs:?}");
-    let sig = find(&result, "test").signature.clone().unwrap_or_default();
-    assert!(sig.contains("let z = x + y in some_prop z"), "signature was: {sig}");
-    assert!(!sig.contains("proof_term"), "signature leaked the body: {sig}");
-}
-
-#[test]
-fn unbalanced_parens_in_inline_comment_within_spec_dont_break_depth() {
-    // The comment carries unbalanced `)` and `(` that would corrupt bracket
-    // counting if comments weren't blanked before scanning.
-    let source = "module M\n\
-                  let test (x y:int) : Lemma (* tricky ) ( comment *) (requires x > y) = ()\n";
-    let result = extract(source);
-    assert_eq!(
-        names_of(&result, NodeKind::Function),
-        vec!["test".to_string()]
-    );
-    let sig = find(&result, "test").signature.clone().unwrap_or_default();
-    assert!(sig.contains("Lemma (requires x > y)"), "signature was: {sig}");
-    assert!(!sig.contains("tricky"), "comment leaked into signature: {sig}");
-}
-
-#[test]
-fn multiline_comment_inside_spec_is_blanked() {
-    let source = "module M\n\
-                  let test (x:int) : Lemma (requires x > 0)\n\
-                  (* this comment spans\n\
-                  \x20  several ) ( unbalanced lines *)\n\
-                  (ensures x >= 0) = ()\n";
-    let result = extract(source);
-    assert_eq!(
-        names_of(&result, NodeKind::Function),
-        vec!["test".to_string()]
-    );
-    let sig = find(&result, "test").signature.clone().unwrap_or_default();
-    assert!(sig.contains("requires x > 0"), "signature was: {sig}");
-    assert!(sig.contains("ensures x >= 0"), "signature was: {sig}");
-    assert!(!sig.contains("unbalanced"), "comment leaked: {sig}");
-}
-
-#[test]
-fn nested_comment_with_parens_inside_spec() {
-    let source = "module M\n\
-                  let f (x:int) : Lemma (* a (* nested ) *) c ( *) (ensures x == x) = ()\n";
-    let result = extract(source);
-    assert_eq!(names_of(&result, NodeKind::Function), vec!["f".to_string()]);
-    let sig = find(&result, "f").signature.clone().unwrap_or_default();
-    assert!(sig.contains("Lemma (ensures x == x)"), "signature was: {sig}");
-    assert!(!sig.contains("nested"), "comment leaked: {sig}");
-}
-
-#[test]
-fn paren_inside_string_in_spec_does_not_break_depth() {
-    // A string literal carrying an unbalanced paren (e.g. in a labelled
-    // assertion message) must also be blanked, not counted.
-    let source = "module M\n\
-                  let test (x:int) : Lemma (requires x > 0) (ensures labeled \")\" (x >= 0)) = ()\n";
-    let result = extract(source);
-    assert_eq!(
-        names_of(&result, NodeKind::Function),
-        vec!["test".to_string()]
-    );
-    let sig = find(&result, "test").signature.clone().unwrap_or_default();
-    assert!(sig.contains("requires x > 0"), "signature was: {sig}");
-    assert!(sig.contains("ensures"), "signature was: {sig}");
-}
-
-#[test]
-fn real_calc_eliminate_lemma_is_single_node_with_clean_signature() {
-    // Faithful to CuteCAS legacy/AlgebraTypes.fst::unit_product_is_unit_new:
-    // `%`-quotations, local operator let-bindings (`let ( = ) = eq in`),
-    // `eliminate exists ... returns ... with`, begin/end, and nested calc
-    // blocks must yield exactly one Function node and a spec-only signature.
-    let source = "module M\n\
-let unit_product_is_unit_new #a (#eq: equivalence_relation a)\n\
-                             (mul: op_with_congruence eq{is_associative mul})\n\
-                             (x y: units_of mul)\n\
-  : Lemma (is_unit (mul x y) mul) =\n\
-  reveal_opaque (`%is_unit) (is_unit #a #eq);\n\
-  let ( * ) = mul in\n\
-  let ( = ) = eq in\n\
-  eliminate exists (x' y':a). (is_neutral_of (x'*x) mul /\\ is_neutral_of (y'*y) mul)\n\
-  returns is_unit (x*y) mul with _.\n\
-  begin\n\
-    calc (=) {\n\
-      (y'*x')*(x*y); = { assoc_lemma_3 mul y' x' (x*y) }\n\
-      y'*y;\n\
-    };\n\
-    ()\n\
-  end\n\
-let after_it (z:int) : int = z\n";
-    let result = extract(source);
-    assert!(result.errors.is_empty(), "errors: {:?}", result.errors);
-
-    let funcs = names_of(&result, NodeKind::Function);
-    // Exactly the lemma and the following decl — nothing from the proof sugar.
-    assert_eq!(
-        funcs,
-        vec![
-            "after_it".to_string(),
-            "unit_product_is_unit_new".to_string()
-        ],
-        "phantom nodes from proof body: {funcs:?}"
-    );
-    // The local operator bindings `let ( * )` / `let ( = )` must not leak as nodes.
-    assert!(!funcs.iter().any(|f| f == "*" || f == "=" || f == "x'"));
-
-    let lemma = find(&result, "unit_product_is_unit_new");
-    let sig = lemma.signature.clone().unwrap_or_default();
-    assert!(
-        sig.contains("Lemma (is_unit (mul x y) mul)"),
-        "signature was: {sig}"
-    );
-    assert!(!sig.contains("reveal_opaque"), "body leaked: {sig}");
-    assert!(!sig.contains("calc"), "body leaked: {sig}");
-    assert!(!sig.contains("eliminate"), "body leaked: {sig}");
-
-    // The span must cover the whole proof (through `end`) up to the next decl.
-    let after = find(&result, "after_it");
-    assert!(lemma.end_line < after.start_line);
-    assert!(
-        lemma.end_line >= 16,
-        "end_line {} should reach the `end` line",
-        lemma.end_line
-    );
-}
-
-#[test]
-fn introduce_exists_block_in_body_is_not_a_decl() {
-    // `introduce exists ... with ... and ...` (F* manual's existential intro).
-    let source = "module M\n\
-let pick (n:nat) : Lemma (exists m. m > n) =\n\
-  introduce exists m. m > n\n\
-  with (n + 1)\n\
-  and ()\n\
-let next () : unit = ()\n";
-    let result = extract(source);
-    let funcs = names_of(&result, NodeKind::Function);
-    assert_eq!(
-        funcs,
-        vec!["next".to_string(), "pick".to_string()],
-        "phantom nodes: {funcs:?}"
-    );
-    let sig = find(&result, "pick").signature.clone().unwrap_or_default();
-    assert!(sig.contains("Lemma (exists m. m > n)"), "signature was: {sig}");
-    assert!(!sig.contains("introduce"), "body leaked: {sig}");
+fn qualifiers_are_stripped_and_private_sets_visibility() {
+    let r = sample();
+    // unfold / irreducible / inline_for_extraction are stripped; still Functions.
+    assert_eq!(find(&r, "twice").kind, NodeKind::Function);
+    assert_eq!(find(&r, "magic").kind, NodeKind::Function);
+    // `bump` is `inline_for_extraction private` -> Private.
+    assert_eq!(find(&r, "bump").visibility, Visibility::Private);
+    assert_eq!(find(&r, "twice").visibility, Visibility::Pub);
 }
 
 #[test]
 fn plain_let_signature_excludes_body() {
-    let source = "module M\nlet add (a b : int) : int = a + b\n";
-    let result = extract(source);
-    let f = find(&result, "add");
-    let sig = f.signature.as_deref().unwrap_or("");
-    assert!(sig.contains("add (a b : int) : int"), "signature was: {sig}");
-    assert!(!sig.contains("a + b"), "signature leaked the body: {sig}");
-}
-
-#[test]
-fn node_line_span_covers_full_spec_for_source_retrieval() {
-    // The node's [start_line, end_line] must cover the whole multi-line spec so
-    // tools that fetch source by line range return requires/ensures too.
-    let source = "module M\n\
-                  val big_lemma (a b : int) : Lemma\n\
-                  \x20 (requires a > b)\n\
-                  \x20 (ensures a - b > 0)\n\
-                  \x20 [SMTPat (a - b)]\n";
-    let result = extract(source);
-    let f = find(&result, "big_lemma");
-    // val starts at line 1; the [SMTPat ...] line is line 4.
-    assert_eq!(f.start_line, 1);
-    assert!(f.end_line >= 4, "end_line {} should cover the spec", f.end_line);
+    assert_eq!(sig(&sample(), "negate"), "let negate (x:int) : int");
 }
 
 // ---------------------------------------------------------------------------
-// Indentation is NOT mandatory in F*: bodies may sit in column 0
+// Specifications: Lemma / Pure / Tot carry requires / ensures / decreases
 // ---------------------------------------------------------------------------
 
 #[test]
-fn unindented_if_body_is_absorbed_not_a_new_decl() {
-    // `if ... then ... else ...` at column 0 is the body of `choice`, not a
-    // new declaration. `choice` and `next` must both be functions; nothing else.
-    let source = "module M\n\
-                  let choice (b:bool) x y =\n\
-                  if b then x else y\n\
-                  let next = 0\n";
-    let result = extract(source);
-    let funcs = names_of(&result, NodeKind::Function);
-    assert_eq!(funcs, vec!["choice".to_string(), "next".to_string()]);
-    // `choice`'s span must extend over the unindented body line.
-    let choice = find(&result, "choice");
-    assert!(choice.end_line >= 2, "choice end_line was {}", choice.end_line);
+fn lemma_signature_has_requires_ensures_decreases() {
+    let s = sig(&sample(), "fact_pos");
+    assert!(s.contains("Lemma"), "{s}");
+    assert!(s.contains("requires n >= 0"), "{s}");
+    assert!(s.contains("ensures factorial n >= 1"), "{s}");
+    assert!(s.contains("decreases n"), "{s}");
+    assert!(!s.contains("if n = 0"), "body leaked: {s}");
 }
 
 #[test]
-fn unindented_local_let_in_is_not_a_top_level_function() {
-    // The crux: a column-0 local `let y = ... in` is the body of `foo`, not a
-    // top-level `let`. Only `foo` and `bar` are functions.
-    let source = "module M\n\
-                  let foo x =\n\
-                  let y = x + 1 in\n\
-                  y\n\
-                  let bar = 2\n";
-    let result = extract(source);
-    let funcs = names_of(&result, NodeKind::Function);
-    assert_eq!(funcs, vec!["bar".to_string(), "foo".to_string()]);
-    assert!(!funcs.contains(&"y".to_string()));
+fn pure_signature_has_requires_ensures_decreases() {
+    let s = sig(&sample(), "divmod");
+    assert!(s.contains("Pure nat"), "{s}");
+    assert!(s.contains("requires x >= 0"), "{s}");
+    assert!(s.contains("ensures fun r -> r >= 0"), "{s}");
+    assert!(s.contains("decreases x"), "{s}");
+    assert!(!s.contains("if x < y"), "body leaked: {s}");
 }
 
 #[test]
-fn unindented_nested_let_in_chain() {
-    let source = "module M\n\
-                  let compute x =\n\
-                  let a = x + 1 in\n\
-                  let b = a * 2 in\n\
-                  let c = b - 3 in\n\
-                  c\n\
-                  let other y = y\n";
-    let result = extract(source);
-    let funcs = names_of(&result, NodeKind::Function);
-    assert_eq!(funcs, vec!["compute".to_string(), "other".to_string()]);
+fn tot_signature_has_decreases() {
+    let s = sig(&sample(), "countdown");
+    assert!(s.contains("Tot nat (decreases n)"), "{s}");
+    assert!(!s.contains("countdown (n - 1)"), "body leaked: {s}");
 }
 
 // ---------------------------------------------------------------------------
-// Typeclass-constraint binders {| ... |}
+// Operators, binding operators, mutual recursion
 // ---------------------------------------------------------------------------
 
 #[test]
-fn let_with_named_tc_constraint_binder() {
-    let source = "module M\n\
-                  let cmp (#a:Type) {| d: eq a |} (x:a) (y:a) : bool = d.eqb x y\n";
-    let result = extract(source);
-    assert!(names_of(&result, NodeKind::Function).contains(&"cmp".to_string()));
+fn symbolic_operator_uses_symbol_as_name() {
+    assert_eq!(find(&sample(), "+^").kind, NodeKind::Function);
 }
 
 #[test]
-fn val_operator_with_anonymous_tc_constraint_binder() {
-    // From FStar.Class.Add: `val (++) : #a:_ -> {| additive a |} -> a -> a -> a`
-    let source = "module M\n\
-                  val ( ++ ) : #a:_ -> {| additive a |} -> a -> a -> a\n\
-                  let ( ++ ) = plus\n";
-    let result = extract(source);
-    let funcs: Vec<_> = result
-        .nodes
-        .iter()
-        .filter(|n| n.kind == NodeKind::Function && n.name == "++")
-        .collect();
-    assert_eq!(funcs.len(), 2, "have: {:?}", names_of_all(&result));
+fn binding_operator_is_a_function() {
+    // `( let? )` is a single operator token, not the `let` keyword.
+    assert_eq!(find(&sample(), "let?").kind, NodeKind::Function);
 }
 
 #[test]
-fn instance_with_anonymous_tc_binder_resolves_class_after_binder() {
-    let source = "module M\ninstance foo {| eq a |} : ord a = mk_ord ()\n";
-    let result = extract(source);
-    let impl_node = find(&result, "foo");
-    assert_eq!(impl_node.kind, NodeKind::Impl);
-    // The implemented class is `ord` (after the binder), not `eq` (inside it).
-    assert!(result.unresolved_refs.iter().any(|r| r.from_node_id
-        == impl_node.id
-        && r.reference_kind == EdgeKind::Implements
-        && r.reference_name == "ord"));
-    assert!(!result
-        .unresolved_refs
-        .iter()
-        .any(|r| r.reference_name == "eq"));
-}
-
-#[test]
-fn instance_with_named_tc_binder_skips_binder_colon() {
-    // From CuteCAS: the `:` inside `{| g: gcd_domain t |}` must be skipped; the
-    // implemented class is `integral_domain`.
-    let source = "module M\n\
-                  instance id_of_gcd t {| g: gcd_domain t |} : integral_domain t = g.gcd_id\n";
-    let result = extract(source);
-    let impl_node = find(&result, "id_of_gcd");
-    assert_eq!(impl_node.kind, NodeKind::Impl);
-    assert!(result.unresolved_refs.iter().any(|r| r.from_node_id
-        == impl_node.id
-        && r.reference_kind == EdgeKind::Implements
-        && r.reference_name == "integral_domain"));
-    assert!(!result
-        .unresolved_refs
-        .iter()
-        .any(|r| r.reference_name == "gcd_domain"));
+fn mutually_recursive_functions_via_and() {
+    let r = sample();
+    assert_eq!(find(&r, "even").kind, NodeKind::Function);
+    assert_eq!(find(&r, "odd").kind, NodeKind::Function); // introduced by `and`
 }
 
 // ---------------------------------------------------------------------------
-// Monadic let / "let operators" (let?, and?, ( let:: ), ( let* ))
+// exception, effect, assume val
 // ---------------------------------------------------------------------------
 
 #[test]
-fn let_operator_definitions_are_functions() {
-    // From examples/misc/MonadicLetBindings.fst
-    let source = "module M\n\
-                  let (let?) (x: option 'a) (f: 'a -> option 'b) : option 'b = bind x f\n\
-                  let (and?) (x: option 'a) (y: option 'b) : option ('a & 'b) = pair x y\n\
-                  let ( let:: ) (l: list 'a) (f: 'a -> list 'b) : list 'b = concatMap f l\n";
-    let result = extract(source);
-    let funcs = names_of(&result, NodeKind::Function);
-    assert!(funcs.contains(&"let?".to_string()), "have: {funcs:?}");
-    assert!(funcs.contains(&"and?".to_string()), "have: {funcs:?}");
-    assert!(funcs.contains(&"let::".to_string()), "have: {funcs:?}");
+fn exception_is_struct() {
+    assert_eq!(find(&sample(), "Out_of_bounds").kind, NodeKind::Struct);
 }
 
 #[test]
-fn operator_name_argument_does_not_become_the_decl_name() {
-    // `let sugared1 (let*) (and*) ex ey ez f = ...` — the operators are
-    // parameters; the function is named `sugared1`.
-    let source = "module M\nlet sugared1 (let*) (and*) ex ey ez f = f ex ey ez\n";
-    let result = extract(source);
-    let funcs = names_of(&result, NodeKind::Function);
-    assert!(funcs.contains(&"sugared1".to_string()), "have: {funcs:?}");
-    assert!(!funcs.contains(&"let*".to_string()));
+fn effect_is_type_alias() {
+    assert_eq!(find(&sample(), "Id").kind, NodeKind::TypeAlias);
 }
 
 #[test]
-fn monadic_let_bang_in_body_is_not_a_top_level_decl() {
-    let source = "module M\n\
-                  let option_example (a b: list (int & int)) =\n\
-                  \x20 let? haL, haR = head a\n\
-                  \x20 and? hbL, hbR = head b in\n\
-                  \x20 Some (haL + hbR)\n\
-                  let next = 0\n";
-    let result = extract(source);
-    let funcs = names_of(&result, NodeKind::Function);
-    assert_eq!(
-        funcs,
-        vec!["next".to_string(), "option_example".to_string()]
-    );
+fn assume_val_is_a_function() {
+    let r = sample();
+    assert_eq!(find(&r, "excluded_middle").kind, NodeKind::Function);
+    assert!(sig(&r, "excluded_middle").starts_with("assume val excluded_middle"));
+}
+
+// ---------------------------------------------------------------------------
+// Robustness: strings, comments, nested let-in, proof-body sugar, pragmas
+// ---------------------------------------------------------------------------
+
+#[test]
+fn string_with_braces_is_not_a_record_and_does_not_swallow_next_decl() {
+    let r = sample();
+    let banner = find(&r, "banner");
+    assert_eq!(banner.kind, NodeKind::Function);
+    assert_eq!(sig(&r, "banner"), "let banner : string");
+    // Regression: a string-valued RHS must not absorb the following decl.
+    assert!(r.nodes.iter().any(|n| n.name == "comm_proof"));
 }
 
 #[test]
-fn unindented_monadic_let_bang_in_body() {
-    // Same as above but with the monadic binds in column 0.
-    let source = "module M\n\
-                  let option_example a b =\n\
-                  let? haL = head a\n\
-                  and? hbL = head b in\n\
-                  Some (haL + hbL)\n\
-                  let next = 0\n";
-    let result = extract(source);
-    let funcs = names_of(&result, NodeKind::Function);
-    assert_eq!(
-        funcs,
-        vec!["next".to_string(), "option_example".to_string()]
-    );
+fn proof_body_with_calc_introduce_eliminate_has_no_phantom_nodes() {
+    let r = sample();
+    let n = find(&r, "comm_proof");
+    assert_eq!(n.kind, NodeKind::Function);
+    // The proof spans through the calc block.
+    assert!(n.end_line > n.start_line);
+    // No phantom function from the local `let z` or `introduce` witness `w`.
+    let funcs = names_of(&r, NodeKind::Function);
+    assert!(!funcs.contains(&"z".to_string()));
+    assert!(!funcs.contains(&"w".to_string()));
+    // Signature is the spec, not the proof term.
+    assert_eq!(sig(&r, "comm_proof"), "let comm_proof (x y : int) : Lemma (x + y == y + x)");
+}
+
+#[test]
+fn local_let_in_and_inline_comment_inside_spec() {
+    let s = sig(&sample(), "spec_let");
+    assert!(s.contains("requires (let p = x > 0 in p)"), "{s}");
+    assert!(s.contains("ensures x >= 0"), "{s}");
+    assert!(!s.contains("mismatched"), "comment leaked into signature: {s}");
+}
+
+#[test]
+fn push_pop_options_pragmas_are_ignored() {
+    let r = sample();
+    // The decl between #push-options and #pop-options is extracted normally.
+    assert_eq!(find(&r, "heavy").kind, NodeKind::Function);
+    assert!(sig(&r, "heavy").contains("requires a > 0"));
+    // No phantom nodes from any #...-options pragma.
+    assert!(!r.nodes.iter().any(|n| n.name.contains("options")));
+}
+
+#[test]
+fn monadic_let_in_body_is_not_a_top_level_decl() {
+    let r = sample();
+    let n = find(&r, "try_add");
+    assert_eq!(n.kind, NodeKind::Function);
+    assert_eq!(sig(&r, "try_add"), "let try_add (a b : option int) : option int");
+}
+
+#[test]
+fn doc_comment_is_captured_as_docstring() {
+    let d = find(&sample(), "point").docstring.clone().unwrap_or_default();
+    assert!(d.contains("record type"), "docstring was: {d:?}");
+}
+
+// ---------------------------------------------------------------------------
+// Span correctness for source retrieval
+// ---------------------------------------------------------------------------
+
+#[test]
+fn multiline_decl_span_covers_full_spec() {
+    let r = sample();
+    // `fact_pos` spans its keyword line through the multi-line spec/body.
+    let n = find(&r, "fact_pos");
+    assert!(n.end_line > n.start_line, "span did not cover the spec/body");
 }

--- a/tests/fstar_extraction_test.rs
+++ b/tests/fstar_extraction_test.rs
@@ -1,0 +1,1090 @@
+use tokensave::extraction::FStarExtractor;
+use tokensave::extraction::LanguageExtractor;
+use tokensave::types::*;
+
+fn extract(source: &str) -> ExtractionResult {
+    FStarExtractor.extract("Demo.fst", source)
+}
+
+fn names_of(result: &ExtractionResult, kind: NodeKind) -> Vec<String> {
+    let mut v: Vec<String> = result
+        .nodes
+        .iter()
+        .filter(|n| n.kind == kind)
+        .map(|n| n.name.clone())
+        .collect();
+    v.sort();
+    v
+}
+
+fn find<'a>(result: &'a ExtractionResult, name: &str) -> &'a Node {
+    result
+        .nodes
+        .iter()
+        .find(|n| n.name == name)
+        .unwrap_or_else(|| panic!("node {name} not found; have: {:?}", names_of_all(result)))
+}
+
+fn names_of_all(result: &ExtractionResult) -> Vec<String> {
+    result.nodes.iter().map(|n| n.name.clone()).collect()
+}
+
+fn contains_edge(result: &ExtractionResult, src: &str, tgt: &str) -> bool {
+    let s = find(result, src);
+    let t = find(result, tgt);
+    result
+        .edges
+        .iter()
+        .any(|e| e.source == s.id && e.target == t.id && e.kind == EdgeKind::Contains)
+}
+
+// ---------------------------------------------------------------------------
+// Basic metadata
+// ---------------------------------------------------------------------------
+
+#[test]
+fn extensions_are_fst_and_fsti() {
+    assert_eq!(FStarExtractor.extensions(), &["fst", "fsti"]);
+}
+
+#[test]
+fn language_name_is_fstar() {
+    assert_eq!(FStarExtractor.language_name(), "F*");
+}
+
+#[test]
+fn empty_file_produces_only_file_node() {
+    let result = extract("");
+    assert_eq!(result.nodes.len(), 1);
+    assert_eq!(result.nodes[0].kind, NodeKind::File);
+    assert!(result.errors.is_empty());
+}
+
+// ---------------------------------------------------------------------------
+// Module, open, include, module abbreviations
+// ---------------------------------------------------------------------------
+
+#[test]
+fn module_declaration_is_module_and_scopes_children() {
+    let source = "module FStar.Demo\n\nlet x = 1\n";
+    let result = extract(source);
+    let m = find(&result, "FStar.Demo");
+    assert_eq!(m.kind, NodeKind::Module);
+    assert_eq!(m.qualified_name, "Demo.fst::FStar.Demo");
+    // `x` is parented to the module, not the file.
+    assert!(contains_edge(&result, "FStar.Demo", "x"));
+    let x = find(&result, "x");
+    assert_eq!(x.qualified_name, "Demo.fst::FStar.Demo::x");
+}
+
+#[test]
+fn open_emits_uses_edge() {
+    let source = "module M\nopen FStar.List.Tot\nlet x = 1\n";
+    let result = extract(source);
+    let uses: Vec<_> = result
+        .edges
+        .iter()
+        .filter(|e| e.kind == EdgeKind::Uses)
+        .collect();
+    assert_eq!(uses.len(), 1);
+}
+
+#[test]
+fn open_with_restriction_emits_single_uses_edge() {
+    let source = "module M\nopen FStar.Fin { fin }\nlet x = 1\n";
+    let result = extract(source);
+    let uses = result
+        .edges
+        .iter()
+        .filter(|e| e.kind == EdgeKind::Uses)
+        .count();
+    assert_eq!(uses, 1);
+}
+
+#[test]
+fn module_abbreviation_emits_uses_edge_not_module_node() {
+    let source = "module M\nmodule CE = FStar.Algebra.CommMonoid.Equiv\nlet x = 1\n";
+    let result = extract(source);
+    // Only one Module node (the file module M).
+    assert_eq!(names_of(&result, NodeKind::Module), vec!["M".to_string()]);
+    let uses = result
+        .edges
+        .iter()
+        .filter(|e| e.kind == EdgeKind::Uses)
+        .count();
+    assert_eq!(uses, 1);
+}
+
+#[test]
+fn include_and_friend_emit_uses_edges() {
+    let source = "module M\ninclude FStar.A\nfriend FStar.B\nlet x = 1\n";
+    let result = extract(source);
+    let uses = result
+        .edges
+        .iter()
+        .filter(|e| e.kind == EdgeKind::Uses)
+        .count();
+    assert_eq!(uses, 2);
+}
+
+// ---------------------------------------------------------------------------
+// let / val / and
+// ---------------------------------------------------------------------------
+
+#[test]
+fn let_is_function() {
+    let source = "module M\nlet square (n:int) : int = n * n\n";
+    let result = extract(source);
+    assert!(names_of(&result, NodeKind::Function).contains(&"square".to_string()));
+}
+
+#[test]
+fn val_is_function() {
+    let source = "module M\nval foo (a b : int) : Lemma (a + b == b + a)\n";
+    let result = extract(source);
+    assert!(names_of(&result, NodeKind::Function).contains(&"foo".to_string()));
+}
+
+#[test]
+fn let_rec_skips_rec_keyword() {
+    let source = "module M\nlet rec fact (n:nat) : nat = if n = 0 then 1 else n * fact (n - 1)\n";
+    let result = extract(source);
+    let funcs = names_of(&result, NodeKind::Function);
+    assert!(funcs.contains(&"fact".to_string()));
+    assert!(!funcs.contains(&"rec".to_string()));
+}
+
+#[test]
+fn operator_let_uses_operator_symbol_as_name() {
+    let source = "module M\nlet ( ++ ) x y = x + y\nlet ( =~ ) a b = a == b\n";
+    let result = extract(source);
+    let funcs = names_of(&result, NodeKind::Function);
+    assert!(funcs.contains(&"++".to_string()), "have: {funcs:?}");
+    assert!(funcs.contains(&"=~".to_string()), "have: {funcs:?}");
+}
+
+#[test]
+fn mutually_recursive_and_creates_two_functions() {
+    let source = "module M\n\
+                  let rec even (n:nat) : bool = if n = 0 then true else odd (n - 1)\n\
+                  and odd (n:nat) : bool = if n = 0 then false else even (n - 1)\n";
+    let result = extract(source);
+    let funcs = names_of(&result, NodeKind::Function);
+    assert!(funcs.contains(&"even".to_string()));
+    assert!(funcs.contains(&"odd".to_string()));
+}
+
+#[test]
+fn multiline_val_then_let_are_distinct() {
+    let source = "module M\n\
+                  val eq_mult_one (a b:int) : Lemma\n\
+                  \x20 (requires a * b = 1)\n\
+                  \x20 (ensures (a = 1 /\\ b = 1) \\/ (a = -1 /\\ b = -1))\n\
+                  let eq_mult_one a b = ()\n";
+    let result = extract(source);
+    // Two functions named eq_mult_one (the val and the let), no phantom nodes
+    // from the indented requires/ensures lines.
+    let funcs: Vec<_> = result
+        .nodes
+        .iter()
+        .filter(|n| n.kind == NodeKind::Function && n.name == "eq_mult_one")
+        .collect();
+    assert_eq!(funcs.len(), 2, "have: {:?}", names_of_all(&result));
+}
+
+// ---------------------------------------------------------------------------
+// Records, variants, type aliases
+// ---------------------------------------------------------------------------
+
+#[test]
+fn record_type_is_struct_with_fields() {
+    let source = "module M\n\
+                  type point = {\n\
+                  \x20 x : int;\n\
+                  \x20 y : int;\n\
+                  }\n";
+    let result = extract(source);
+    assert_eq!(names_of(&result, NodeKind::Struct), vec!["point".to_string()]);
+    assert_eq!(
+        names_of(&result, NodeKind::Field),
+        vec!["x".to_string(), "y".to_string()]
+    );
+    assert!(contains_edge(&result, "point", "x"));
+    assert!(contains_edge(&result, "point", "y"));
+}
+
+#[test]
+fn record_with_params_and_function_fields() {
+    let source = "module M\n\
+                  noeq\n\
+                  type bijection (a b : Type) = {\n\
+                  \x20 right : a -> GTot b;\n\
+                  \x20 left  : b -> GTot a;\n\
+                  \x20 left_right : x:a -> squash (left (right x) == x);\n\
+                  }\n";
+    let result = extract(source);
+    assert_eq!(
+        names_of(&result, NodeKind::Struct),
+        vec!["bijection".to_string()]
+    );
+    let fields = names_of(&result, NodeKind::Field);
+    assert_eq!(
+        fields,
+        vec![
+            "left".to_string(),
+            "left_right".to_string(),
+            "right".to_string()
+        ]
+    );
+}
+
+#[test]
+fn record_body_brace_on_next_line() {
+    let source = "module M\n\
+                  type t =\n\
+                  {\n\
+                  \x20 a : int;\n\
+                  \x20 b : bool;\n\
+                  }\n";
+    let result = extract(source);
+    assert_eq!(names_of(&result, NodeKind::Struct), vec!["t".to_string()]);
+    assert_eq!(
+        names_of(&result, NodeKind::Field),
+        vec!["a".to_string(), "b".to_string()]
+    );
+}
+
+#[test]
+fn variant_type_is_enum_with_constructors() {
+    let source = "module M\n\
+                  type color =\n\
+                  \x20 | Red\n\
+                  \x20 | Green\n\
+                  \x20 | Blue\n";
+    let result = extract(source);
+    assert_eq!(names_of(&result, NodeKind::Enum), vec!["color".to_string()]);
+    assert_eq!(
+        names_of(&result, NodeKind::EnumVariant),
+        vec!["Blue".to_string(), "Green".to_string(), "Red".to_string()]
+    );
+    assert!(contains_edge(&result, "color", "Red"));
+}
+
+#[test]
+fn variant_with_constructor_args() {
+    let source = "module M\n\
+                  type tree =\n\
+                  \x20 | Leaf\n\
+                  \x20 | Node of tree * int * tree\n";
+    let result = extract(source);
+    assert_eq!(
+        names_of(&result, NodeKind::EnumVariant),
+        vec!["Leaf".to_string(), "Node".to_string()]
+    );
+}
+
+#[test]
+fn type_alias_is_type_alias() {
+    let source = "module M\ntype nat32 = x:int{x >= 0 /\\ x < 4_294_967_296}\n";
+    let result = extract(source);
+    assert_eq!(
+        names_of(&result, NodeKind::TypeAlias),
+        vec!["nat32".to_string()]
+    );
+    // A refinement brace must not be mistaken for a record.
+    assert!(names_of(&result, NodeKind::Struct).is_empty());
+    assert!(names_of(&result, NodeKind::Field).is_empty());
+}
+
+#[test]
+fn mutually_recursive_types_with_and() {
+    let source = "module M\n\
+                  type even = | EZ | ES of odd\n\
+                  and odd = | OS of even\n";
+    let result = extract(source);
+    let enums = names_of(&result, NodeKind::Enum);
+    assert!(enums.contains(&"even".to_string()));
+    assert!(enums.contains(&"odd".to_string()));
+}
+
+// ---------------------------------------------------------------------------
+// Typeclasses and instances
+// ---------------------------------------------------------------------------
+
+#[test]
+fn class_is_trait_with_method_fields() {
+    let source = "module M\n\
+                  class additive a = {\n\
+                  \x20 zero : a;\n\
+                  \x20 plus : a -> a -> a;\n\
+                  }\n";
+    let result = extract(source);
+    assert_eq!(
+        names_of(&result, NodeKind::Trait),
+        vec!["additive".to_string()]
+    );
+    assert_eq!(
+        names_of(&result, NodeKind::Field),
+        vec!["plus".to_string(), "zero".to_string()]
+    );
+    assert!(contains_edge(&result, "additive", "zero"));
+}
+
+#[test]
+fn instance_is_impl() {
+    let source = "module M\n\
+                  instance add_int : additive int = {\n\
+                  \x20 zero = 0;\n\
+                  \x20 plus = (+);\n\
+                  }\n";
+    let result = extract(source);
+    assert_eq!(
+        names_of(&result, NodeKind::Impl),
+        vec!["add_int".to_string()]
+    );
+    // The instance body assignments must not become fields.
+    assert!(names_of(&result, NodeKind::Field).is_empty());
+}
+
+#[test]
+fn instance_records_implements_reference() {
+    let source = "module M\ninstance add_int : additive int = { zero = 0; plus = (+); }\n";
+    let result = extract(source);
+    let impl_node = find(&result, "add_int");
+    assert!(result
+        .unresolved_refs
+        .iter()
+        .any(|r| r.from_node_id == impl_node.id
+            && r.reference_kind == EdgeKind::Implements
+            && r.reference_name == "additive"));
+}
+
+// ---------------------------------------------------------------------------
+// exception / assume / effect
+// ---------------------------------------------------------------------------
+
+#[test]
+fn exception_is_struct() {
+    let source = "module M\nexception NotFound\nexception Bad of string\n";
+    let result = extract(source);
+    let structs = names_of(&result, NodeKind::Struct);
+    assert!(structs.contains(&"NotFound".to_string()));
+    assert!(structs.contains(&"Bad".to_string()));
+}
+
+#[test]
+fn assume_val_is_function() {
+    let source = "module M\nassume val opaque_fn (x:int) : int\n";
+    let result = extract(source);
+    assert!(names_of(&result, NodeKind::Function).contains(&"opaque_fn".to_string()));
+}
+
+#[test]
+fn assume_declaration_is_const() {
+    let source = "module M\nassume Axiom1 : 1 + 1 == 2\n";
+    let result = extract(source);
+    assert!(names_of(&result, NodeKind::Const).contains(&"Axiom1".to_string()));
+}
+
+#[test]
+fn effect_abbreviation_is_type_alias() {
+    let source = "module M\neffect St (a:Type) = ST a (fun _ -> True) (fun _ _ _ -> True)\n";
+    let result = extract(source);
+    assert!(names_of(&result, NodeKind::TypeAlias).contains(&"St".to_string()));
+}
+
+// ---------------------------------------------------------------------------
+// Qualifiers and attributes
+// ---------------------------------------------------------------------------
+
+#[test]
+fn private_qualifier_sets_visibility() {
+    let source = "module M\nprivate let helper x = x + 1\n";
+    let result = extract(source);
+    let helper = find(&result, "helper");
+    assert_eq!(helper.visibility, Visibility::Private);
+}
+
+#[test]
+fn attribute_block_above_decl_is_attrs_start() {
+    let source = "module M\n\
+                  [@@erasable]\n\
+                  noeq\n\
+                  type t = { a : int; }\n";
+    let result = extract(source);
+    let t = find(&result, "t");
+    assert_eq!(t.kind, NodeKind::Struct);
+    // attrs_start_line points at the `[@@erasable]` line (index 1).
+    assert_eq!(t.attrs_start_line, 1);
+    assert!(t.start_line > t.attrs_start_line);
+}
+
+#[test]
+fn inline_for_extraction_qualifier_does_not_break_name() {
+    let source = "module M\ninline_for_extraction\nlet f x = x\n";
+    let result = extract(source);
+    assert!(names_of(&result, NodeKind::Function).contains(&"f".to_string()));
+}
+
+#[test]
+fn doc_comment_is_captured() {
+    let source = "module M\n/// This is a helper.\n/// Second line.\nlet helper x = x\n";
+    let result = extract(source);
+    let helper = find(&result, "helper");
+    assert_eq!(
+        helper.docstring.as_deref(),
+        Some("This is a helper.\nSecond line.")
+    );
+}
+
+// ---------------------------------------------------------------------------
+// Pragmas / directives are ignored
+// ---------------------------------------------------------------------------
+
+#[test]
+fn set_and_push_options_pragmas_are_ignored() {
+    let source = "module M\n\
+                  #set-options \"--max_fuel 1 --z3rlimit 50\"\n\
+                  #push-options \"--split_queries no\"\n\
+                  let lemma_x () : Lemma (True) = ()\n\
+                  #pop-options\n\
+                  #restart-solver\n";
+    let result = extract(source);
+    assert!(result.errors.is_empty());
+    // The pragma strings (which contain no decl keywords) yield no nodes.
+    let funcs = names_of(&result, NodeKind::Function);
+    assert_eq!(funcs, vec!["lemma_x".to_string()]);
+}
+
+// ---------------------------------------------------------------------------
+// Term-level constructs inside bodies must not produce phantom nodes
+// ---------------------------------------------------------------------------
+
+#[test]
+fn calc_block_inside_let_yields_only_outer_function() {
+    let source = "module M\n\
+                  let proof (x:int) : Lemma (x + 0 == x) =\n\
+                  \x20 calc (==) {\n\
+                  \x20   x + 0;\n\
+                  \x20   == { () }\n\
+                  \x20   x;\n\
+                  \x20 }\n";
+    let result = extract(source);
+    let funcs = names_of(&result, NodeKind::Function);
+    assert_eq!(funcs, vec!["proof".to_string()]);
+    // The `{ ... }` of the calc block must not be parsed as a record.
+    assert!(names_of(&result, NodeKind::Field).is_empty());
+}
+
+#[test]
+fn eliminate_introduce_inside_let_yields_only_outer_function() {
+    let source = "module M\n\
+                  let divides_transitive a b c =\n\
+                  \x20 eliminate exists q1. b == q1 * a\n\
+                  \x20 returns a `divides` c\n\
+                  \x20 with _pf.\n\
+                  \x20   introduce exists q. c == q * a\n\
+                  \x20   with (q1 * q2)\n\
+                  \x20   and ()\n";
+    let result = extract(source);
+    let funcs = names_of(&result, NodeKind::Function);
+    assert_eq!(funcs, vec!["divides_transitive".to_string()]);
+}
+
+#[test]
+fn local_let_in_is_not_a_top_level_function() {
+    let source = "module M\n\
+                  let outer x =\n\
+                  \x20 let y = x + 1 in\n\
+                  \x20 let z = y * 2 in\n\
+                  \x20 z\n";
+    let result = extract(source);
+    let funcs = names_of(&result, NodeKind::Function);
+    assert_eq!(funcs, vec!["outer".to_string()]);
+    assert!(!funcs.contains(&"y".to_string()));
+    assert!(!funcs.contains(&"z".to_string()));
+}
+
+#[test]
+fn record_literal_in_let_body_is_not_a_record_type() {
+    // A `let` whose value is a record literal (with its closing brace in
+    // column 0) must not create a Struct or Field nodes.
+    let source = "module M\n\
+                  let mk : point =\n\
+                  {\n\
+                  \x20 x = 1;\n\
+                  \x20 y = 2;\n\
+                  }\n";
+    let result = extract(source);
+    assert!(names_of(&result, NodeKind::Struct).is_empty());
+    assert!(names_of(&result, NodeKind::Field).is_empty());
+    assert!(names_of(&result, NodeKind::Function).contains(&"mk".to_string()));
+}
+
+#[test]
+fn comments_do_not_confuse_parser() {
+    let source = "module M\n\
+                  (* type fake = { a : int; } *)\n\
+                  let real x = x // let alsofake = 1\n\
+                  (* nested (* comment *) still comment *)\n\
+                  let real2 x = x\n";
+    let result = extract(source);
+    let funcs = names_of(&result, NodeKind::Function);
+    assert_eq!(funcs, vec!["real".to_string(), "real2".to_string()]);
+    assert!(names_of(&result, NodeKind::Struct).is_empty());
+}
+
+#[test]
+fn string_with_braces_does_not_confuse_record_detection() {
+    let source = "module M\nlet msg = \"a record { x : int }\"\n";
+    let result = extract(source);
+    assert!(names_of(&result, NodeKind::Function).contains(&"msg".to_string()));
+    assert!(names_of(&result, NodeKind::Struct).is_empty());
+}
+
+// ---------------------------------------------------------------------------
+// A larger, realistic file
+// ---------------------------------------------------------------------------
+
+#[test]
+fn realistic_file_extracts_expected_symbols() {
+    let source = "module FStar.Demo\n\
+                  \n\
+                  open FStar.List.Tot\n\
+                  module L = FStar.List.Tot.Base\n\
+                  \n\
+                  /// A typeclass for addition.\n\
+                  class additive a = {\n\
+                  \x20 zero : a;\n\
+                  \x20 plus : a -> a -> a;\n\
+                  }\n\
+                  \n\
+                  instance add_int : additive int = {\n\
+                  \x20 zero = 0;\n\
+                  \x20 plus = (+);\n\
+                  }\n\
+                  \n\
+                  type color = | Red | Green | Blue\n\
+                  \n\
+                  noeq\n\
+                  type pair (a b : Type) = {\n\
+                  \x20 fst : a;\n\
+                  \x20 snd : b;\n\
+                  }\n\
+                  \n\
+                  #set-options \"--z3rlimit 20\"\n\
+                  \n\
+                  val add_comm (a b : int) : Lemma (a + b == b + a)\n\
+                  let add_comm a b = ()\n\
+                  \n\
+                  let rec sum (l : list int) : int =\n\
+                  \x20 match l with\n\
+                  \x20 | [] -> 0\n\
+                  \x20 | hd :: tl -> hd + sum tl\n";
+    let result = extract(source);
+    assert!(result.errors.is_empty(), "errors: {:?}", result.errors);
+
+    assert_eq!(
+        names_of(&result, NodeKind::Module),
+        vec!["FStar.Demo".to_string()]
+    );
+    assert_eq!(
+        names_of(&result, NodeKind::Trait),
+        vec!["additive".to_string()]
+    );
+    assert_eq!(
+        names_of(&result, NodeKind::Impl),
+        vec!["add_int".to_string()]
+    );
+    assert_eq!(names_of(&result, NodeKind::Enum), vec!["color".to_string()]);
+    assert_eq!(names_of(&result, NodeKind::Struct), vec!["pair".to_string()]);
+
+    let funcs = names_of(&result, NodeKind::Function);
+    assert!(funcs.contains(&"add_comm".to_string()));
+    assert!(funcs.contains(&"sum".to_string()));
+
+    // Two Uses edges: open + module abbreviation.
+    let uses = result
+        .edges
+        .iter()
+        .filter(|e| e.kind == EdgeKind::Uses)
+        .count();
+    assert_eq!(uses, 2);
+
+    // Everything is parented under the module.
+    assert!(contains_edge(&result, "FStar.Demo", "additive"));
+    assert!(contains_edge(&result, "FStar.Demo", "sum"));
+}
+
+// ---------------------------------------------------------------------------
+// Signatures must capture the spec (requires / ensures / decreases / refinements)
+// ---------------------------------------------------------------------------
+
+#[test]
+fn val_signature_includes_requires_and_ensures() {
+    let source = "module M\n\
+                  val eq_mult_one (a b:int) : Lemma\n\
+                  \x20 (requires a * b = 1)\n\
+                  \x20 (ensures (a = 1 /\\ b = 1) \\/ (a = -1 /\\ b = -1))\n";
+    let result = extract(source);
+    let f = find(&result, "eq_mult_one");
+    let sig = f.signature.as_deref().unwrap_or("");
+    assert!(sig.contains("requires a * b = 1"), "signature was: {sig}");
+    assert!(sig.contains("ensures"), "signature was: {sig}");
+    assert!(sig.contains("Lemma"), "signature was: {sig}");
+}
+
+#[test]
+fn let_lemma_signature_has_spec_but_not_proof_body() {
+    let source = "module M\n\
+                  let lemma_pos (x:int)\n\
+                  \x20 : Lemma (requires x > 0) (ensures x >= 0)\n\
+                  \x20 = assert (x >= 0)\n";
+    let result = extract(source);
+    let f = find(&result, "lemma_pos");
+    let sig = f.signature.as_deref().unwrap_or("");
+    assert!(sig.contains("requires x > 0"), "signature was: {sig}");
+    assert!(sig.contains("ensures x >= 0"), "signature was: {sig}");
+    // The proof term after `=` must NOT be part of the signature.
+    assert!(!sig.contains("assert"), "signature leaked the body: {sig}");
+}
+
+#[test]
+fn refinement_type_is_preserved_in_signature() {
+    let source = "module M\nval to_nat (x:int) : y:int{y >= 0 /\\ y >= x}\n";
+    let result = extract(source);
+    let f = find(&result, "to_nat");
+    let sig = f.signature.as_deref().unwrap_or("");
+    assert!(sig.contains("y >= 0"), "signature was: {sig}");
+    assert!(sig.contains("{"), "refinement braces dropped: {sig}");
+}
+
+#[test]
+fn decreases_clause_preserved_in_signature() {
+    let source = "module M\n\
+                  let rec ackermann (m n:nat) : Tot nat (decreases %[m; n]) =\n\
+                  \x20 if m = 0 then n + 1 else 0\n";
+    let result = extract(source);
+    let f = find(&result, "ackermann");
+    let sig = f.signature.as_deref().unwrap_or("");
+    assert!(sig.contains("decreases"), "signature was: {sig}");
+    assert!(!sig.contains("if m = 0"), "signature leaked the body: {sig}");
+}
+
+#[test]
+fn tot_effect_with_decreases_is_captured() {
+    // A non-lemma recursive function with a `Tot _ (decreases _)` annotation.
+    let source = "module M\n\
+                  let rec fp_enum_from (p:int{p > 1}) (lo:nat{lo <= p})\n\
+                  \x20 : Tot (list (fp p)) (decreases (p - lo))\n\
+                  \x20 = if lo = p then [] else mk lo :: fp_enum_from p (lo + 1)\n";
+    let result = extract(source);
+    let sig = find(&result, "fp_enum_from").signature.clone().unwrap_or_default();
+    assert!(sig.contains("Tot (list (fp p))"), "signature was: {sig}");
+    assert!(sig.contains("decreases (p - lo)"), "signature was: {sig}");
+    assert!(!sig.contains("if lo = p"), "signature leaked the body: {sig}");
+}
+
+#[test]
+fn pure_effect_with_requires_ensures_is_captured() {
+    // A non-lemma function with `Pure _ (requires _) (ensures _)`.
+    let source = "module M\n\
+                  let fp_inv_member (p:int{is_prime p}) (x: fp p)\n\
+                  \x20 : Pure (fp p) (requires x <> 0) (ensures fun y -> y <> 0)\n\
+                  \x20 = compute_inverse p x\n";
+    let result = extract(source);
+    let sig = find(&result, "fp_inv_member").signature.clone().unwrap_or_default();
+    assert!(sig.contains("Pure (fp p)"), "signature was: {sig}");
+    assert!(sig.contains("requires x <> 0"), "signature was: {sig}");
+    assert!(sig.contains("ensures fun y -> y <> 0"), "signature was: {sig}");
+    assert!(!sig.contains("compute_inverse"), "signature leaked the body: {sig}");
+}
+
+#[test]
+fn stateful_effect_signature_is_captured() {
+    // Stack/ST style effect with pre/post predicates (no `requires`/`ensures`
+    // keywords) is still part of the type and captured verbatim.
+    let source = "module M\n\
+                  let push (x:int) : Stack unit (fun _ -> True) (fun h0 _ h1 -> modifies !{} h0 h1)\n\
+                  \x20 = ()\n";
+    let result = extract(source);
+    let sig = find(&result, "push").signature.clone().unwrap_or_default();
+    assert!(sig.contains("Stack unit"), "signature was: {sig}");
+    assert!(sig.contains("modifies"), "signature was: {sig}");
+}
+
+#[test]
+fn local_let_in_inside_lemma_spec_is_kept_and_cut_correctly() {
+    // The `=` inside `let z = x + y` lives inside `Lemma ( ... )` (depth >= 1),
+    // so it must NOT be taken as the body separator. The whole spec is kept,
+    // the proof term is dropped, and no phantom `z` node appears.
+    let source =
+        "module M\nlet test (x y: t) : Lemma (let z = x + y in some_prop z) = proof_term\n";
+    let result = extract(source);
+    let funcs = names_of(&result, NodeKind::Function);
+    assert_eq!(funcs, vec!["test".to_string()], "phantom node? {funcs:?}");
+    let sig = find(&result, "test").signature.clone().unwrap_or_default();
+    assert!(
+        sig.contains("Lemma (let z = x + y in some_prop z)"),
+        "signature was: {sig}"
+    );
+    assert!(!sig.contains("proof_term"), "signature leaked the body: {sig}");
+}
+
+#[test]
+fn multiline_local_let_in_inside_spec_with_col0_equals() {
+    // Same, but the spec spans lines and the body `=` sits in column 0 — it is
+    // still the definitional `=` (depth 0) and the cut point.
+    let source = "module M\n\
+                  let test (x y: t) : Lemma (let z = x + y in\n\
+                  some_prop z)\n\
+                  = proof_term\n";
+    let result = extract(source);
+    let funcs = names_of(&result, NodeKind::Function);
+    assert_eq!(funcs, vec!["test".to_string()], "phantom node? {funcs:?}");
+    let sig = find(&result, "test").signature.clone().unwrap_or_default();
+    assert!(sig.contains("let z = x + y in some_prop z"), "signature was: {sig}");
+    assert!(!sig.contains("proof_term"), "signature leaked the body: {sig}");
+}
+
+#[test]
+fn unbalanced_parens_in_inline_comment_within_spec_dont_break_depth() {
+    // The comment carries unbalanced `)` and `(` that would corrupt bracket
+    // counting if comments weren't blanked before scanning.
+    let source = "module M\n\
+                  let test (x y:int) : Lemma (* tricky ) ( comment *) (requires x > y) = ()\n";
+    let result = extract(source);
+    assert_eq!(
+        names_of(&result, NodeKind::Function),
+        vec!["test".to_string()]
+    );
+    let sig = find(&result, "test").signature.clone().unwrap_or_default();
+    assert!(sig.contains("Lemma (requires x > y)"), "signature was: {sig}");
+    assert!(!sig.contains("tricky"), "comment leaked into signature: {sig}");
+}
+
+#[test]
+fn multiline_comment_inside_spec_is_blanked() {
+    let source = "module M\n\
+                  let test (x:int) : Lemma (requires x > 0)\n\
+                  (* this comment spans\n\
+                  \x20  several ) ( unbalanced lines *)\n\
+                  (ensures x >= 0) = ()\n";
+    let result = extract(source);
+    assert_eq!(
+        names_of(&result, NodeKind::Function),
+        vec!["test".to_string()]
+    );
+    let sig = find(&result, "test").signature.clone().unwrap_or_default();
+    assert!(sig.contains("requires x > 0"), "signature was: {sig}");
+    assert!(sig.contains("ensures x >= 0"), "signature was: {sig}");
+    assert!(!sig.contains("unbalanced"), "comment leaked: {sig}");
+}
+
+#[test]
+fn nested_comment_with_parens_inside_spec() {
+    let source = "module M\n\
+                  let f (x:int) : Lemma (* a (* nested ) *) c ( *) (ensures x == x) = ()\n";
+    let result = extract(source);
+    assert_eq!(names_of(&result, NodeKind::Function), vec!["f".to_string()]);
+    let sig = find(&result, "f").signature.clone().unwrap_or_default();
+    assert!(sig.contains("Lemma (ensures x == x)"), "signature was: {sig}");
+    assert!(!sig.contains("nested"), "comment leaked: {sig}");
+}
+
+#[test]
+fn paren_inside_string_in_spec_does_not_break_depth() {
+    // A string literal carrying an unbalanced paren (e.g. in a labelled
+    // assertion message) must also be blanked, not counted.
+    let source = "module M\n\
+                  let test (x:int) : Lemma (requires x > 0) (ensures labeled \")\" (x >= 0)) = ()\n";
+    let result = extract(source);
+    assert_eq!(
+        names_of(&result, NodeKind::Function),
+        vec!["test".to_string()]
+    );
+    let sig = find(&result, "test").signature.clone().unwrap_or_default();
+    assert!(sig.contains("requires x > 0"), "signature was: {sig}");
+    assert!(sig.contains("ensures"), "signature was: {sig}");
+}
+
+#[test]
+fn real_calc_eliminate_lemma_is_single_node_with_clean_signature() {
+    // Faithful to CuteCAS legacy/AlgebraTypes.fst::unit_product_is_unit_new:
+    // `%`-quotations, local operator let-bindings (`let ( = ) = eq in`),
+    // `eliminate exists ... returns ... with`, begin/end, and nested calc
+    // blocks must yield exactly one Function node and a spec-only signature.
+    let source = "module M\n\
+let unit_product_is_unit_new #a (#eq: equivalence_relation a)\n\
+                             (mul: op_with_congruence eq{is_associative mul})\n\
+                             (x y: units_of mul)\n\
+  : Lemma (is_unit (mul x y) mul) =\n\
+  reveal_opaque (`%is_unit) (is_unit #a #eq);\n\
+  let ( * ) = mul in\n\
+  let ( = ) = eq in\n\
+  eliminate exists (x' y':a). (is_neutral_of (x'*x) mul /\\ is_neutral_of (y'*y) mul)\n\
+  returns is_unit (x*y) mul with _.\n\
+  begin\n\
+    calc (=) {\n\
+      (y'*x')*(x*y); = { assoc_lemma_3 mul y' x' (x*y) }\n\
+      y'*y;\n\
+    };\n\
+    ()\n\
+  end\n\
+let after_it (z:int) : int = z\n";
+    let result = extract(source);
+    assert!(result.errors.is_empty(), "errors: {:?}", result.errors);
+
+    let funcs = names_of(&result, NodeKind::Function);
+    // Exactly the lemma and the following decl — nothing from the proof sugar.
+    assert_eq!(
+        funcs,
+        vec![
+            "after_it".to_string(),
+            "unit_product_is_unit_new".to_string()
+        ],
+        "phantom nodes from proof body: {funcs:?}"
+    );
+    // The local operator bindings `let ( * )` / `let ( = )` must not leak as nodes.
+    assert!(!funcs.iter().any(|f| f == "*" || f == "=" || f == "x'"));
+
+    let lemma = find(&result, "unit_product_is_unit_new");
+    let sig = lemma.signature.clone().unwrap_or_default();
+    assert!(
+        sig.contains("Lemma (is_unit (mul x y) mul)"),
+        "signature was: {sig}"
+    );
+    assert!(!sig.contains("reveal_opaque"), "body leaked: {sig}");
+    assert!(!sig.contains("calc"), "body leaked: {sig}");
+    assert!(!sig.contains("eliminate"), "body leaked: {sig}");
+
+    // The span must cover the whole proof (through `end`) up to the next decl.
+    let after = find(&result, "after_it");
+    assert!(lemma.end_line < after.start_line);
+    assert!(
+        lemma.end_line >= 16,
+        "end_line {} should reach the `end` line",
+        lemma.end_line
+    );
+}
+
+#[test]
+fn introduce_exists_block_in_body_is_not_a_decl() {
+    // `introduce exists ... with ... and ...` (F* manual's existential intro).
+    let source = "module M\n\
+let pick (n:nat) : Lemma (exists m. m > n) =\n\
+  introduce exists m. m > n\n\
+  with (n + 1)\n\
+  and ()\n\
+let next () : unit = ()\n";
+    let result = extract(source);
+    let funcs = names_of(&result, NodeKind::Function);
+    assert_eq!(
+        funcs,
+        vec!["next".to_string(), "pick".to_string()],
+        "phantom nodes: {funcs:?}"
+    );
+    let sig = find(&result, "pick").signature.clone().unwrap_or_default();
+    assert!(sig.contains("Lemma (exists m. m > n)"), "signature was: {sig}");
+    assert!(!sig.contains("introduce"), "body leaked: {sig}");
+}
+
+#[test]
+fn plain_let_signature_excludes_body() {
+    let source = "module M\nlet add (a b : int) : int = a + b\n";
+    let result = extract(source);
+    let f = find(&result, "add");
+    let sig = f.signature.as_deref().unwrap_or("");
+    assert!(sig.contains("add (a b : int) : int"), "signature was: {sig}");
+    assert!(!sig.contains("a + b"), "signature leaked the body: {sig}");
+}
+
+#[test]
+fn node_line_span_covers_full_spec_for_source_retrieval() {
+    // The node's [start_line, end_line] must cover the whole multi-line spec so
+    // tools that fetch source by line range return requires/ensures too.
+    let source = "module M\n\
+                  val big_lemma (a b : int) : Lemma\n\
+                  \x20 (requires a > b)\n\
+                  \x20 (ensures a - b > 0)\n\
+                  \x20 [SMTPat (a - b)]\n";
+    let result = extract(source);
+    let f = find(&result, "big_lemma");
+    // val starts at line 1; the [SMTPat ...] line is line 4.
+    assert_eq!(f.start_line, 1);
+    assert!(f.end_line >= 4, "end_line {} should cover the spec", f.end_line);
+}
+
+// ---------------------------------------------------------------------------
+// Indentation is NOT mandatory in F*: bodies may sit in column 0
+// ---------------------------------------------------------------------------
+
+#[test]
+fn unindented_if_body_is_absorbed_not_a_new_decl() {
+    // `if ... then ... else ...` at column 0 is the body of `choice`, not a
+    // new declaration. `choice` and `next` must both be functions; nothing else.
+    let source = "module M\n\
+                  let choice (b:bool) x y =\n\
+                  if b then x else y\n\
+                  let next = 0\n";
+    let result = extract(source);
+    let funcs = names_of(&result, NodeKind::Function);
+    assert_eq!(funcs, vec!["choice".to_string(), "next".to_string()]);
+    // `choice`'s span must extend over the unindented body line.
+    let choice = find(&result, "choice");
+    assert!(choice.end_line >= 2, "choice end_line was {}", choice.end_line);
+}
+
+#[test]
+fn unindented_local_let_in_is_not_a_top_level_function() {
+    // The crux: a column-0 local `let y = ... in` is the body of `foo`, not a
+    // top-level `let`. Only `foo` and `bar` are functions.
+    let source = "module M\n\
+                  let foo x =\n\
+                  let y = x + 1 in\n\
+                  y\n\
+                  let bar = 2\n";
+    let result = extract(source);
+    let funcs = names_of(&result, NodeKind::Function);
+    assert_eq!(funcs, vec!["bar".to_string(), "foo".to_string()]);
+    assert!(!funcs.contains(&"y".to_string()));
+}
+
+#[test]
+fn unindented_nested_let_in_chain() {
+    let source = "module M\n\
+                  let compute x =\n\
+                  let a = x + 1 in\n\
+                  let b = a * 2 in\n\
+                  let c = b - 3 in\n\
+                  c\n\
+                  let other y = y\n";
+    let result = extract(source);
+    let funcs = names_of(&result, NodeKind::Function);
+    assert_eq!(funcs, vec!["compute".to_string(), "other".to_string()]);
+}
+
+// ---------------------------------------------------------------------------
+// Typeclass-constraint binders {| ... |}
+// ---------------------------------------------------------------------------
+
+#[test]
+fn let_with_named_tc_constraint_binder() {
+    let source = "module M\n\
+                  let cmp (#a:Type) {| d: eq a |} (x:a) (y:a) : bool = d.eqb x y\n";
+    let result = extract(source);
+    assert!(names_of(&result, NodeKind::Function).contains(&"cmp".to_string()));
+}
+
+#[test]
+fn val_operator_with_anonymous_tc_constraint_binder() {
+    // From FStar.Class.Add: `val (++) : #a:_ -> {| additive a |} -> a -> a -> a`
+    let source = "module M\n\
+                  val ( ++ ) : #a:_ -> {| additive a |} -> a -> a -> a\n\
+                  let ( ++ ) = plus\n";
+    let result = extract(source);
+    let funcs: Vec<_> = result
+        .nodes
+        .iter()
+        .filter(|n| n.kind == NodeKind::Function && n.name == "++")
+        .collect();
+    assert_eq!(funcs.len(), 2, "have: {:?}", names_of_all(&result));
+}
+
+#[test]
+fn instance_with_anonymous_tc_binder_resolves_class_after_binder() {
+    let source = "module M\ninstance foo {| eq a |} : ord a = mk_ord ()\n";
+    let result = extract(source);
+    let impl_node = find(&result, "foo");
+    assert_eq!(impl_node.kind, NodeKind::Impl);
+    // The implemented class is `ord` (after the binder), not `eq` (inside it).
+    assert!(result.unresolved_refs.iter().any(|r| r.from_node_id
+        == impl_node.id
+        && r.reference_kind == EdgeKind::Implements
+        && r.reference_name == "ord"));
+    assert!(!result
+        .unresolved_refs
+        .iter()
+        .any(|r| r.reference_name == "eq"));
+}
+
+#[test]
+fn instance_with_named_tc_binder_skips_binder_colon() {
+    // From CuteCAS: the `:` inside `{| g: gcd_domain t |}` must be skipped; the
+    // implemented class is `integral_domain`.
+    let source = "module M\n\
+                  instance id_of_gcd t {| g: gcd_domain t |} : integral_domain t = g.gcd_id\n";
+    let result = extract(source);
+    let impl_node = find(&result, "id_of_gcd");
+    assert_eq!(impl_node.kind, NodeKind::Impl);
+    assert!(result.unresolved_refs.iter().any(|r| r.from_node_id
+        == impl_node.id
+        && r.reference_kind == EdgeKind::Implements
+        && r.reference_name == "integral_domain"));
+    assert!(!result
+        .unresolved_refs
+        .iter()
+        .any(|r| r.reference_name == "gcd_domain"));
+}
+
+// ---------------------------------------------------------------------------
+// Monadic let / "let operators" (let?, and?, ( let:: ), ( let* ))
+// ---------------------------------------------------------------------------
+
+#[test]
+fn let_operator_definitions_are_functions() {
+    // From examples/misc/MonadicLetBindings.fst
+    let source = "module M\n\
+                  let (let?) (x: option 'a) (f: 'a -> option 'b) : option 'b = bind x f\n\
+                  let (and?) (x: option 'a) (y: option 'b) : option ('a & 'b) = pair x y\n\
+                  let ( let:: ) (l: list 'a) (f: 'a -> list 'b) : list 'b = concatMap f l\n";
+    let result = extract(source);
+    let funcs = names_of(&result, NodeKind::Function);
+    assert!(funcs.contains(&"let?".to_string()), "have: {funcs:?}");
+    assert!(funcs.contains(&"and?".to_string()), "have: {funcs:?}");
+    assert!(funcs.contains(&"let::".to_string()), "have: {funcs:?}");
+}
+
+#[test]
+fn operator_name_argument_does_not_become_the_decl_name() {
+    // `let sugared1 (let*) (and*) ex ey ez f = ...` — the operators are
+    // parameters; the function is named `sugared1`.
+    let source = "module M\nlet sugared1 (let*) (and*) ex ey ez f = f ex ey ez\n";
+    let result = extract(source);
+    let funcs = names_of(&result, NodeKind::Function);
+    assert!(funcs.contains(&"sugared1".to_string()), "have: {funcs:?}");
+    assert!(!funcs.contains(&"let*".to_string()));
+}
+
+#[test]
+fn monadic_let_bang_in_body_is_not_a_top_level_decl() {
+    let source = "module M\n\
+                  let option_example (a b: list (int & int)) =\n\
+                  \x20 let? haL, haR = head a\n\
+                  \x20 and? hbL, hbR = head b in\n\
+                  \x20 Some (haL + hbR)\n\
+                  let next = 0\n";
+    let result = extract(source);
+    let funcs = names_of(&result, NodeKind::Function);
+    assert_eq!(
+        funcs,
+        vec!["next".to_string(), "option_example".to_string()]
+    );
+}
+
+#[test]
+fn unindented_monadic_let_bang_in_body() {
+    // Same as above but with the monadic binds in column 0.
+    let source = "module M\n\
+                  let option_example a b =\n\
+                  let? haL = head a\n\
+                  and? hbL = head b in\n\
+                  Some (haL + hbL)\n\
+                  let next = 0\n";
+    let result = extract(source);
+    let funcs = names_of(&result, NodeKind::Function);
+    assert_eq!(
+        funcs,
+        vec!["next".to_string(), "option_example".to_string()]
+    );
+}


### PR DESCRIPTION
## Summary

Added support for F* proof-oriented programming language.
This one fetches pre/post-conditions along with top level definition names, which is crucial for F*.

## Motivation

F* diverged from OCaml / F# far enough

## Changes

Added support to fst / fsti F* files

## Test plan

- [x] `cargo test` passes
- [x] `cargo clippy` has no new warnings
- [x] Tested manually against my pet computer algebra project [CuteCAS](https://github.com/hacklex/CuteCAS) (over 50k LoC)

Fixture file added, extraction test added.

## Checklist

- [x] `CHANGELOG.md` updated (under `[Unreleased]` if no version bump)
- [x] No secrets, credentials, or `.env` files included
- [x] No Breaking Changes