### PR TITLE
feat(context): calls-first BFS, entry-point cap, non-prod dir down-weight (#118 #120 #119)

### DIFF
--- a/src/context/builder.rs
+++ b/src/context/builder.rs
@@ -326,6 +326,17 @@ impl<'a> ContextBuilder<'a> {
             apply_cooccurrence_boost(&mut candidates, &query_terms);
         }
 
+        // --- Cap BFS roots (#120) ---
+        // Every surviving entry point seeds its own BFS in `expand_subgraph`,
+        // which shares a fixed `max_nodes` budget across all roots. With many
+        // roots the per-root budget collapses to a shallow fan-out (e.g. 36
+        // roots over a 120-node budget gives ~3 nodes each). Capping the roots
+        // to `search_limit` keeps each top-ranked root's traversal meaningful.
+        // Candidates are score-sorted here (rerank + connectivity + cooccurrence
+        // boosts all re-sort), so truncation keeps the highest-scoring roots.
+        // Done before the per-file cap so the cap rebalances the retained set.
+        candidates.truncate(options.search_limit);
+
         // --- Per-file diversity cap ---
         let max_per_file = options.max_per_file.unwrap_or(options.max_nodes);
         let entry_points = apply_per_file_cap(candidates, options.max_nodes, max_per_file);

--- a/src/context/ranking.rs
+++ b/src/context/ranking.rs
@@ -85,6 +85,21 @@ const VENDOR_PATH_SEGMENTS: &[&str] = &[
     "out",
 ];
 
+/// Path segments of non-production trees that ship alongside first-party code
+/// but rarely contain the symbol a user is searching for: example programs,
+/// sample snippets, benchmarks, and demos. Down-weighted softly (not filtered)
+/// so an exact match still surfaces, just below equivalent production code.
+const NON_PROD_PATH_SEGMENTS: &[&str] = &[
+    "examples",
+    "example",
+    "samples",
+    "sample",
+    "benchmarks",
+    "benchmark",
+    "demos",
+    "demo",
+];
+
 /// Path segments of typical application source directories. A match gives a
 /// modest boost so first-party code surfaces ahead of equally-relevant code
 /// living elsewhere.
@@ -102,14 +117,18 @@ fn has_path_segment(normalized: &str, segment: &str) -> bool {
 /// * `< 1.0` for nodes living under a known vendor / generated tree
 ///   (`node_modules`, `dist`, `target`, `venv`, …) so dependency or build
 ///   output sinks below first-party code.
+/// * `< 1.0`, but milder, for non-production trees (`examples/`, `samples/`,
+///   `benchmarks/`, `demos/`, …) so they rank below equivalent production code
+///   without being filtered out.
 /// * `> 1.0` for nodes under a typical app source dir (`src/`, `app/`,
 ///   `lib/`) so application code surfaces first by default.
 /// * exactly `1.0` for everything else (neutral).
 ///
 /// The effect is proportional, not a filter: a strong exact-name match in
-/// `node_modules` can still appear, just ranked lower. Vendor classification
-/// wins over app classification when a path matches both (e.g. a `src` dir
-/// nested inside `node_modules`).
+/// `node_modules` or `examples/` can still appear, just ranked lower. Vendor
+/// classification wins over both non-production and app classification when a
+/// path matches more than one (e.g. a `src` dir nested inside `node_modules`,
+/// or an `examples` dir under `target`).
 pub fn path_rank_multiplier(file_path: &str) -> f64 {
     let normalized = file_path.replace('\\', "/");
     if VENDOR_PATH_SEGMENTS
@@ -117,6 +136,14 @@ pub fn path_rank_multiplier(file_path: &str) -> f64 {
         .any(|seg| has_path_segment(&normalized, seg))
     {
         return 0.4;
+    }
+    if NON_PROD_PATH_SEGMENTS
+        .iter()
+        .any(|seg| has_path_segment(&normalized, seg))
+    {
+        // Between the vendor (0.4) and neutral (1.0) factors: example/demo
+        // code is more relevant than vendored deps but less than production.
+        return 0.6;
     }
     if APP_PATH_SEGMENTS
         .iter()
@@ -324,6 +351,63 @@ mod tests {
     fn test_path_rank_multiplier_vendor_wins_over_app() {
         // A `src` dir nested inside node_modules is still vendored code.
         assert!(path_rank_multiplier("node_modules/pkg/src/index.js") < 1.0);
+    }
+
+    #[test]
+    fn test_path_rank_multiplier_nonprod_below_one() {
+        assert!(path_rank_multiplier("examples/foo.rs") < 1.0);
+        assert!(path_rank_multiplier("example/foo.rs") < 1.0);
+        assert!(path_rank_multiplier("samples/foo.rs") < 1.0);
+        assert!(path_rank_multiplier("sample/foo.rs") < 1.0);
+        assert!(path_rank_multiplier("benchmarks/bench.rs") < 1.0);
+        assert!(path_rank_multiplier("benchmark/bench.rs") < 1.0);
+        assert!(path_rank_multiplier("demos/app.rs") < 1.0);
+        assert!(path_rank_multiplier("demo/app.rs") < 1.0);
+        assert!(path_rank_multiplier("crate/examples/usage.rs") < 1.0);
+    }
+
+    #[test]
+    fn test_path_rank_multiplier_nonprod_above_vendor() {
+        // Non-production code is more relevant than vendored deps.
+        assert!(
+            path_rank_multiplier("examples/foo.rs") > path_rank_multiplier("node_modules/foo.js")
+        );
+    }
+
+    #[test]
+    fn test_path_rank_multiplier_vendor_wins_over_nonprod() {
+        // An `examples` dir nested inside a build/vendor tree is still vendored.
+        assert_eq!(
+            path_rank_multiplier("target/examples/foo.rs"),
+            path_rank_multiplier("target/debug/foo.rs")
+        );
+        assert!(
+            path_rank_multiplier("target/examples/foo.rs")
+                < path_rank_multiplier("examples/foo.rs")
+        );
+    }
+
+    #[test]
+    fn test_path_rank_multiplier_nonprod_substring_not_matched() {
+        // "demolition" contains "demo" but is not the `demo` dir.
+        assert_eq!(path_rank_multiplier("demolition/handler.rs"), 1.0);
+        // "exampled" contains "example" but is not the `example` dir.
+        assert_eq!(path_rank_multiplier("exampled/foo.rs"), 1.0);
+    }
+
+    #[test]
+    fn test_src_outranks_examples_in_rerank() {
+        let mut candidates = vec![
+            make_result(
+                NodeKind::Function,
+                Visibility::Pub,
+                "examples/handler.rs",
+                10.0,
+            ),
+            make_result(NodeKind::Function, Visibility::Pub, "src/handler.rs", 10.0),
+        ];
+        rerank_candidates(&mut candidates);
+        assert_eq!(candidates[0].node.file_path, "src/handler.rs");
     }
 
     #[test]

--- a/src/graph/traversal.rs
+++ b/src/graph/traversal.rs
@@ -69,9 +69,17 @@ impl<'a> GraphTraverser<'a> {
                 break;
             }
 
-            let edges = self
+            let mut edges = self
                 .get_edges_for_direction(&current_id, edge_filter, &opts.direction)
                 .await?;
+
+            // Order `calls` edges ahead of reference/other edges before they
+            // seed the FIFO queue. Under a tight `opts.limit`, this lets the
+            // subgraph fill with structural call relationships before fanning
+            // out to references. Stable so DB order is preserved within a kind.
+            // (`contains` edges were denormalized in v9 and are expanded above
+            // via `get_children_of`, so they need no ordering here.)
+            edges.sort_by_key(|edge| edge_kind_priority(edge.kind));
 
             let neighbor_ids: Vec<String> = edges
                 .iter()
@@ -761,6 +769,20 @@ impl<'a> GraphTraverser<'a> {
             }
         }
         true
+    }
+}
+
+/// BFS/DFS visitation priority for an edge kind: lower is visited first.
+///
+/// `Calls` edges (structural call relationships) are prioritized over
+/// reference and other edges so a budget-limited traversal fills with call
+/// structure before fanning out to weaker references. `Contains` edges were
+/// denormalized in v9 (children come via `parent_id`) and do not flow through
+/// this path, so they are grouped with the default tier.
+fn edge_kind_priority(kind: EdgeKind) -> u8 {
+    match kind {
+        EdgeKind::Calls => 0,
+        _ => 1,
     }
 }
 

--- a/tests/context_test.rs
+++ b/tests/context_test.rs
@@ -704,3 +704,83 @@ async fn test_merge_adjacent_code_blocks() {
     assert!(ctx.code_blocks[0].content.contains("alpha"));
     assert!(ctx.code_blocks[0].content.contains("beta"));
 }
+
+#[tokio::test]
+async fn test_entry_points_capped_to_search_limit() {
+    // Regression test for #120: when many candidates match, the number of
+    // entry points (BFS roots) must be bounded by `search_limit` so each
+    // root's traversal budget stays meaningful.
+    use std::fs;
+    use tempfile::TempDir;
+    use tokensave::context::ContextBuilder;
+    use tokensave::db::Database;
+
+    let dir = TempDir::new().unwrap();
+    let project = dir.path();
+    fs::create_dir_all(project.join("src")).unwrap();
+
+    let (db, _) = Database::initialize(&project.join(".tokensave/tokensave.db"))
+        .await
+        .unwrap();
+
+    // Insert many distinct nodes, each matching a distinct keyword. Each
+    // per-keyword FTS search surfaces its node, so the candidate pool greatly
+    // exceeds `search_limit`.
+    const NUM_NODES: usize = 12;
+    let keywords: Vec<String> = (0..NUM_NODES).map(|i| format!("widgetkind{i}")).collect();
+    let mut nodes = Vec::new();
+    for (i, kw) in keywords.iter().enumerate() {
+        nodes.push(Node {
+            id: format!("function:{kw}"),
+            kind: NodeKind::Function,
+            name: kw.clone(),
+            qualified_name: format!("src/file{i}.rs::{kw}"),
+            file_path: format!("src/file{i}.rs"),
+            start_line: 1,
+            attrs_start_line: 1,
+            end_line: 5,
+            start_column: 0,
+            end_column: 1,
+            signature: Some(format!("pub fn {kw}()")),
+            docstring: None,
+            visibility: Visibility::Pub,
+            is_async: false,
+            branches: 0,
+            loops: 0,
+            returns: 0,
+            max_nesting: 0,
+            unsafe_blocks: 0,
+            unchecked_calls: 0,
+            assertions: 0,
+            updated_at: 0,
+            parent_id: None,
+        });
+    }
+    db.insert_nodes(&nodes).await.unwrap();
+
+    const SEARCH_LIMIT: usize = 5;
+    let opts = BuildContextOptions {
+        search_limit: SEARCH_LIMIT,
+        max_nodes: 100, // large, so search_limit is the binding cap on roots
+        max_per_file: Some(100),
+        extra_keywords: keywords.clone(),
+        ..Default::default()
+    };
+
+    let builder = ContextBuilder::new(&db, project);
+    // Query the first keyword; the rest surface via extra_keywords, producing
+    // far more candidates than `search_limit`.
+    let ctx = builder.build_context(&keywords[0], &opts).await.unwrap();
+
+    assert!(
+        ctx.entry_points.len() > 1,
+        "expected multiple matching candidates, got {}",
+        ctx.entry_points.len()
+    );
+    assert!(
+        ctx.entry_points.len() <= SEARCH_LIMIT,
+        "entry points (BFS roots) must be capped to search_limit ({}), got {}",
+        SEARCH_LIMIT,
+        ctx.entry_points.len()
+    );
+}

--- a/tests/graph_test.rs
+++ b/tests/graph_test.rs
@@ -293,6 +293,79 @@ async fn test_dfs_traversal() {
 }
 
 #[tokio::test]
+async fn test_bfs_visits_calls_before_references() {
+    // Regression test for #118: a budget-limited BFS frontier must visit
+    // `calls` neighbors before reference/other-kind neighbors, regardless of
+    // database edge order. We insert the reference edge FIRST (so it would win
+    // a naive DB-order traversal) and assert the `calls` neighbor is the one
+    // that survives a one-neighbor budget.
+    let (db, _dir) = setup_db().await;
+
+    let root = make_node("n-root", "root", "src/root.rs", Visibility::Pub);
+    let ref_target = make_node("n-ref", "ref_target", "src/ref.rs", Visibility::Pub);
+    let call_target = make_node("n-call", "call_target", "src/call.rs", Visibility::Pub);
+    db.insert_nodes(&[root, ref_target, call_target])
+        .await
+        .expect("failed to insert nodes");
+
+    // Reference edge inserted first, calls edge second.
+    let edges = vec![
+        Edge {
+            source: "n-root".to_string(),
+            target: "n-ref".to_string(),
+            kind: EdgeKind::Uses,
+            line: Some(1),
+        },
+        Edge {
+            source: "n-root".to_string(),
+            target: "n-call".to_string(),
+            kind: EdgeKind::Calls,
+            line: Some(2),
+        },
+    ];
+    db.insert_edges(&edges)
+        .await
+        .expect("failed to insert edges");
+
+    let traverser = GraphTraverser::new(&db);
+
+    // limit = 2: the start node plus exactly one neighbor. The `calls`
+    // neighbor must be the one chosen.
+    let opts = TraversalOptions {
+        max_depth: 5,
+        edge_kinds: None,
+        node_kinds: None,
+        direction: TraversalDirection::Outgoing,
+        limit: 2,
+        include_start: true,
+    };
+
+    let subgraph = traverser
+        .traverse_bfs("n-root", &opts)
+        .await
+        .expect("traverse_bfs failed");
+
+    let node_names: Vec<&str> = subgraph.nodes.iter().map(|n| n.name.as_str()).collect();
+    assert!(
+        node_names.contains(&"call_target"),
+        "calls neighbor should be visited ahead of reference neighbor, got: {node_names:?}"
+    );
+    assert!(
+        !node_names.contains(&"ref_target"),
+        "reference neighbor should be cut off by the budget, got: {node_names:?}"
+    );
+
+    // The first edge recorded in the subgraph should be the `calls` edge,
+    // confirming queue ordering and not just which node fit the budget.
+    assert_eq!(
+        subgraph.edges.first().map(|e| e.kind),
+        Some(EdgeKind::Calls),
+        "calls edge should be queued first, got: {:?}",
+        subgraph.edges
+    );
+}
+
+#[tokio::test]
 async fn test_find_path() {
     let (db, _dir) = setup_call_chain().await;
     let traverser = GraphTraverser::new(&db);


### PR DESCRIPTION
Closes #118, closes #120, closes #119. Three small, related context/traversal-quality improvements in one pass.

## #118 — calls-first BFS (`src/graph/traversal.rs`)
Stable-sort adjacent edges by kind in `traverse_bfs` (`Calls` → 0, else → 1) before the neighbor loop, so `calls` edges enter the FIFO queue ahead of reference edges and a budget-limited frontier fills with call structure first. `contains` is not handled here (denormalized in v9, expanded via `get_children_of`). `traverse_dfs` left unchanged on purpose — its LIFO stack would invert the intent.

## #120 — cap entry points (`src/context/builder.rs`)
`candidates.truncate(options.search_limit)` after rerank/connectivity/cooccurrence boosts and before `apply_per_file_cap`, bounding the number of BFS roots so each top root keeps a meaningful slice of the shared `max_nodes` budget. Exclusion/min_score/path filters/per-file cap all run before the truncate and are unaffected.

## #119 — non-production dir down-weight (`src/context/ranking.rs`)
New `NON_PROD_PATH_SEGMENTS` (examples/sample/benchmark/demo, sing+plural) with a `0.6` multiplier in `path_rank_multiplier`, checked after vendor (`0.4`, so vendor still wins) and before app (`1.25`). Soft down-weight, not a filter; matched as full path components.

## Tests (no existing snapshots churned)
- `tests/graph_test.rs::test_bfs_visits_calls_before_references`
- `tests/context_test.rs::test_entry_points_capped_to_search_limit`
- 5 `ranking.rs` unit tests (nonprod < 1.0, vendor-wins, substring-not-matched, `src/` outranks `examples/`)
- Full suite: 2051 passed. `cargo fmt --check` clean; clippy clean on touched files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)