### PR TITLE
fix(dead_code): exclude Rust trait-impl methods (#137)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+- **Dead-code analysis no longer reports Rust trait-impl methods as false positives (#137).** Methods inside `impl Trait for Type` blocks — `Display::fmt`, `Deref::deref`, `Drop::drop`, `From::from`, `AsRef::as_ref`, etc. — are dispatched implicitly by the compiler (format macros, auto-deref, drop glue, `?`/`.into()`), so they carry no incoming `calls` edge, and because they can't be written `pub` in Rust they are stored as `private` and slipped past the visibility filter. `tokensave_dead_code` flagged them as dead (inflating `dead_code_count`) and `tokensave_health` counted them against the `redundancy` dimension. `find_dead_code` now excludes methods whose parent is an `Impl`-kind node bearing an outgoing `implements` edge — precisely Rust's trait-impl blocks, which contain only the trait's methods. Inherent-impl and free functions are still reported. The exclusion is language-aware: class-based languages (C#/Java/TS/PHP/VB) attach `implements` to the `Class` node and store interface methods `public` (already filtered), and ObjC `@implementation` blocks carry no `implements` edge, so neither is affected. New `include_trait_impls: true` arg on `tokensave_dead_code` opts back into reporting them.
+
 
 ## [6.4.0] - 2026-06-16
 

--- a/src/graph/queries.rs
+++ b/src/graph/queries.rs
@@ -121,6 +121,7 @@ impl<'a> GraphQueryManager<'a> {
         &self,
         kinds: &[NodeKind],
         include_public: bool,
+        include_trait_impls: bool,
     ) -> Result<Vec<Node>> {
         let kind_filter = if kinds.is_empty() {
             String::new()
@@ -133,6 +134,34 @@ impl<'a> GraphQueryManager<'a> {
             ""
         } else {
             " AND visibility != 'public'"
+        };
+
+        // Trait-impl methods (Rust `impl Trait for Type` blocks) are reached
+        // implicitly by the compiler — `Display::fmt` via `{}`, `Deref::deref`
+        // via auto-deref, `Drop::drop` via drop glue, `From::from` via `?`/
+        // `.into()` — so they carry no explicit incoming `calls` edge. They
+        // also can't be written `pub` in Rust, so they're stored as `private`
+        // and the visibility filter above never excludes them. The result is
+        // a flood of false positives (issue #137). Exclude any method whose
+        // parent is an `Impl`-kind node bearing an outgoing `implements` edge:
+        // that set is exactly Rust's trait-impl blocks, which contain ONLY the
+        // trait's methods, so the exclusion is precise. It deliberately does
+        // NOT fire for class-based languages — there the `implements` edge
+        // hangs off the `Class` node (whose methods are a mix of interface and
+        // private), and interface methods are stored `public` so the
+        // visibility filter already covers them. ObjC `@implementation` blocks
+        // are `Impl` nodes too but carry no `implements` edge (conformance is
+        // recorded on the `@interface`), so they are untouched. The guarding
+        // `parent_id IS NULL OR` is required: `NULL NOT IN (...)` is NULL, not
+        // true, which would silently drop every top-level function.
+        let trait_impl_filter = if include_trait_impls {
+            ""
+        } else {
+            " AND (parent_id IS NULL OR parent_id NOT IN (
+                 SELECT e.source FROM edges e
+                 JOIN nodes p ON p.id = e.source
+                 WHERE e.kind = 'implements' AND p.kind = 'impl'
+             ))"
         };
 
         // Only true "use sites" count as evidence that a symbol is alive:
@@ -180,7 +209,7 @@ impl<'a> GraphQueryManager<'a> {
         //   probe is now against a ~15K-row indexed lookup table, not a
         //   correlated subquery the optimiser can re-shape.
         let result = self
-            .find_dead_code_inner(visibility_filter, &kind_filter)
+            .find_dead_code_inner(visibility_filter, &kind_filter, trait_impl_filter)
             .await;
 
         // Always drop both temp tables, even on the error path, so a
@@ -198,6 +227,7 @@ impl<'a> GraphQueryManager<'a> {
         &self,
         visibility_filter: &str,
         kind_filter: &str,
+        trait_impl_filter: &str,
     ) -> Result<Vec<Node>> {
         let marker_ids = self.db.collect_test_marker_ids().await?;
         self.db.populate_test_marker_temp_table(&marker_ids).await?;
@@ -213,6 +243,7 @@ impl<'a> GraphQueryManager<'a> {
              AND name NOT LIKE 'test%'
              {visibility_filter}
              {kind_filter}
+             {trait_impl_filter}
              AND NOT EXISTS (
                  SELECT 1 FROM edges
                  WHERE target = nodes.id

--- a/src/mcp/tools/definitions.rs
+++ b/src/mcp/tools/definitions.rs
@@ -591,7 +591,11 @@ fn def_dead_code() -> ToolDefinition {
          Always excludes `main` and `test*` functions. By default also excludes \
          `pub` items (they may be referenced outside the indexed scope) — pass \
          `include_public: true` to audit pub items with zero indexed callers, \
-         which is what you want for workspace-internal cleanup.",
+         which is what you want for workspace-internal cleanup. Rust trait-impl \
+         methods (e.g. `Display::fmt`, `Deref::deref`, `Drop::drop`) are also \
+         excluded by default: they are dispatched implicitly by the compiler so \
+         they have no caller edge yet are never truly dead — pass \
+         `include_trait_impls: true` to include them.",
         json!({
             "type": "object",
             "properties": {
@@ -603,6 +607,10 @@ fn def_dead_code() -> ToolDefinition {
                 "include_public": {
                     "type": "boolean",
                     "description": "When true, do NOT exclude pub items. Default false."
+                },
+                "include_trait_impls": {
+                    "type": "boolean",
+                    "description": "When true, do NOT exclude Rust trait-impl methods (implicitly-dispatched methods like fmt/deref/drop). Default false."
                 }
             }
         }),

--- a/src/mcp/tools/handlers/analysis.rs
+++ b/src/mcp/tools/handlers/analysis.rs
@@ -168,7 +168,13 @@ pub(super) async fn handle_dead_code(
         .get("include_public")
         .and_then(serde_json::Value::as_bool)
         .unwrap_or(false);
-    let dead = cg.find_dead_code(&kinds, include_public).await?;
+    let include_trait_impls = args
+        .get("include_trait_impls")
+        .and_then(serde_json::Value::as_bool)
+        .unwrap_or(false);
+    let dead = cg
+        .find_dead_code(&kinds, include_public, include_trait_impls)
+        .await?;
     let dead = filter_by_scope(dead, scope_prefix, |n| &n.file_path);
 
     let touched_files = unique_file_paths(dead.iter().map(|n| n.file_path.as_str()));

--- a/src/mcp/tools/handlers/health.rs
+++ b/src/mcp/tools/handlers/health.rs
@@ -95,8 +95,11 @@ pub(super) async fn compute_health_snapshot(
     let gini = gini_coefficient(&complexity_values);
     let equality = (1.0 - gini).clamp(0.0, 1.0);
 
+    // Exclude trait-impl methods (issue #137): they have no explicit caller
+    // edge but are reached via implicit compiler dispatch, so counting them
+    // as dead falsely depresses the redundancy dimension.
     let dead = cg
-        .find_dead_code(&[NodeKind::Function, NodeKind::Method], false)
+        .find_dead_code(&[NodeKind::Function, NodeKind::Method], false, false)
         .await?;
     let dead_in_scope = dead.iter().filter(|n| {
         path_prefix.is_none_or(|pfx| {

--- a/src/tokensave.rs
+++ b/src/tokensave.rs
@@ -2182,13 +2182,21 @@ impl TokenSave {
     /// excluded — they may be referenced by code outside the indexed
     /// scope. Pass `true` to also surface pub items with zero indexed
     /// callers (useful for workspace-internal audits).
+    ///
+    /// When `include_trait_impls` is `false` (the default), Rust trait-impl
+    /// methods are excluded — they are dispatched implicitly by the compiler
+    /// (e.g. `Display::fmt`, `Deref::deref`, `Drop::drop`) so they carry no
+    /// explicit caller edge yet are never truly dead. Pass `true` to include
+    /// them anyway. See issue #137.
     pub async fn find_dead_code(
         &self,
         kinds: &[NodeKind],
         include_public: bool,
+        include_trait_impls: bool,
     ) -> Result<Vec<Node>> {
         let qm = GraphQueryManager::new(&self.db);
-        qm.find_dead_code(kinds, include_public).await
+        qm.find_dead_code(kinds, include_public, include_trait_impls)
+            .await
     }
 
     /// Returns all nodes for a given file, ordered by start line.

--- a/tests/graph_test.rs
+++ b/tests/graph_test.rs
@@ -443,7 +443,7 @@ async fn test_find_dead_code() {
 
     let qm = GraphQueryManager::new(&db);
     let dead = qm
-        .find_dead_code(&[], false)
+        .find_dead_code(&[], false, true)
         .await
         .expect("find_dead_code failed");
 
@@ -471,7 +471,7 @@ async fn test_find_dead_code_excludes_pub() {
 
     let qm = GraphQueryManager::new(&db);
     let dead = qm
-        .find_dead_code(&[], false)
+        .find_dead_code(&[], false, true)
         .await
         .expect("find_dead_code failed");
 
@@ -479,6 +479,77 @@ async fn test_find_dead_code_excludes_pub() {
     assert!(
         !dead_names.contains(&"public_api"),
         "pub functions should not be reported as dead code"
+    );
+}
+
+/// Regression for issue #137: Rust trait-impl methods (e.g. `Display::fmt`)
+/// are reached via implicit compiler dispatch, so they carry no incoming
+/// `calls` edge and — being un-`pub`able — are stored as `private`. They must
+/// NOT be reported as dead by default, but inherent-impl methods (whose impl
+/// block has no `implements` edge) with no callers still must be. Passing
+/// `include_trait_impls: true` opts back into reporting them.
+#[tokio::test]
+async fn test_find_dead_code_excludes_trait_impl_methods() {
+    let (db, _dir) = setup_db().await;
+
+    // `impl Display for MyType` block + the trait it implements.
+    let mut trait_impl = make_node("n-impl-display", "MyType", "src/ty.rs", Visibility::Pub);
+    trait_impl.kind = NodeKind::Impl;
+    let mut display_trait = make_node("n-trait-display", "Display", "src/ty.rs", Visibility::Pub);
+    display_trait.kind = NodeKind::Trait;
+
+    // The trait-impl method `fmt`: private, no incoming call edge.
+    let mut fmt = make_node("n-fmt", "fmt", "src/ty.rs", Visibility::Private);
+    fmt.kind = NodeKind::Method;
+    fmt.parent_id = Some("n-impl-display".to_string());
+
+    // An inherent `impl MyType` block (no `implements` edge) holding a private
+    // method with no callers — a *genuine* dead-code candidate that must still
+    // be reported, proving the exclusion is scoped to trait impls only.
+    let mut inherent_impl = make_node("n-impl-inherent", "MyType", "src/ty.rs", Visibility::Pub);
+    inherent_impl.kind = NodeKind::Impl;
+    let mut truly_dead = make_node("n-dead", "truly_dead", "src/ty.rs", Visibility::Private);
+    truly_dead.kind = NodeKind::Method;
+    truly_dead.parent_id = Some("n-impl-inherent".to_string());
+
+    db.insert_nodes(&[trait_impl, display_trait, fmt, inherent_impl, truly_dead])
+        .await
+        .expect("insert nodes failed");
+    db.insert_edges(&[Edge {
+        source: "n-impl-display".to_string(),
+        target: "n-trait-display".to_string(),
+        kind: EdgeKind::Implements,
+        line: Some(1),
+    }])
+    .await
+    .expect("insert edges failed");
+
+    let qm = GraphQueryManager::new(&db);
+
+    // Default: trait-impl method excluded, inherent dead method still reported.
+    let dead = qm
+        .find_dead_code(&[NodeKind::Method], false, false)
+        .await
+        .expect("find_dead_code failed");
+    let names: Vec<&str> = dead.iter().map(|n| n.name.as_str()).collect();
+    assert!(
+        !names.contains(&"fmt"),
+        "trait-impl method `fmt` should not be dead by default, got: {names:?}"
+    );
+    assert!(
+        names.contains(&"truly_dead"),
+        "inherent-impl method with no callers should still be dead, got: {names:?}"
+    );
+
+    // Opt-in: include_trait_impls=true surfaces `fmt` again.
+    let dead_all = qm
+        .find_dead_code(&[NodeKind::Method], false, true)
+        .await
+        .expect("find_dead_code failed");
+    let names_all: Vec<&str> = dead_all.iter().map(|n| n.name.as_str()).collect();
+    assert!(
+        names_all.contains(&"fmt"),
+        "include_trait_impls=true should surface `fmt`, got: {names_all:?}"
     );
 }
 
@@ -580,7 +651,7 @@ async fn test_find_dead_code_excludes_test_annotated() {
 
     let qm = GraphQueryManager::new(&db);
     let dead = qm
-        .find_dead_code(&[NodeKind::Function], false)
+        .find_dead_code(&[NodeKind::Function], false, true)
         .await
         .expect("find_dead_code failed");
 
@@ -619,7 +690,7 @@ async fn test_find_dead_code_with_kind_filter() {
 
     // Filter to only Function kind.
     let dead = qm
-        .find_dead_code(&[NodeKind::Function], false)
+        .find_dead_code(&[NodeKind::Function], false, true)
         .await
         .expect("find_dead_code failed");
 
@@ -1377,7 +1448,7 @@ async fn dead_code_marker_resolve_is_single_pass() {
 
     let t0 = std::time::Instant::now();
     let dead = qm
-        .find_dead_code(&[NodeKind::Function], false)
+        .find_dead_code(&[NodeKind::Function], false, true)
         .await
         .expect("find_dead_code failed");
     let elapsed = t0.elapsed();

--- a/tests/tokensave_test.rs
+++ b/tests/tokensave_test.rs
@@ -207,7 +207,7 @@ async fn test_get_file_dependents() {
 async fn test_find_dead_code_functions() {
     let (cg, _dir) = setup().await;
     let dead = cg
-        .find_dead_code(&[NodeKind::Function], false)
+        .find_dead_code(&[NodeKind::Function], false, true)
         .await
         .unwrap();
     // The method should return successfully. Private functions without
@@ -233,7 +233,10 @@ async fn test_find_dead_code_functions() {
 async fn test_find_dead_code_custom_kinds() {
     let (cg, _dir) = setup().await;
     // Look for dead structs — our test project has none, should return empty
-    let dead = cg.find_dead_code(&[NodeKind::Struct], false).await.unwrap();
+    let dead = cg
+        .find_dead_code(&[NodeKind::Struct], false, true)
+        .await
+        .unwrap();
     assert!(
         dead.is_empty(),
         "test project has no structs, so no dead struct code expected",


### PR DESCRIPTION
## Summary

Fixes #137. `tokensave_dead_code` (and the `redundancy` dimension of `tokensave_health`) reported Rust trait-impl methods — `Display::fmt`, `Deref::deref`, `Drop::drop`, `From::from`, `AsRef::as_ref`, … — as dead code.

These methods are dispatched implicitly by the compiler (format macros, auto-deref, drop glue, `?`/`.into()`), so they carry no incoming `calls` edge. Because they can't be written `pub` in a trait impl they're stored as `private`, so the visibility filter never excluded them either. Deleting any of them breaks the build, so they're clear false positives.

## Fix

`find_dead_code` now excludes methods whose parent is an `Impl`-kind node bearing an outgoing `implements` edge — precisely Rust's trait-impl blocks, which contain only the trait's methods. Inherent-impl methods and free functions are still reported.

A new `include_trait_impls: true` arg on `tokensave_dead_code` opts back into reporting them (parallel to the existing `include_public`).

## Cross-language safety

The exclusion is language-aware and fires for Rust only:
- **C#/Java/TS/PHP/VB** attach the `implements` edge to the `Class` node (mixed methods) and store interface methods `public` — already covered by the visibility filter; the `Class`-parented clause doesn't touch them.
- **ObjC** `@implementation` blocks are `Impl` nodes but carry no `implements` edge (conformance is on `@interface`), so they're untouched.
- **Swift/Kotlin/Scala/etc.** default interface methods to `public`.

## Tests

`test_find_dead_code_excludes_trait_impl_methods` verifies: trait-impl `fmt` is excluded by default, an inherent-impl method with no callers is still reported (exclusion scoped to trait impls), and `include_trait_impls: true` surfaces `fmt` again.

🤖 Generated with [Claude Code](https://claude.com/claude-code)