### PR TITLE
feat(accounting): add 'tokensave discover' missed-opportunity analyzer (#123)

### DIFF
--- a/src/accounting/discover.rs
+++ b/src/accounting/discover.rs
@@ -1,0 +1,329 @@
+//! Missed-opportunity analyzer over ingested Claude Code transcript turns.
+//!
+//! Scans the `turns` table and flags turns that consisted *only* of
+//! file-navigation tools (`Read`, `Grep`, `Glob`) — work a tokensave graph
+//! query (`search`, `context`, `callers`, `callees`, `impact`, `outline`,
+//! `read`, `node`) could have served far more cheaply. Results are bucketed by
+//! the navigation tool that drove the turn, with a deliberately CONSERVATIVE
+//! estimate of recoverable input tokens.
+//!
+//! # Estimation method and assumptions
+//!
+//! The `turns` table records, per turn, the comma-joined `tool_names` and the
+//! `input_tokens` billed for that turn. It does **not** store the byte/char
+//! size of the content each navigation tool returned, nor the content of
+//! `Bash` commands (only the literal tool name `Bash` is persisted). Two
+//! consequences follow, and we stay strictly within what the data supports:
+//!
+//! 1. Bash-based navigation (`grep`/`find`/`cat`/`rg`) cannot be detected here,
+//!    because command text is not in the table. Those turns are simply not
+//!    counted — this makes the analyzer a lower bound, never an over-claim.
+//! 2. We cannot compute exact recoverable tokens (that would need the size of
+//!    the file payload a `Read`/`Grep`/`Glob` pulled into context). Instead we
+//!    report the **addressable** input tokens — the full `input_tokens` spent
+//!    on replaceable navigation turns — and a clearly-labeled conservative
+//!    lower-bound recoverable figure: `addressable * RECOVERABLE_FRACTION`.
+//!
+//! A turn is "replaceable" only when *every* tool it used is a navigation tool;
+//! a turn that also edits, runs Bash, delegates, etc. is left out entirely.
+//! This keeps the count conservative and avoids attributing edit-turn cost to
+//! navigation.
+
+/// Conservative fraction of a navigation turn's input tokens treated as
+/// recoverable by a graph query.
+///
+/// A navigation turn's `input_tokens` covers the system prompt, prior
+/// conversation, and tool-result payloads carried in context — not just the
+/// freshly-read file. A graph query returns a compact slice instead of whole
+/// files, but cannot shrink the fixed conversational overhead. We therefore
+/// claim only half the addressable input as recoverable. This is intentionally
+/// pessimistic: it is a stated lower bound, not a measured value. Changing it
+/// only rescales the recoverable column; the addressable figure is exact.
+pub const RECOVERABLE_FRACTION: f64 = 0.5;
+
+/// Which tokensave graph query would have replaced a navigation tool.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+pub enum NavBucket {
+    /// `Read` of a file → `outline` / `read` / `node`.
+    Read,
+    /// `Grep` across files → `search` / `callers` / `callees` / `impact`.
+    Grep,
+    /// `Glob` file discovery → `files` / `search`.
+    Glob,
+}
+
+impl NavBucket {
+    /// Short stable identifier (used for ordering and machine output).
+    pub fn as_str(&self) -> &'static str {
+        match self {
+            Self::Read => "read",
+            Self::Grep => "grep",
+            Self::Glob => "glob",
+        }
+    }
+
+    /// The navigation tool name this bucket corresponds to.
+    pub fn tool_name(&self) -> &'static str {
+        match self {
+            Self::Read => "Read",
+            Self::Grep => "Grep",
+            Self::Glob => "Glob",
+        }
+    }
+
+    /// The tokensave query/queries that would have served the same intent.
+    pub fn suggestion(&self) -> &'static str {
+        match self {
+            Self::Read => "outline / read / node",
+            Self::Grep => "search / callers / callees / impact",
+            Self::Glob => "files / search",
+        }
+    }
+}
+
+/// The navigation tool names this analyzer recognizes from `tool_names`.
+const NAV_TOOLS: [&str; 3] = ["Read", "Grep", "Glob"];
+
+/// Per-bucket tally of replaceable navigation turns.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct BucketStat {
+    pub bucket: NavBucket,
+    /// Number of replaceable navigation turns attributed to this bucket.
+    pub turns: u64,
+    /// Sum of `input_tokens` across those turns (the "addressable" total).
+    pub addressable_input_tokens: u64,
+}
+
+impl BucketStat {
+    /// Conservative lower-bound recoverable input tokens for this bucket.
+    ///
+    /// Defined as `addressable_input_tokens * RECOVERABLE_FRACTION`, rounded
+    /// down. See the module-level docs for the assumption behind the fraction.
+    pub fn recoverable_input_tokens(&self) -> u64 {
+        ((self.addressable_input_tokens as f64) * RECOVERABLE_FRACTION) as u64
+    }
+}
+
+/// Result of analyzing a set of turns for replaceable navigation.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct DiscoverReport {
+    /// Total turns examined (navigation and non-navigation alike).
+    pub total_turns: u64,
+    /// Per-bucket stats, ranked by addressable input tokens descending.
+    pub buckets: Vec<BucketStat>,
+}
+
+impl DiscoverReport {
+    /// Total replaceable navigation turns across all buckets.
+    pub fn total_replaceable_turns(&self) -> u64 {
+        self.buckets.iter().map(|b| b.turns).sum()
+    }
+
+    /// Total addressable input tokens across all buckets.
+    pub fn total_addressable_input_tokens(&self) -> u64 {
+        self.buckets
+            .iter()
+            .map(|b| b.addressable_input_tokens)
+            .sum()
+    }
+
+    /// Total conservative recoverable input tokens across all buckets.
+    pub fn total_recoverable_input_tokens(&self) -> u64 {
+        self.buckets
+            .iter()
+            .map(BucketStat::recoverable_input_tokens)
+            .sum()
+    }
+}
+
+/// Split a stored `tool_names` value (comma-joined) into trimmed names.
+fn split_tools(tool_names: &str) -> Vec<&str> {
+    tool_names
+        .split(',')
+        .map(str::trim)
+        .filter(|s| !s.is_empty())
+        .collect()
+}
+
+/// Decide whether a turn is "replaceable navigation" and, if so, which bucket.
+///
+/// A turn qualifies only when it is non-empty and *every* tool it used is a
+/// recognized navigation tool. Mixed turns (navigation + edit/Bash/etc.) return
+/// `None` so their cost is never attributed to navigation. When several
+/// navigation tools appear, the bucket is chosen by a fixed priority
+/// (`Grep` > `Glob` > `Read`): a cross-file search is the strongest signal of
+/// an opportunity a graph query would have answered, so it wins attribution.
+fn classify_nav(tools: &[&str]) -> Option<NavBucket> {
+    if tools.is_empty() {
+        return None;
+    }
+    if !tools.iter().all(|t| NAV_TOOLS.contains(t)) {
+        return None;
+    }
+    if tools.contains(&"Grep") {
+        Some(NavBucket::Grep)
+    } else if tools.contains(&"Glob") {
+        Some(NavBucket::Glob)
+    } else {
+        Some(NavBucket::Read)
+    }
+}
+
+/// Analyze `(tool_names, input_tokens)` rows into a ranked [`DiscoverReport`].
+///
+/// Pure function over already-fetched rows: deterministic, no I/O, no LLM. The
+/// caller supplies rows via [`crate::global_db::GlobalDb::nav_turns_since`].
+pub fn analyze(turns: &[(String, u64)]) -> DiscoverReport {
+    let mut read = BucketStat {
+        bucket: NavBucket::Read,
+        turns: 0,
+        addressable_input_tokens: 0,
+    };
+    let mut grep = BucketStat {
+        bucket: NavBucket::Grep,
+        turns: 0,
+        addressable_input_tokens: 0,
+    };
+    let mut glob = BucketStat {
+        bucket: NavBucket::Glob,
+        turns: 0,
+        addressable_input_tokens: 0,
+    };
+
+    for (tool_names, input_tokens) in turns {
+        let tools = split_tools(tool_names);
+        if let Some(bucket) = classify_nav(&tools) {
+            let stat = match bucket {
+                NavBucket::Read => &mut read,
+                NavBucket::Grep => &mut grep,
+                NavBucket::Glob => &mut glob,
+            };
+            stat.turns += 1;
+            stat.addressable_input_tokens =
+                stat.addressable_input_tokens.saturating_add(*input_tokens);
+        }
+    }
+
+    // Keep only buckets that actually fired, ranked by addressable tokens
+    // descending (ties broken by the stable bucket identifier).
+    let mut buckets: Vec<BucketStat> = [read, grep, glob]
+        .into_iter()
+        .filter(|b| b.turns > 0)
+        .collect();
+    buckets.sort_by(|a, b| {
+        b.addressable_input_tokens
+            .cmp(&a.addressable_input_tokens)
+            .then_with(|| a.bucket.as_str().cmp(b.bucket.as_str()))
+    });
+
+    DiscoverReport {
+        total_turns: turns.len() as u64,
+        buckets,
+    }
+}
+
+#[cfg(test)]
+#[allow(clippy::unwrap_used, clippy::expect_used)]
+mod tests {
+    use super::*;
+
+    fn t(tools: &str, input: u64) -> (String, u64) {
+        (tools.to_string(), input)
+    }
+
+    #[test]
+    fn empty_input_is_empty_report() {
+        let report = analyze(&[]);
+        assert_eq!(report.total_turns, 0);
+        assert!(report.buckets.is_empty());
+        assert_eq!(report.total_recoverable_input_tokens(), 0);
+    }
+
+    #[test]
+    fn pure_read_turn_is_read_bucket() {
+        let report = analyze(&[t("Read", 1000)]);
+        assert_eq!(report.buckets.len(), 1);
+        let b = &report.buckets[0];
+        assert_eq!(b.bucket, NavBucket::Read);
+        assert_eq!(b.turns, 1);
+        assert_eq!(b.addressable_input_tokens, 1000);
+        assert_eq!(b.recoverable_input_tokens(), 500);
+    }
+
+    #[test]
+    fn grep_wins_over_glob_and_read_when_mixed_navigation() {
+        // All-navigation turn with several nav tools attributes to Grep.
+        let report = analyze(&[t("Read,Grep,Glob", 2000)]);
+        assert_eq!(report.buckets.len(), 1);
+        assert_eq!(report.buckets[0].bucket, NavBucket::Grep);
+        assert_eq!(report.buckets[0].turns, 1);
+    }
+
+    #[test]
+    fn glob_wins_over_read() {
+        let report = analyze(&[t("Read,Glob", 800)]);
+        assert_eq!(report.buckets.len(), 1);
+        assert_eq!(report.buckets[0].bucket, NavBucket::Glob);
+    }
+
+    #[test]
+    fn turn_with_edit_is_not_replaceable() {
+        // Navigation mixed with a mutating tool is excluded entirely.
+        let report = analyze(&[t("Read,Edit", 5000), t("Grep,Write", 5000)]);
+        assert!(report.buckets.is_empty());
+        assert_eq!(report.total_replaceable_turns(), 0);
+        assert_eq!(report.total_addressable_input_tokens(), 0);
+    }
+
+    #[test]
+    fn bash_only_turn_is_not_counted() {
+        // Bash command content is not stored, so Bash turns are never nav.
+        let report = analyze(&[t("Bash", 3000)]);
+        assert!(report.buckets.is_empty());
+    }
+
+    #[test]
+    fn empty_tool_names_conversation_turn_excluded() {
+        let report = analyze(&[t("", 1234)]);
+        assert_eq!(report.total_turns, 1);
+        assert!(report.buckets.is_empty());
+    }
+
+    #[test]
+    fn buckets_ranked_by_addressable_tokens_descending() {
+        let report = analyze(&[
+            t("Read", 100),
+            t("Read", 100),
+            t("Grep", 5000),
+            t("Glob", 900),
+        ]);
+        assert_eq!(report.buckets.len(), 3);
+        assert_eq!(report.buckets[0].bucket, NavBucket::Grep);
+        assert_eq!(report.buckets[1].bucket, NavBucket::Glob);
+        assert_eq!(report.buckets[2].bucket, NavBucket::Read);
+        // Read bucket aggregates both read turns.
+        assert_eq!(report.buckets[2].turns, 2);
+        assert_eq!(report.buckets[2].addressable_input_tokens, 200);
+    }
+
+    #[test]
+    fn estimate_is_non_negative_and_monotonic() {
+        let small = analyze(&[t("Read", 1000)]);
+        let large = analyze(&[t("Read", 1000), t("Grep", 4000)]);
+        assert!(large.total_recoverable_input_tokens() >= small.total_recoverable_input_tokens());
+        // Recoverable never exceeds addressable (fraction <= 1).
+        assert!(
+            large.total_recoverable_input_tokens() <= large.total_addressable_input_tokens()
+        );
+        // And is never negative (u64) — trivially true, but assert the bound.
+        assert!(small.total_recoverable_input_tokens() <= small.total_addressable_input_tokens());
+    }
+
+    #[test]
+    fn whitespace_in_tool_names_is_tolerated() {
+        let report = analyze(&[t(" Read , Grep ", 1200)]);
+        assert_eq!(report.buckets.len(), 1);
+        assert_eq!(report.buckets[0].bucket, NavBucket::Grep);
+        assert_eq!(report.buckets[0].turns, 1);
+    }
+}

--- a/src/accounting/discover.rs
+++ b/src/accounting/discover.rs
@@ -312,9 +312,7 @@ mod tests {
         let large = analyze(&[t("Read", 1000), t("Grep", 4000)]);
         assert!(large.total_recoverable_input_tokens() >= small.total_recoverable_input_tokens());
         // Recoverable never exceeds addressable (fraction <= 1).
-        assert!(
-            large.total_recoverable_input_tokens() <= large.total_addressable_input_tokens()
-        );
+        assert!(large.total_recoverable_input_tokens() <= large.total_addressable_input_tokens());
         // And is never negative (u64) — trivially true, but assert the bound.
         assert!(small.total_recoverable_input_tokens() <= small.total_addressable_input_tokens());
     }

--- a/src/accounting/mod.rs
+++ b/src/accounting/mod.rs
@@ -5,10 +5,12 @@
 //! the global database for fast aggregate queries.
 
 pub mod classifier;
+pub mod discover;
 pub mod metrics;
 pub mod parser;
 pub mod pricing;
 
 pub use classifier::TaskCategory;
+pub use discover::{analyze, DiscoverReport};
 pub use metrics::{quick_cost_summary, CostSummary};
 pub use parser::ingest;

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -206,6 +206,15 @@ pub enum Commands {
         #[arg(long)]
         export: Option<String>,
     },
+    /// Find navigation turns a tokensave query could have served more cheaply
+    Discover {
+        /// Time range: "today", "7d", "30d", "month", or "all"
+        #[arg(long, default_value = "30d")]
+        since: String,
+        /// Output as JSON
+        #[arg(long)]
+        json: bool,
+    },
     /// Run a reproducible retrieval benchmark against the current project.
     Bench {
         /// Path to a TOML query file (defaults to the shipped default set).

--- a/src/commands.rs
+++ b/src/commands.rs
@@ -626,6 +626,106 @@ pub async fn handle_gain(
     Ok(())
 }
 
+/// Handle `tokensave discover`: surface file-navigation turns that a tokensave
+/// graph query could have served far more cheaply.
+///
+/// Ingests any new session data first (mirroring `tokensave cost`), then runs
+/// the deterministic [`tokensave::accounting::discover::analyze`] over the
+/// `turns` table for the requested range and prints a ranked summary. The
+/// recoverable figure is a clearly-labeled conservative lower bound; see the
+/// `discover` module docs for the estimation assumptions.
+pub async fn handle_discover(since: &str, json_output: bool) -> tokensave::errors::Result<()> {
+    use tokensave::accounting::discover;
+
+    let gdb = match tokensave::global_db::GlobalDb::open().await {
+        Some(db) => db,
+        None => {
+            eprintln!("Could not open the global database (~/.tokensave/global.db).");
+            return Ok(());
+        }
+    };
+
+    // Ingest new session data before querying, same as `tokensave cost`.
+    let ingest_stats = tokensave::accounting::parser::ingest(&gdb).await;
+    if ingest_stats.turns_inserted > 0 {
+        eprintln!(
+            "Ingested {} new turns from Claude Code sessions.",
+            ingest_stats.turns_inserted
+        );
+    }
+
+    let since_ts = tokensave::accounting::metrics::parse_range(since);
+    let rows = gdb.nav_turns_since(since_ts).await;
+    let report = discover::analyze(&rows);
+
+    if json_output {
+        let buckets: Vec<_> = report
+            .buckets
+            .iter()
+            .map(|b| {
+                serde_json::json!({
+                    "bucket": b.bucket.as_str(),
+                    "tool": b.bucket.tool_name(),
+                    "suggestion": b.bucket.suggestion(),
+                    "turns": b.turns,
+                    "addressable_input_tokens": b.addressable_input_tokens,
+                    "recoverable_input_tokens": b.recoverable_input_tokens(),
+                })
+            })
+            .collect();
+        let out = serde_json::json!({
+            "since": since,
+            "recoverable_fraction": discover::RECOVERABLE_FRACTION,
+            "total_turns": report.total_turns,
+            "replaceable_turns": report.total_replaceable_turns(),
+            "total_addressable_input_tokens": report.total_addressable_input_tokens(),
+            "total_recoverable_input_tokens": report.total_recoverable_input_tokens(),
+            "buckets": buckets,
+        });
+        println!("{}", serde_json::to_string_pretty(&out).unwrap_or_default());
+        return Ok(());
+    }
+
+    println!("Missed-opportunity scan (since: {since})");
+    if report.buckets.is_empty() {
+        println!(
+            "  No replaceable file-navigation turns found in {} examined turns.",
+            report.total_turns
+        );
+        return Ok(());
+    }
+
+    println!(
+        "  {:<8} {:<32} {:>6} {:>14} {:>14}",
+        "Tool", "TokenSave alternative", "Turns", "Addressable", "Recoverable"
+    );
+    for b in &report.buckets {
+        println!(
+            "  {:<8} {:<32} {:>6} {:>14} {:>14}",
+            b.bucket.tool_name(),
+            b.bucket.suggestion(),
+            b.turns,
+            tokensave::display::format_token_count(b.addressable_input_tokens),
+            tokensave::display::format_token_count(b.recoverable_input_tokens()),
+        );
+    }
+
+    println!();
+    println!(
+        "  {} navigation turns; addressable input tokens \u{2248} {}.",
+        report.total_replaceable_turns(),
+        tokensave::display::format_token_count(report.total_addressable_input_tokens()),
+    );
+    println!(
+        "  Conservative recoverable \u{2248} {} (lower bound: {:.0}% of addressable; \
+         excludes Bash grep/find/cat/rg, whose command text is not stored).",
+        tokensave::display::format_token_count(report.total_recoverable_input_tokens()),
+        discover::RECOVERABLE_FRACTION * 100.0,
+    );
+
+    Ok(())
+}
+
 /// Print the `--doctor` report after an incremental sync.
 pub(crate) fn print_sync_doctor(result: &tokensave::tokensave::SyncResult) {
     let has_changes = !result.added_paths.is_empty()

--- a/src/global_db.rs
+++ b/src/global_db.rs
@@ -423,6 +423,32 @@ impl GlobalDb {
         out
     }
 
+    /// Fetch `(tool_names, input_tokens)` for every turn since a timestamp.
+    ///
+    /// Used by the "missed opportunity" analyzer (`tokensave discover`), which
+    /// inspects `tool_names` to decide whether a turn was pure file navigation
+    /// that a graph query could have served more cheaply. Returns an empty
+    /// vector on any DB error.
+    pub async fn nav_turns_since(&self, since: u64) -> Vec<(String, u64)> {
+        let Ok(mut rows) = self
+            .conn
+            .query(
+                "SELECT tool_names, input_tokens FROM turns WHERE timestamp >= ?1",
+                params![since as i64],
+            )
+            .await
+        else {
+            return Vec::new();
+        };
+        let mut out = Vec::new();
+        while let Ok(Some(row)) = rows.next().await {
+            let tool_names: String = row.get(0).unwrap_or_default();
+            let input_tokens: i64 = row.get(1).unwrap_or(0);
+            out.push((tool_names, input_tokens.max(0) as u64));
+        }
+        out
+    }
+
     // ── Accounting: parse_offsets table ────────────────────────────────
 
     /// Get the saved parse offset for a JSONL file.

--- a/src/main.rs
+++ b/src/main.rs
@@ -1080,6 +1080,9 @@ async fn run(cli: Cli) -> tokensave::errors::Result<()> {
                 }
             }
         }
+        Commands::Discover { since, json } => {
+            commands::handle_discover(&since, json).await?;
+        }
         Commands::Bench {
             queries,
             json,

--- a/tests/discover_test.rs
+++ b/tests/discover_test.rs
@@ -1,0 +1,123 @@
+//! Integration tests for the `tokensave discover` analyzer over a temp DB.
+//!
+//! Seeds a small set of `turns` (navigation vs non-navigation) into an isolated
+//! `GlobalDb`, then asserts `nav_turns_since` + `discover::analyze` bucket and
+//! count them correctly, and that the recoverable estimate is non-negative,
+//! monotonic, and never exceeds the addressable total.
+
+use tempfile::TempDir;
+use tokensave::accounting::discover::{self, NavBucket};
+use tokensave::global_db::GlobalDb;
+use tokensave::types::CostTurn;
+
+async fn open_isolated_db(tmp: &TempDir) -> GlobalDb {
+    let db_path = tmp.path().join(".tokensave").join("global.db");
+    GlobalDb::open_at(&db_path).await.expect("global db open")
+}
+
+fn turn(id: &str, ts: u64, input: u64, tool_names: &str) -> CostTurn {
+    CostTurn {
+        message_id: id.to_string(),
+        project_hash: "proj".to_string(),
+        session_id: "sess".to_string(),
+        model: "claude-opus-4-6".to_string(),
+        timestamp: ts,
+        input_tokens: input,
+        output_tokens: 10,
+        cache_write_tokens: 0,
+        cache_read_tokens: 0,
+        cost_usd: 0.01,
+        category: "exploration".to_string(),
+        tool_names: tool_names.to_string(),
+    }
+}
+
+#[tokio::test]
+async fn analyzer_buckets_seeded_turns() {
+    let tmp = TempDir::new().unwrap();
+    let db = open_isolated_db(&tmp).await;
+
+    let base: u64 = 1_715_000_000;
+    // Replaceable navigation turns.
+    assert!(db.insert_turn(&turn("m1", base, 1000, "Read")).await);
+    assert!(db.insert_turn(&turn("m2", base + 1, 2000, "Read")).await);
+    assert!(db.insert_turn(&turn("m3", base + 2, 5000, "Grep")).await);
+    assert!(db.insert_turn(&turn("m4", base + 3, 900, "Glob")).await);
+    assert!(db
+        .insert_turn(&turn("m5", base + 4, 1500, "Read,Grep"))
+        .await); // -> Grep
+    // Non-navigation / mixed turns that must NOT be counted.
+    assert!(db
+        .insert_turn(&turn("m6", base + 5, 9999, "Read,Edit"))
+        .await);
+    assert!(db.insert_turn(&turn("m7", base + 6, 9999, "Bash")).await);
+    assert!(db.insert_turn(&turn("m8", base + 7, 9999, "")).await);
+
+    let rows = db.nav_turns_since(0).await;
+    assert_eq!(rows.len(), 8, "all 8 turns fetched");
+
+    let report = discover::analyze(&rows);
+    assert_eq!(report.total_turns, 8);
+    // Replaceable: m1, m2, m3, m4, m5 = 5 turns.
+    assert_eq!(report.total_replaceable_turns(), 5);
+
+    // Three buckets fired, ranked by addressable input tokens descending.
+    assert_eq!(report.buckets.len(), 3);
+    assert_eq!(report.buckets[0].bucket, NavBucket::Grep); // 5000 + 1500 = 6500
+    assert_eq!(report.buckets[0].turns, 2);
+    assert_eq!(report.buckets[0].addressable_input_tokens, 6500);
+    assert_eq!(report.buckets[1].bucket, NavBucket::Read); // 1000 + 2000 = 3000
+    assert_eq!(report.buckets[1].turns, 2);
+    assert_eq!(report.buckets[1].addressable_input_tokens, 3000);
+    assert_eq!(report.buckets[2].bucket, NavBucket::Glob); // 900
+    assert_eq!(report.buckets[2].turns, 1);
+
+    // Addressable excludes the mixed/non-nav turns (3 * 9999).
+    assert_eq!(report.total_addressable_input_tokens(), 6500 + 3000 + 900);
+
+    // Estimate is a non-negative lower bound never exceeding addressable.
+    assert!(
+        report.total_recoverable_input_tokens() <= report.total_addressable_input_tokens()
+    );
+    assert_eq!(
+        report.total_recoverable_input_tokens(),
+        ((6500 + 3000 + 900) as f64 * discover::RECOVERABLE_FRACTION) as u64
+    );
+}
+
+#[tokio::test]
+async fn since_filter_restricts_window_and_estimate_is_monotonic() {
+    let tmp = TempDir::new().unwrap();
+    let db = open_isolated_db(&tmp).await;
+
+    let base: u64 = 1_715_000_000;
+    assert!(db.insert_turn(&turn("old", base, 1000, "Read")).await);
+    assert!(db
+        .insert_turn(&turn("new", base + 10_000, 4000, "Grep"))
+        .await);
+
+    // Full window sees both turns.
+    let full = discover::analyze(&db.nav_turns_since(0).await);
+    assert_eq!(full.total_replaceable_turns(), 2);
+
+    // Narrowed window sees only the newer turn.
+    let narrowed = discover::analyze(&db.nav_turns_since(base + 5_000).await);
+    assert_eq!(narrowed.total_replaceable_turns(), 1);
+    assert_eq!(narrowed.buckets[0].bucket, NavBucket::Grep);
+
+    // A superset window never reports fewer recoverable tokens.
+    assert!(
+        full.total_recoverable_input_tokens() >= narrowed.total_recoverable_input_tokens()
+    );
+}
+
+#[tokio::test]
+async fn empty_db_yields_empty_report() {
+    let tmp = TempDir::new().unwrap();
+    let db = open_isolated_db(&tmp).await;
+
+    let report = discover::analyze(&db.nav_turns_since(0).await);
+    assert_eq!(report.total_turns, 0);
+    assert!(report.buckets.is_empty());
+    assert_eq!(report.total_recoverable_input_tokens(), 0);
+}

--- a/tests/discover_test.rs
+++ b/tests/discover_test.rs
@@ -43,13 +43,15 @@ async fn analyzer_buckets_seeded_turns() {
     assert!(db.insert_turn(&turn("m2", base + 1, 2000, "Read")).await);
     assert!(db.insert_turn(&turn("m3", base + 2, 5000, "Grep")).await);
     assert!(db.insert_turn(&turn("m4", base + 3, 900, "Glob")).await);
-    assert!(db
-        .insert_turn(&turn("m5", base + 4, 1500, "Read,Grep"))
-        .await); // -> Grep
-    // Non-navigation / mixed turns that must NOT be counted.
-    assert!(db
-        .insert_turn(&turn("m6", base + 5, 9999, "Read,Edit"))
-        .await);
+    assert!(
+        db.insert_turn(&turn("m5", base + 4, 1500, "Read,Grep"))
+            .await
+    ); // -> Grep
+       // Non-navigation / mixed turns that must NOT be counted.
+    assert!(
+        db.insert_turn(&turn("m6", base + 5, 9999, "Read,Edit"))
+            .await
+    );
     assert!(db.insert_turn(&turn("m7", base + 6, 9999, "Bash")).await);
     assert!(db.insert_turn(&turn("m8", base + 7, 9999, "")).await);
 
@@ -76,9 +78,7 @@ async fn analyzer_buckets_seeded_turns() {
     assert_eq!(report.total_addressable_input_tokens(), 6500 + 3000 + 900);
 
     // Estimate is a non-negative lower bound never exceeding addressable.
-    assert!(
-        report.total_recoverable_input_tokens() <= report.total_addressable_input_tokens()
-    );
+    assert!(report.total_recoverable_input_tokens() <= report.total_addressable_input_tokens());
     assert_eq!(
         report.total_recoverable_input_tokens(),
         ((6500 + 3000 + 900) as f64 * discover::RECOVERABLE_FRACTION) as u64
@@ -92,9 +92,10 @@ async fn since_filter_restricts_window_and_estimate_is_monotonic() {
 
     let base: u64 = 1_715_000_000;
     assert!(db.insert_turn(&turn("old", base, 1000, "Read")).await);
-    assert!(db
-        .insert_turn(&turn("new", base + 10_000, 4000, "Grep"))
-        .await);
+    assert!(
+        db.insert_turn(&turn("new", base + 10_000, 4000, "Grep"))
+            .await
+    );
 
     // Full window sees both turns.
     let full = discover::analyze(&db.nav_turns_since(0).await);
@@ -106,9 +107,7 @@ async fn since_filter_restricts_window_and_estimate_is_monotonic() {
     assert_eq!(narrowed.buckets[0].bucket, NavBucket::Grep);
 
     // A superset window never reports fewer recoverable tokens.
-    assert!(
-        full.total_recoverable_input_tokens() >= narrowed.total_recoverable_input_tokens()
-    );
+    assert!(full.total_recoverable_input_tokens() >= narrowed.total_recoverable_input_tokens());
 }
 
 #[tokio::test]


### PR DESCRIPTION
Closes #123.

Adds a deterministic analyzer over the already-ingested `turns` table that surfaces navigation turns (`Read`/`Grep`/`Glob`) replaceable by tokensave graph queries, with a conservative recoverable-token estimate.

## Approach
- **Detection by tool name only** — a turn counts only if *every* tool it used is a navigation tool (mixed nav+Edit/Bash turns excluded, so navigation never inherits edit cost).
- **Bash grep/find/cat deliberately NOT counted** (command text isn't persisted) → result is a strict lower bound.
- **Bucketing**: Read→outline/read/node, Grep→search/callers/callees/impact, Glob→files/search (multi-nav turns attribute via fixed priority).
- **Addressable** = exact sum of `input_tokens` on replaceable turns; **Recoverable** = addressable × 0.5 (documented lower-bound assumption; graph queries can't shrink fixed conversational overhead).
- New `tokensave discover [--since RANGE] [--json]` CLI.

## Files
`src/accounting/discover.rs` (new), `accounting/mod.rs`, `global_db.rs` (`nav_turns_since`), `cli.rs`, `commands.rs`, `main.rs`, `tests/discover_test.rs` (new). +592 lines.

## Tests
- Accounting lib: 40 passed (10 new). Full lib suite: 417 passed; 0 failed. `tests/discover_test.rs`: 3 passed. Clippy clean on new/modified code.

## Follow-up candidate
Precise per-bucket estimates would need the parser to persist returned-payload size per tool_use — a future parser/schema enhancement, out of scope here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)