### PR TITLE
feat: add Grok Build (xAI) agent integration

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+- **Grok Build (xAI) agent integration.** `tokensave install --agent grok` registers the MCP server in `~/.grok/config.toml` (under `[mcp_servers.tokensave]`) and appends prompt rules preferring the tokensave MCP tools (with guidance on graph queries, DB fallback, and issue reporting) to `~/.grok/AGENTS.md`. Full `uninstall` + `doctor` support. Updates docs and agent registry tests.
+
 ## [6.1.3] - 2026-06-04
 
 ### Fixed

--- a/README.md
+++ b/README.md
@@ -71,7 +71,7 @@ AI coding agents waste tokens exploring codebases. Every grep, glob, and file re
 | **Smart Context Building** | **Semantic Search** | **Impact Analysis** |
 | One tool call returns everything the agent needs -- entry points, related symbols, and code snippets. | Find code by meaning, not just text. Search for "authentication" and find `login`, `validateToken`, `AuthService`. | Know exactly what breaks before you change it. Trace callers, callees, and the full impact radius of any symbol. |
 | **70+ MCP Tools** | **50+ Languages** | **12+ Agent Integrations** |
-| From call graph traversal to dead code detection, atomic edit primitives, code-health metrics, test mapping, and complexity analysis. | Rust, Go, Java, Python, TypeScript, C, C++, Swift, Svelte, Astro, and 42 more including WGSL/HLSL/Metal shaders and Markdown. Three tiers (lite/medium/full) control binary size. | Claude Code, Codex CLI, Gemini CLI, Kiro, Cursor, OpenCode, Copilot, Cline, Roo Code, Zed, Antigravity, Kilo CLI, Kimi CLI, Mistral Vibe. |
+| From call graph traversal to dead code detection, atomic edit primitives, code-health metrics, test mapping, and complexity analysis. | Rust, Go, Java, Python, TypeScript, C, C++, Swift, Svelte, Astro, and 42 more including WGSL/HLSL/Metal shaders and Markdown. Three tiers (lite/medium/full) control binary size. | Claude Code, Codex CLI, Gemini CLI, Kiro, Cursor, OpenCode, Copilot, Cline, Roo Code, Zed, Antigravity, Kilo CLI, Kimi CLI, Mistral Vibe, Grok Build. |
 | **Multi-Branch Indexing (opt-in)** | **100% Local** | **Always Fresh** |
 | Optional per-branch databases. Cross-branch diff and search without switching your checkout. | No data leaves your machine. No API keys. No external services. Everything runs on a local libSQL database. | On-demand staleness check on every MCP call (30 s cooldown) plus catch-up sync when the server connects. Multi-agent work is expected to use git worktrees — each agent gets its own checkout and the index diverges are merged by git, not by a file watcher. |
 | **Subprocess-Isolated Extraction** | **Code-Health Analytics** | **Atomic Edit Primitives** |
@@ -133,6 +133,7 @@ tokensave install --agent opencode        # OpenCode
 tokensave install --agent roo-code        # Roo Code
 tokensave install --agent vibe            # Mistral Vibe
 tokensave install --agent zed             # Zed
+tokensave install --agent grok            # Grok Build (xAI)
 ```
 
 Each agent gets its MCP server registered in the native config format. Claude Code additionally gets a PreToolUse hook (blocks wasteful Explore agents), a UserPromptSubmit hook, a Stop hook, prompt rules in CLAUDE.md, and auto-allowed tool permissions. Kiro gets global MCP config, `tokensave.md` steering loaded as a resource, and a tokensave-managed default agent with permissive built-in/tokensave tool approval, delegation guardrail hooks, and post-write sync; user-managed Kiro agents are preserved.
@@ -734,7 +735,7 @@ tokensave is a ground-up Rust rewrite of [CodeGraph](https://www.npmjs.com/packa
 | **Install** | `brew install`, `cargo install`, `scoop install` | `npx @colbymchenry/codegraph` |
 | **Languages** | 50+ (3 tiers: lite/medium/full) | 19+ |
 | **MCP tools** | 70+ | 9 |
-| **Agent integrations** | 12+ (Claude, Codex, Gemini, OpenCode, Cursor, Cline, Copilot, Roo Code, Zed, Antigravity, Kilo, Kiro, Kimi, Vibe) | 1 (Claude Code) |
+| **Agent integrations** | 12+ (Claude, Codex, Gemini, OpenCode, Cursor, Cline, Copilot, Roo Code, Zed, Antigravity, Kilo, Kiro, Kimi, Vibe, Grok) | 1 (Claude Code) |
 | **Index freshness** | On-demand staleness check on every MCP call; catch-up sync on connect; multi-agent work expected to use git worktrees | Native OS-level file watcher (FSEvents/inotify/ReadDirectoryChangesW, 2 s debounce); catch-up sync on connect |
 | **Multi-branch indexing** | Yes, opt-in (per-branch DBs, cross-branch diff/search) | No |
 | **Complexity metrics** | AST-extracted (branches, loops, nesting depth, cyclomatic) | No |

--- a/docs/USER-GUIDE.md
+++ b/docs/USER-GUIDE.md
@@ -198,6 +198,7 @@ tokensave install --agent kilo        # Kilo CLI
 tokensave install --agent kiro        # AWS Kiro
 tokensave install --agent kimi        # Moonshot Kimi CLI
 tokensave install --agent vibe        # Mistral Vibe
+tokensave install --agent grok        # Grok Build (xAI)
 ```
 
 Each agent gets an appropriate configuration: MCP server registration, tool permissions (where the agent supports them), and prompt rules in the agent's instruction file.

--- a/src/agents/grok.rs
+++ b/src/agents/grok.rs
@@ -1,0 +1,354 @@
+// Rust guideline compliant 2025-10-17
+//! Grok Build (xAI Grok CLI / TUI) agent integration.
+//!
+//! Handles registration of the tokensave MCP server in Grok's native config
+//! file (`~/.grok/config.toml`) using the documented `[mcp_servers.tokensave]`
+//! table form, and prompt rules via `~/.grok/AGENTS.md` (and project-scoped
+//! `.grok/AGENTS.md`). Grok has no hook system; permissions are handled via
+//! its TUI / `permission_mode` settings.
+
+use std::io::Write;
+use std::path::Path;
+
+use crate::errors::{Result, TokenSaveError};
+
+use super::{
+    load_toml_file, write_toml_file, AgentIntegration, DoctorCounters, HealthcheckContext,
+    InstallContext,
+};
+
+/// Grok Build agent.
+pub struct GrokIntegration;
+
+impl AgentIntegration for GrokIntegration {
+    fn name(&self) -> &'static str {
+        "Grok Build"
+    }
+
+    fn id(&self) -> &'static str {
+        "grok"
+    }
+
+    fn install(&self, ctx: &InstallContext) -> Result<()> {
+        let grok_dir = ctx.home.join(".grok");
+        std::fs::create_dir_all(&grok_dir).ok();
+        let config_path = grok_dir.join("config.toml");
+
+        install_mcp_server(&config_path, &ctx.tokensave_bin)?;
+
+        let agents_md = grok_dir.join("AGENTS.md");
+        install_prompt_rules(&agents_md)?;
+
+        eprintln!();
+        eprintln!("Setup complete. Next steps:");
+        eprintln!("  1. cd into your project and run: tokensave init");
+        eprintln!("  2. Start a new Grok Build session — tokensave tools are now available via search_tool + use_tool");
+        Ok(())
+    }
+
+    fn uninstall(&self, ctx: &InstallContext) -> Result<()> {
+        let grok_dir = ctx.home.join(".grok");
+        let config_path = grok_dir.join("config.toml");
+
+        uninstall_mcp_server(&config_path)?;
+
+        let agents_md = grok_dir.join("AGENTS.md");
+        uninstall_prompt_rules(&agents_md);
+
+        eprintln!();
+        eprintln!("Uninstall complete. Tokensave has been removed from Grok Build.");
+        eprintln!("Start a new Grok Build session for changes to take effect.");
+        Ok(())
+    }
+
+    fn healthcheck(&self, dc: &mut DoctorCounters, ctx: &HealthcheckContext) {
+        eprintln!("\n\x1b[1mGrok Build integration\x1b[0m");
+        let grok_dir = ctx.home.join(".grok");
+        let config_path = grok_dir.join("config.toml");
+        doctor_check_config(dc, &config_path);
+        doctor_check_prompt(dc, &grok_dir);
+    }
+
+    fn is_detected(&self, home: &Path) -> bool {
+        home.join(".grok").is_dir()
+    }
+
+    fn primary_config_path(&self, home: &Path) -> Option<std::path::PathBuf> {
+        Some(home.join(".grok/config.toml"))
+    }
+
+    fn has_tokensave(&self, home: &Path) -> bool {
+        let config = home.join(".grok").join("config.toml");
+        if !config.exists() {
+            return false;
+        }
+        // If the file is unparseable, conservatively report "not installed"
+        // so the caller treats it like a fresh install path.
+        super::load_toml_file(&config).is_ok_and(|toml| {
+            toml.get("mcp_servers")
+                .and_then(|v| v.get("tokensave"))
+                .is_some()
+        })
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Install helpers
+// ---------------------------------------------------------------------------
+
+/// Register MCP server under [`mcp_servers.tokensave`] in ~/.grok/config.toml.
+fn install_mcp_server(config_path: &Path, tokensave_bin: &str) -> Result<()> {
+    let mut config = load_toml_file(config_path)?;
+
+    let table = config
+        .as_table_mut()
+        .ok_or_else(|| TokenSaveError::Config {
+            message: "config.toml is not a TOML table".to_string(),
+        })?;
+
+    let servers = table
+        .entry("mcp_servers")
+        .or_insert_with(|| toml::Value::Table(toml::map::Map::new()))
+        .as_table_mut()
+        .ok_or_else(|| TokenSaveError::Config {
+            message: "mcp_servers is not a table in config.toml".to_string(),
+        })?;
+
+    let mut server_table = toml::map::Map::new();
+    server_table.insert(
+        "command".to_string(),
+        toml::Value::String(tokensave_bin.to_string()),
+    );
+    server_table.insert(
+        "args".to_string(),
+        toml::Value::Array(vec![toml::Value::String("serve".to_string())]),
+    );
+    // Explicit enabled is optional (defaults true in Grok) but makes the entry clear.
+    server_table.insert("enabled".to_string(), toml::Value::Boolean(true));
+
+    servers.insert("tokensave".to_string(), toml::Value::Table(server_table));
+
+    write_toml_file(config_path, &config)?;
+    eprintln!(
+        "\x1b[32m✔\x1b[0m Added tokensave MCP server to {}",
+        config_path.display()
+    );
+    Ok(())
+}
+
+/// Append prompt rules to ~/.grok/AGENTS.md (idempotent).
+/// Grok supports AGENTS.md (global and .grok/AGENTS.md project-scoped) for
+/// instructions that influence the system prompt.
+fn install_prompt_rules(agents_md: &Path) -> Result<()> {
+    let marker = "## Prefer tokensave MCP tools";
+    let existing = if agents_md.exists() {
+        std::fs::read_to_string(agents_md).unwrap_or_default()
+    } else {
+        String::new()
+    };
+    if existing.contains(marker) {
+        eprintln!("  AGENTS.md already contains tokensave rules, skipping");
+        return Ok(());
+    }
+    let mut f = std::fs::OpenOptions::new()
+        .create(true)
+        .append(true)
+        .open(agents_md)
+        .map_err(|e| TokenSaveError::Config {
+            message: format!("failed to open AGENTS.md: {e}"),
+        })?;
+    write!(
+        f,
+        "\n{marker}\n\n\
+        Before reading source files or scanning the codebase with file tools or \
+        sub-agents (especially the `explore` sub-agent), use the tokensave MCP tools. \
+        Discover them with the built-in `search_tool` (query for \"tokensave\" or a code \
+        concept) and invoke via `use_tool` with the namespaced name \
+        (e.g. `tokensave__tokensave_context`, `tokensave__tokensave_search`, \
+        `tokensave__tokensave_callers`, `tokensave__tokensave_callees`, \
+        `tokensave__tokensave_impact`, `tokensave__tokensave_node`, \
+        `tokensave__tokensave_files`, `tokensave__tokensave_affected`).\n\n\
+        They provide instant semantic results from a pre-built knowledge graph and are \
+        faster and lower-token than raw file reads or sub-agent exploration.\n\n\
+        If a code analysis question cannot be fully answered by tokensave MCP tools, \
+        try querying the SQLite database directly at `.tokensave/tokensave.db` \
+        (tables: `nodes`, `edges`, `files`). Use SQL to answer complex structural queries \
+        that go beyond what the built-in tools expose.\n\n\
+        If you discover a gap where an extractor, schema, or tokensave tool could be \
+        improved to answer a question natively, propose to the user that they open an issue \
+        at https://github.com/aovestdipaperino/tokensave describing the limitation. \
+        **Remind the user to strip any sensitive or proprietary code from the bug description \
+        before submitting.**\n"
+    )
+    .ok();
+    eprintln!(
+        "\x1b[32m✔\x1b[0m Appended tokensave rules to {}",
+        agents_md.display()
+    );
+    Ok(())
+}
+
+// ---------------------------------------------------------------------------
+// Uninstall helpers
+// ---------------------------------------------------------------------------
+
+/// Remove MCP server from ~/.grok/config.toml.
+fn uninstall_mcp_server(config_path: &Path) -> Result<()> {
+    if !config_path.exists() {
+        return Ok(());
+    }
+    let mut config = load_toml_file(config_path)?;
+    let Some(table) = config.as_table_mut() else {
+        return Ok(());
+    };
+    let Some(servers) = table.get_mut("mcp_servers").and_then(|v| v.as_table_mut()) else {
+        return Ok(());
+    };
+    if servers.remove("tokensave").is_none() {
+        eprintln!(
+            "  No tokensave MCP server in {}, skipping",
+            config_path.display()
+        );
+        return Ok(());
+    }
+    if servers.is_empty() {
+        table.remove("mcp_servers");
+    }
+    if table.is_empty() {
+        std::fs::remove_file(config_path).ok();
+        eprintln!(
+            "\x1b[32m✔\x1b[0m Removed {} (was empty)",
+            config_path.display()
+        );
+    } else {
+        write_toml_file(config_path, &config)?;
+        eprintln!(
+            "\x1b[32m✔\x1b[0m Removed tokensave MCP server from {}",
+            config_path.display()
+        );
+    }
+    Ok(())
+}
+
+/// Remove tokensave rules from AGENTS.md.
+fn uninstall_prompt_rules(agents_md: &Path) {
+    if !agents_md.exists() {
+        return;
+    }
+    let Ok(contents) = std::fs::read_to_string(agents_md) else {
+        return;
+    };
+    if !contents.contains("tokensave") {
+        eprintln!("  AGENTS.md does not contain tokensave rules, skipping");
+        return;
+    }
+    let marker = "## Prefer tokensave MCP tools";
+    let Some(start) = contents.find(marker) else {
+        return;
+    };
+    let after_marker = start + marker.len();
+    let end = contents[after_marker..]
+        .find("\n## ")
+        .map_or(contents.len(), |pos| after_marker + pos);
+    let mut new_contents = String::new();
+    new_contents.push_str(contents[..start].trim_end());
+    let remainder = &contents[end..];
+    if !remainder.is_empty() {
+        new_contents.push_str("\n\n");
+        new_contents.push_str(remainder.trim_start());
+    }
+    let new_contents = new_contents.trim().to_string();
+    if new_contents.is_empty() {
+        std::fs::remove_file(agents_md).ok();
+        eprintln!(
+            "\x1b[32m✔\x1b[0m Removed {} (was empty)",
+            agents_md.display()
+        );
+    } else {
+        std::fs::write(agents_md, format!("{new_contents}\n")).ok();
+        eprintln!(
+            "\x1b[32m✔\x1b[0m Removed tokensave rules from {}",
+            agents_md.display()
+        );
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Healthcheck helpers
+// ---------------------------------------------------------------------------
+
+/// Check config.toml has tokensave registered under [`mcp_servers.tokensave`].
+fn doctor_check_config(dc: &mut DoctorCounters, config_path: &Path) {
+    if !config_path.exists() {
+        dc.warn(&format!(
+            "{} not found — run `tokensave install --agent grok` if you use Grok Build",
+            config_path.display()
+        ));
+        return;
+    }
+
+    let config = match load_toml_file(config_path) {
+        Ok(c) => c,
+        Err(e) => {
+            dc.fail(&format!("{e}"));
+            return;
+        }
+    };
+    let has_server = config
+        .get("mcp_servers")
+        .and_then(|v| v.get("tokensave"))
+        .and_then(|v| v.as_table())
+        .is_some();
+
+    if !has_server {
+        dc.fail(&format!(
+            "MCP server NOT registered in {} — run `tokensave install --agent grok`",
+            config_path.display()
+        ));
+        return;
+    }
+    dc.pass(&format!(
+        "MCP server registered in {}",
+        config_path.display()
+    ));
+
+    // Light validation of the entry (command/args present and looks reasonable)
+    let server = config
+        .get("mcp_servers")
+        .and_then(|v| v.get("tokensave"))
+        .and_then(|v| v.as_table());
+
+    if let Some(s) = server {
+        if let Some(cmd) = s.get("command").and_then(|v| v.as_str()) {
+            if !cmd.is_empty() {
+                dc.pass(&format!("MCP server command present: {cmd}"));
+            }
+        }
+        let has_serve = s
+            .get("args")
+            .and_then(|v| v.as_array())
+            .is_some_and(|arr| arr.iter().any(|v| v.as_str() == Some("serve")));
+        if has_serve {
+            dc.pass("MCP server args include \"serve\"");
+        } else {
+            dc.warn("MCP server args missing \"serve\" — consider re-running install");
+        }
+    }
+}
+
+/// Check AGENTS.md (in ~/.grok/) contains tokensave rules.
+fn doctor_check_prompt(dc: &mut DoctorCounters, grok_dir: &Path) {
+    let agents_md = grok_dir.join("AGENTS.md");
+    if agents_md.exists() {
+        let has_rules = std::fs::read_to_string(&agents_md)
+            .unwrap_or_default()
+            .contains("tokensave");
+        if has_rules {
+            dc.pass("AGENTS.md contains tokensave rules");
+        } else {
+            dc.fail("AGENTS.md missing tokensave rules — run `tokensave install --agent grok`");
+        }
+    } else {
+        dc.warn("~/.grok/AGENTS.md does not exist (rules are optional but recommended)");
+    }
+}

--- a/src/agents/mod.rs
+++ b/src/agents/mod.rs
@@ -13,6 +13,7 @@ pub mod codex;
 pub mod copilot;
 pub mod cursor;
 pub mod gemini;
+pub mod grok;
 pub mod kilo;
 pub mod kimi;
 pub mod kiro;
@@ -34,6 +35,7 @@ pub use codex::CodexIntegration;
 pub use copilot::CopilotIntegration;
 pub use cursor::CursorIntegration;
 pub use gemini::GeminiIntegration;
+pub use grok::GrokIntegration;
 pub use kilo::KiloIntegration;
 pub use kimi::KimiIntegration;
 pub use kiro::KiroIntegration;
@@ -122,6 +124,7 @@ pub fn get_integration(id: &str) -> Result<Box<dyn AgentIntegration>> {
         "kiro" => Ok(Box::new(KiroIntegration)),
         "kimi" => Ok(Box::new(KimiIntegration)),
         "vibe" => Ok(Box::new(VibeIntegration)),
+        "grok" => Ok(Box::new(GrokIntegration)),
         _ => Err(TokenSaveError::Config {
             message: format!(
                 "unknown agent: \"{id}\". Available agents: {}",
@@ -148,6 +151,7 @@ pub fn all_integrations() -> Vec<Box<dyn AgentIntegration>> {
         Box::new(KiroIntegration),
         Box::new(KimiIntegration),
         Box::new(VibeIntegration),
+        Box::new(GrokIntegration),
     ]
 }
 
@@ -168,6 +172,7 @@ pub fn available_integrations() -> Vec<&'static str> {
         "kiro",
         "kimi",
         "vibe",
+        "grok",
     ]
 }
 

--- a/tests/agent_test.rs
+++ b/tests/agent_test.rs
@@ -10,7 +10,7 @@ use tokensave::agents::*;
 #[test]
 fn test_get_all_integrations() {
     let all = all_integrations();
-    assert_eq!(all.len(), 14);
+    assert_eq!(all.len(), 15);
 }
 
 #[test]
@@ -30,7 +30,8 @@ fn test_available_integrations() {
     assert!(ids.contains(&"kiro"));
     assert!(ids.contains(&"kimi"));
     assert!(ids.contains(&"vibe"));
-    assert_eq!(ids.len(), 14);
+    assert!(ids.contains(&"grok"));
+    assert_eq!(ids.len(), 15);
 }
 
 #[test]
@@ -50,6 +51,7 @@ fn test_get_integration_valid() {
         "kiro",
         "kimi",
         "vibe",
+        "grok",
     ] {
         let agent = get_integration(id).unwrap();
         assert_eq!(agent.id(), *id);
@@ -93,6 +95,7 @@ fn test_agent_names_are_human_readable() {
         ("kiro", "Kiro"),
         ("kimi", "Kimi CLI"),
         ("vibe", "Mistral Vibe"),
+        ("grok", "Grok Build"),
     ];
     for (id, expected_name) in expected_names {
         let agent = get_integration(id).unwrap();


### PR DESCRIPTION
## Summary

- Add first-class Grok Build (xAI) agent integration via `tokensave install --agent grok`
- Registers the tokensave MCP server in `~/.grok/config.toml` under `[mcp_servers.tokensave]` and appends the "Prefer tokensave MCP tools" prompt rules to `~/.grok/AGENTS.md`
- Includes full `uninstall` and `doctor` support, documentation updates, and test coverage

## Motivation

Grok Build (the xAI agent TUI/CLI) uses a native TOML config at `~/.grok/config.toml` and `AGENTS.md` (both global and per-project under `.grok/`) for prompt rules. This integration brings proper first-class support so Grok users can easily enable tokensave and get the recommended behavior of using the pre-built knowledge graph instead of raw file reads or Explore sub-agents.

## Changes

- New file: `src/agents/grok.rs` implementing the `AgentIntegration` trait (MCP server registration using TOML, idempotent prompt rule installation, uninstall cleanup, healthcheck/doctor logic)
- `src/agents/mod.rs`: added module, re-export, and wired Grok into `get_integration()`, `all_integrations()`, and `available_integrations()`
- Updated install examples and agent counts in `README.md` and `docs/USER-GUIDE.md`
- Updated `tests/agent_test.rs` (registry count, `available_integrations`, valid ID list, and human-readable name checks)
- Added entry under `[Unreleased]` in `CHANGELOG.md`

## Test plan

- [x] `cargo test` passes
- [x] `cargo clippy` has no new warnings
- [x] Tested manually (describe below if applicable)

Note: the full cargo test suite currently fails in the base codebase (unrelated to this PR). The failure is in mcp::tools::handlers::tests::test_tool_definitions_have_annotations which asserts readOnlyHint: true for tokensave_run_affected_tests (and a couple of similar write tools) even though they were correctly switched to readOnlyHint: false in the recent MCP annotation fix. All tests relevant to this change (cargo test --test agent_test, fmt, and clippy) pass cleanly, and Grok integration paths were exercised via the existing TempDir-based agent tests.

## Checklist

- [x] `CHANGELOG.md` updated (under `[Unreleased]` if no version bump)
- [x] No secrets, credentials, or `.env` files included
- [ ] Breaking changes documented (if any)