### PR TITLE
feat(memory): compact session_start delta + decay-weighted recall (#122)

### DIFF
--- a/src/mcp/tools/handlers/health.rs
+++ b/src/mcp/tools/handlers/health.rs
@@ -1235,10 +1235,17 @@ pub(super) async fn handle_session_start(
         message: format!("failed to write session baseline: {e}"),
     })?;
 
+    // Augment the response with a compact, budget-bounded memory delta — a
+    // cheap "here's where we left off" summary of the highest-value recent
+    // decisions and touched code areas (issue #122). A failure to read memory
+    // must not block the baseline save, so degrade to an empty delta.
+    let memory_delta = cg.session_delta().await.ok();
+
     let output = json!({
         "status": "baseline_saved",
         "quality_signal": snap.quality_signal,
         "files_analyzed": snap.files_analyzed,
+        "memory_delta": memory_delta,
     });
     let formatted = serde_json::to_string_pretty(&output).unwrap_or_default();
     Ok(ToolResult {

--- a/src/tokensave.rs
+++ b/src/tokensave.rs
@@ -2901,6 +2901,72 @@ impl TokenSave {
 const MAX_RECALL_LIMIT: usize = 200;
 const MAX_CODE_AREAS_LIMIT: usize = 200;
 
+/// Half-life (in seconds) of the recency-decay weight applied to decisions in
+/// the no-explicit-query recall path.
+///
+/// A decision's weight halves every `RECALL_DECAY_HALF_LIFE_SECS`. Chosen as
+/// 14 days: recent decisions clearly outrank stale ones within a typical
+/// multi-week work cycle, while the decay stays gentle enough that month-old
+/// context still carries meaningful weight. This is a *ranking* knob only —
+/// the weight asymptotically approaches zero but never reaches it, so no
+/// decision is ever dropped or expired (issue #122: decay, not TTL).
+const RECALL_DECAY_HALF_LIFE_SECS: f64 = 14.0 * 24.0 * 60.0 * 60.0;
+
+/// Maximum number of decisions summarised in the `session_start` delta.
+///
+/// Keeps the injected "here's where we left off" summary within a small token
+/// budget. Each entry is additionally truncated (see [`DELTA_TEXT_MAX_CHARS`]).
+const SESSION_DELTA_MAX_DECISIONS: usize = 5;
+
+/// Maximum number of code areas summarised in the `session_start` delta.
+const SESSION_DELTA_MAX_CODE_AREAS: usize = 5;
+
+/// Maximum character length of any single text field in the session delta.
+const DELTA_TEXT_MAX_CHARS: usize = 120;
+
+/// Recency-decay weight for a decision recorded at `created_at`, evaluated at
+/// `now`.
+///
+/// Returns `2^(-age / half_life)`, an exponential decay in `[0, 1]` that is
+/// `1.0` for a just-recorded decision and halves every
+/// [`RECALL_DECAY_HALF_LIFE_SECS`]. The weight is strictly positive for all
+/// finite ages, so older decisions sink in ranking but are never excluded.
+///
+/// Future timestamps (clock skew) clamp to weight `1.0`.
+fn recency_decay_weight(created_at: i64, now: i64) -> f64 {
+    let age = (now - created_at).max(0) as f64;
+    2.0_f64.powf(-age / RECALL_DECAY_HALF_LIFE_SECS)
+}
+
+/// Truncate `s` to at most `max_chars` characters, appending an ellipsis when
+/// the string was shortened. Respects UTF-8 char boundaries.
+fn truncate_chars(s: &str, max_chars: usize) -> String {
+    if s.chars().count() <= max_chars {
+        return s.to_string();
+    }
+    let kept: String = s.chars().take(max_chars).collect();
+    format!("{kept}…")
+}
+
+/// A compact, budget-bounded "where we left off" summary emitted at session
+/// start. See [`TokenSave::session_delta`].
+#[derive(Debug, Clone, serde::Serialize)]
+pub struct SessionDelta {
+    /// Highest-value recent decisions, newest-first, each truncated.
+    pub recent_decisions: Vec<DeltaEntry>,
+    /// Recently touched code areas, newest-first, each truncated.
+    pub recent_code_areas: Vec<DeltaEntry>,
+}
+
+/// A single truncated line in a [`SessionDelta`].
+#[derive(Debug, Clone, serde::Serialize)]
+pub struct DeltaEntry {
+    /// Short, truncated headline (decision text or code-area path).
+    pub summary: String,
+    /// UNIX timestamp (seconds) the underlying memory was recorded/touched.
+    pub at: i64,
+}
+
 impl TokenSave {
     /// Record an agent decision. Returns the new row id.
     pub async fn record_decision(
@@ -2936,8 +3002,10 @@ impl TokenSave {
         Ok(conn.last_insert_rowid())
     }
 
-    /// Recall decisions. With `query`, runs FTS5 MATCH against text+reason.
-    /// Without `query`, returns newest-first.
+    /// Recall decisions. With `query`, runs FTS5 MATCH against text+reason
+    /// ordered by relevance (recency). Without `query`, orders by a
+    /// recency-decay weight ([`recency_decay_weight`]) so older decisions
+    /// rank lower but are never dropped — there is no TTL or hard expiry.
     pub async fn session_recall(
         &self,
         query: Option<&str>,
@@ -3016,7 +3084,65 @@ impl TokenSave {
                 tags: serde_json::from_str(&tags_json).map_err(json_err)?,
             });
         }
+
+        // Recency-decay ranking for the no-explicit-query path. The SQL above
+        // already LIMITed to the newest N rows (which, because the decay is
+        // monotonic in `created_at`, are exactly the N highest-weighted rows),
+        // so we only need to (re)order the selected set by decay weight here.
+        // Higher weight first; ties keep newest-first. No row is dropped — old
+        // decisions still surface, just lower down.
+        if query.is_none() {
+            let now = current_timestamp();
+            out.sort_by(|a, b| {
+                let wa = recency_decay_weight(a.created_at, now);
+                let wb = recency_decay_weight(b.created_at, now);
+                wb.partial_cmp(&wa)
+                    .unwrap_or(std::cmp::Ordering::Equal)
+                    .then(b.created_at.cmp(&a.created_at))
+            });
+        }
         Ok(out)
+    }
+
+    /// Build a compact, budget-bounded "where we left off" delta for session
+    /// start.
+    ///
+    /// Returns the highest-value *recent* memories — the most recent decisions
+    /// (ranked by the same recency-decay weight as [`session_recall`]) and the
+    /// most recently touched code areas — each truncated to a short headline.
+    /// Entry counts are capped ([`SESSION_DELTA_MAX_DECISIONS`],
+    /// [`SESSION_DELTA_MAX_CODE_AREAS`]) so the result stays cheap to inject at
+    /// session start. This never deletes or expires any memory; it is a view.
+    ///
+    /// # Errors
+    /// Returns a database error if the underlying recall queries fail.
+    pub async fn session_delta(&self) -> crate::errors::Result<SessionDelta> {
+        let decisions = self
+            .session_recall(None, None, SESSION_DELTA_MAX_DECISIONS)
+            .await?;
+        let recent_decisions = decisions
+            .into_iter()
+            .take(SESSION_DELTA_MAX_DECISIONS)
+            .map(|d| DeltaEntry {
+                summary: truncate_chars(&d.text, DELTA_TEXT_MAX_CHARS),
+                at: d.created_at,
+            })
+            .collect();
+
+        let areas = self.list_code_areas(SESSION_DELTA_MAX_CODE_AREAS).await?;
+        let recent_code_areas = areas
+            .into_iter()
+            .take(SESSION_DELTA_MAX_CODE_AREAS)
+            .map(|a| DeltaEntry {
+                summary: truncate_chars(&a.path, DELTA_TEXT_MAX_CHARS),
+                at: a.last_touched_at,
+            })
+            .collect();
+
+        Ok(SessionDelta {
+            recent_decisions,
+            recent_code_areas,
+        })
     }
 
     /// Record (or update) a code area the agent worked in. Increments `touch_count`

--- a/tests/mcp_handler_test.rs
+++ b/tests/mcp_handler_test.rs
@@ -3128,6 +3128,14 @@ async fn test_dependencies_crate_lookup() {
 #[tokio::test]
 async fn test_session_start() {
     let (cg, dir) = setup_project().await;
+
+    // Record more decisions than the delta budget to assert the cap.
+    for i in 0..10 {
+        cg.record_decision(&format!("decision {i}"), None, &[], &[])
+            .await
+            .unwrap();
+    }
+
     let result = handle_tool_call(&cg, "tokensave_session_start", json!({}), None, None)
         .await
         .unwrap();
@@ -3137,6 +3145,18 @@ async fn test_session_start() {
     assert_eq!(output["status"].as_str().unwrap(), "baseline_saved");
     let baseline_path = dir.path().join(".tokensave/session_baseline.json");
     assert!(baseline_path.exists(), "baseline file should exist");
+
+    // session_start emits a compact, budget-bounded memory delta (issue #122).
+    let decisions = output["memory_delta"]["recent_decisions"]
+        .as_array()
+        .expect("memory_delta.recent_decisions should be present");
+    assert!(!decisions.is_empty(), "delta should contain decisions");
+    assert!(
+        decisions.len() <= 5,
+        "delta decisions must be capped, got {}",
+        decisions.len()
+    );
+    assert!(decisions[0]["summary"].as_str().is_some());
 }
 
 #[tokio::test]

--- a/tests/memory_test.rs
+++ b/tests/memory_test.rs
@@ -67,6 +67,106 @@ async fn record_code_area_upserts_touch_count() {
     assert_eq!(areas[0].description.as_deref(), Some("OAuth provider"));
 }
 
+/// Insert a decision with an explicit `created_at`, bypassing
+/// `record_decision`'s `now()` so tests can simulate old vs. recent memories.
+async fn insert_decision_at(cg: &TokenSave, text: &str, created_at: i64) {
+    cg.db()
+        .conn()
+        .execute(
+            "INSERT INTO memory_decisions (text, reason, created_at, files, tags) \
+             VALUES (?1, NULL, ?2, '[]', '[]')",
+            libsql::params![text, created_at],
+        )
+        .await
+        .unwrap();
+}
+
+#[tokio::test]
+async fn session_recall_ranks_by_recency_decay_without_dropping_old() {
+    let (_tmp, cg) = make_project().await;
+
+    let now = std::time::SystemTime::now()
+        .duration_since(std::time::UNIX_EPOCH)
+        .unwrap()
+        .as_secs() as i64;
+    // ~6 months old: heavily decayed but must still surface (no TTL).
+    let very_old = now - 180 * 24 * 60 * 60;
+    let recent = now - 60; // a minute ago
+
+    insert_decision_at(&cg, "ancient decision", very_old).await;
+    insert_decision_at(&cg, "fresh decision", recent).await;
+
+    let hits = cg.session_recall(None, None, 10).await.unwrap();
+    // Both are returned — the old one is NOT dropped.
+    assert_eq!(hits.len(), 2);
+    let texts: Vec<&str> = hits.iter().map(|d| d.text.as_str()).collect();
+    assert!(texts.contains(&"ancient decision"));
+    assert!(texts.contains(&"fresh decision"));
+    // Recent ranks above old by decay weight.
+    assert_eq!(hits[0].text, "fresh decision");
+    assert_eq!(hits[1].text, "ancient decision");
+}
+
+#[tokio::test]
+async fn session_delta_is_compact_and_budget_bounded() {
+    let (_tmp, cg) = make_project().await;
+
+    let now = std::time::SystemTime::now()
+        .duration_since(std::time::UNIX_EPOCH)
+        .unwrap()
+        .as_secs() as i64;
+
+    // Record more decisions than the delta budget allows.
+    for i in 0..12 {
+        insert_decision_at(&cg, &format!("decision number {i}"), now - i64::from(i)).await;
+    }
+    // And several touched code areas.
+    for i in 0..8 {
+        cg.record_code_area(&format!("src/area_{i}.rs"), None)
+            .await
+            .unwrap();
+    }
+
+    let delta = cg.session_delta().await.unwrap();
+
+    // Entry counts are capped to the budget.
+    assert!(
+        delta.recent_decisions.len() <= 5,
+        "decisions capped, got {}",
+        delta.recent_decisions.len()
+    );
+    assert!(
+        delta.recent_code_areas.len() <= 5,
+        "code areas capped, got {}",
+        delta.recent_code_areas.len()
+    );
+    // Content is present and non-empty.
+    assert!(!delta.recent_decisions.is_empty());
+    assert!(!delta.recent_code_areas.is_empty());
+    assert!(!delta.recent_decisions[0].summary.is_empty());
+    // The most recent decision (created_at == now) ranks first.
+    assert_eq!(delta.recent_decisions[0].summary, "decision number 0");
+}
+
+#[tokio::test]
+async fn session_delta_truncates_long_text() {
+    let (_tmp, cg) = make_project().await;
+
+    let long = "x".repeat(500);
+    cg.record_decision(&long, None, &[], &[]).await.unwrap();
+
+    let delta = cg.session_delta().await.unwrap();
+    assert_eq!(delta.recent_decisions.len(), 1);
+    // Truncated to the 120-char budget plus an ellipsis.
+    let summary = &delta.recent_decisions[0].summary;
+    assert!(summary.ends_with('…'));
+    assert!(
+        summary.chars().count() <= 121,
+        "summary too long: {} chars",
+        summary.chars().count()
+    );
+}
+
 #[tokio::test]
 async fn session_recall_filters_by_since() {
     let (_tmp, cg) = make_project().await;


### PR DESCRIPTION
Closes #122 (narrowed scope; contradiction detection → #126, validity/ROI ranking → #127).

## 1. Compact delta at `session_start`
New `session_delta()` → `SessionDelta { recent_decisions, recent_code_areas }`, bounded to 5+5 entries, each headline truncated to 120 chars (UTF-8-safe). Surfaced as a new `memory_delta` field on `handle_session_start`; existing contract (baseline write, `quality_signal`, etc.) untouched. Memory-read failure degrades to `null` rather than blocking baseline save.

## 2. Decay-weighted recall (no TTL / no deletion)
New `recency_decay_weight(created_at, now) = 2^(-age / half_life)` with a 14-day half-life. `session_recall`'s no-query paths sort by decay weight (ties → newest first). Decay is monotonic in `created_at`, so the existing `ORDER BY created_at DESC LIMIT n` still pre-selects the correct top-n. Nothing is ever dropped/expired; old decisions remain permanently recallable. FTS/query path unchanged.

## Tests
- `memory_test.rs`: recency-decay ranking keeps a 6-month-old decision (recent ranks above old); delta capped at 5/5; long-text truncation.
- `mcp_handler_test.rs`: `test_session_start` asserts `memory_delta.recent_decisions` present, non-empty, capped at 5.
- Full suite: 2054 passed. `cargo fmt --check` clean; clippy clean on changed code.

🤖 Generated with [Claude Code](https://claude.com/claude-code)