### PR TITLE
fix(context): merge entry-point channels by MAX score (#117)

### DIFF
--- a/src/context/builder.rs
+++ b/src/context/builder.rs
@@ -179,12 +179,22 @@ impl<'a> ContextBuilder<'a> {
         symbols: &[String],
         options: &BuildContextOptions,
     ) -> Result<Vec<Node>> {
+        // Base score for an exact name match. Far above any realistic BM25
+        // score (~1e-6 in practice), so a perfect name match always wins the
+        // MAX merge over FTS noise and ranks ahead of it.
+        const EXACT_MATCH_SCORE: f64 = 20.0;
         debug_assert!(
             !query.is_empty(),
             "find_entry_points called with empty query"
         );
         debug_assert!(options.search_limit > 0, "search_limit must be positive");
-        let mut seen_ids: HashSet<String> = options.exclude_node_ids.clone();
+        // `excluded` is the hard exclusion set: nodes here never enter
+        // `candidates`, regardless of which channel surfaces them.
+        let excluded: HashSet<String> = options.exclude_node_ids.clone();
+        // `index_of` maps an already-collected node id to its slot in
+        // `candidates`, so a node surfaced by multiple channels (FTS + exact
+        // name) is merged in place via MAX score rather than first-seen-wins.
+        let mut index_of: HashMap<String, usize> = HashMap::new();
         let mut candidates: Vec<SearchResult> = Vec::new();
         let cap = options.max_nodes * 2;
 
@@ -221,9 +231,17 @@ impl<'a> ContextBuilder<'a> {
             }
             let results = self.db.search_nodes(term, options.search_limit).await?;
             for sr in results {
-                if Self::score_passes(sr.score, options.min_score)
-                    && seen_ids.insert(sr.node.id.clone())
+                if !Self::score_passes(sr.score, options.min_score)
+                    || excluded.contains(&sr.node.id)
                 {
+                    continue;
+                }
+                // Merge by MAX score: a node surfaced by an earlier term keeps
+                // the higher of the two BM25 scores instead of being dropped.
+                if let Some(&idx) = index_of.get(&sr.node.id) {
+                    candidates[idx].score = candidates[idx].score.max(sr.score);
+                } else {
+                    index_of.insert(sr.node.id.clone(), candidates.len());
                     candidates.push(sr);
                 }
             }
@@ -242,9 +260,20 @@ impl<'a> ContextBuilder<'a> {
                 .search_nodes_by_exact_name(&exact_names, options.search_limit)
                 .await?;
             for node in exact_nodes {
-                if seen_ids.insert(node.id.clone()) {
-                    // Give exact matches a high base score so they compete well.
-                    candidates.push(SearchResult { node, score: 20.0 });
+                if excluded.contains(&node.id) {
+                    continue;
+                }
+                // Exact matches bypass the min_score gate by design. If the node
+                // already arrived via FTS (with a low score), upgrade it in place
+                // to the exact-match score rather than dropping the duplicate.
+                if let Some(&idx) = index_of.get(&node.id) {
+                    candidates[idx].score = candidates[idx].score.max(EXACT_MATCH_SCORE);
+                } else {
+                    index_of.insert(node.id.clone(), candidates.len());
+                    candidates.push(SearchResult {
+                        node,
+                        score: EXACT_MATCH_SCORE,
+                    });
                 }
             }
         }

--- a/tests/context_test.rs
+++ b/tests/context_test.rs
@@ -505,9 +505,7 @@ async fn test_exact_name_match_wins_max_merge() {
 
     // Excluding the exact-match node must still keep it out entirely.
     let opts_excl = BuildContextOptions {
-        exclude_node_ids: vec!["variant:validate".to_string()]
-            .into_iter()
-            .collect(),
+        exclude_node_ids: vec!["variant:validate".to_string()].into_iter().collect(),
         ..Default::default()
     };
     let ctx_excl = builder

--- a/tests/context_test.rs
+++ b/tests/context_test.rs
@@ -408,6 +408,122 @@ async fn test_exclude_node_ids_deduplication() {
 }
 
 #[tokio::test]
+async fn test_exact_name_match_wins_max_merge() {
+    // Regression for #117: a node that matches BOTH an FTS term (with a tiny
+    // BM25 score) and the exact-name lookup must carry the exact-match base
+    // score, not the low FTS score it happened to be seen with first.
+    use tempfile::TempDir;
+    use tokensave::context::ContextBuilder;
+    use tokensave::db::Database;
+
+    let dir = TempDir::new().unwrap();
+    let project = dir.path();
+
+    let (db, _) = Database::initialize(&project.join(".tokensave/tokensave.db"))
+        .await
+        .unwrap();
+
+    // Exact-match target: a low-boost node (enum variant, private). Without the
+    // exact-match score it would rank dead last after structural re-ranking.
+    // Name is camelCase so the query token is extracted as a symbol (a plain
+    // lowercase word is not), which is what feeds the exact-name lookup.
+    db.insert_node(&Node {
+        id: "variant:validate".to_string(),
+        kind: NodeKind::EnumVariant,
+        name: "validateInput".to_string(),
+        qualified_name: "src/lib.rs::Action::validateInput".to_string(),
+        file_path: "src/lib.rs".to_string(),
+        start_line: 1,
+        attrs_start_line: 1,
+        end_line: 1,
+        start_column: 0,
+        end_column: 10,
+        signature: Some("validateInput".to_string()),
+        docstring: None,
+        visibility: Visibility::Private,
+        is_async: false,
+        branches: 0,
+        loops: 0,
+        returns: 0,
+        max_nesting: 0,
+        unsafe_blocks: 0,
+        unchecked_calls: 0,
+        assertions: 0,
+        updated_at: 0,
+        parent_id: None,
+    })
+    .await
+    .unwrap();
+
+    // Competitor: a high-boost node (public function) that only matches the FTS
+    // "validate" prefix term, never the exact symbol names. Its structural boost
+    // dwarfs the enum variant's, so under the old first-seen bug it ranks first.
+    db.insert_node(&Node {
+        id: "fn:validate_helper".to_string(),
+        kind: NodeKind::Function,
+        name: "validateRequest".to_string(),
+        qualified_name: "src/lib.rs::validateRequest".to_string(),
+        file_path: "src/lib.rs".to_string(),
+        start_line: 2,
+        attrs_start_line: 2,
+        end_line: 6,
+        start_column: 0,
+        end_column: 1,
+        signature: Some("pub fn validateRequest()".to_string()),
+        docstring: None,
+        visibility: Visibility::Pub,
+        is_async: false,
+        branches: 0,
+        loops: 0,
+        returns: 0,
+        max_nesting: 0,
+        unsafe_blocks: 0,
+        unchecked_calls: 0,
+        assertions: 0,
+        updated_at: 0,
+        parent_id: None,
+    })
+    .await
+    .unwrap();
+
+    let builder = ContextBuilder::new(&db, project);
+
+    // Both nodes match the "validate" FTS term; only validateInput is an exact
+    // name match for the query's extracted symbols.
+    let ctx = builder
+        .build_context("validateInput", &BuildContextOptions::default())
+        .await
+        .unwrap();
+
+    // The exact-match node must carry the high base score and rank first,
+    // despite its much weaker structural boost.
+    assert_eq!(
+        ctx.entry_points.first().map(|n| n.id.as_str()),
+        Some("variant:validate"),
+        "exact-name match should rank first via MAX-merge, not be buried by BM25"
+    );
+
+    // Excluding the exact-match node must still keep it out entirely.
+    let opts_excl = BuildContextOptions {
+        exclude_node_ids: vec!["variant:validate".to_string()]
+            .into_iter()
+            .collect(),
+        ..Default::default()
+    };
+    let ctx_excl = builder
+        .build_context("validateInput", &opts_excl)
+        .await
+        .unwrap();
+    assert!(
+        !ctx_excl
+            .entry_points
+            .iter()
+            .any(|n| n.id == "variant:validate"),
+        "excluded node must not reappear via the exact-name supplement"
+    );
+}
+
+#[tokio::test]
 async fn test_query_ignore_filters_context_entry_points() {
     use tempfile::TempDir;
     use tokensave::config::{load_query_ignore, QueryIgnore};


### PR DESCRIPTION
Fixes #117.

## Problem
`find_entry_points` (`src/context/builder.rs`) merged search channels with first-seen dedup. A node returned by FTS first (low BM25 score) was skipped at the exact-name step because `seen_ids` already contained it, so the exact-match base score (20.0) was dropped and the node stayed buried by BM25 noise — defeating the exact-name supplement.

## Fix
Merge by **max score across channels**. Split the overloaded `seen_ids` into a dedicated `excluded` set + an `index_of` map; on a duplicate, upgrade the stored score via `score.max(new)`. Exact matches upgrade an existing entry to the base score instead of being discarded. `min_score` gate, `cap` early-exit, and `exclude_node_ids` exclusion all preserved across every channel.

## Tests
- Added `test_exact_name_match_wins_max_merge` (verified it FAILS on the buggy code, passes with the fix).
- `cargo test --test context_test` 16 passed; `cargo test --lib context::builder` 15 passed; clippy clean on touched files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)