### PR TITLE
fix(dead_code): detect trait impls by signature, completing #137

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+- **Dead-code trait-impl exclusion now actually fires for stdlib traits (#137, completes 6.4.1).** The 6.4.1 fix keyed off the impl block's outgoing `implements` edge, but that edge only materializes when the trait resolves to an *indexed* node. Impls of stdlib/external traits — `Display`, `Drop`, `Deref`, `From`, `AsRef`, the exact traits in the bug report — never get the edge, so the fix was inert on real codebases (the mex codebase has zero `implements` edges; all 13 trait-impl methods were still flagged). Detection now keys off the impl node's signature (`impl <Trait> for <Type>` contains ` for `), with the `implements` edge kept only as a fallback for multi-line headers that `extract_first_line` truncates before the ` for `. Verified against mex: false positives dropped from 20 to 7, the 7 remaining being genuine inherent/free functions. Inherent impls (`impl Type`, no ` for `) and ObjC `@implementation` blocks are still untouched.
+
 
 ## [6.4.1] - 2026-06-17
 

--- a/src/graph/queries.rs
+++ b/src/graph/queries.rs
@@ -143,24 +143,37 @@ impl<'a> GraphQueryManager<'a> {
         // also can't be written `pub` in Rust, so they're stored as `private`
         // and the visibility filter above never excludes them. The result is
         // a flood of false positives (issue #137). Exclude any method whose
-        // parent is an `Impl`-kind node bearing an outgoing `implements` edge:
-        // that set is exactly Rust's trait-impl blocks, which contain ONLY the
-        // trait's methods, so the exclusion is precise. It deliberately does
-        // NOT fire for class-based languages — there the `implements` edge
-        // hangs off the `Class` node (whose methods are a mix of interface and
-        // private), and interface methods are stored `public` so the
-        // visibility filter already covers them. ObjC `@implementation` blocks
-        // are `Impl` nodes too but carry no `implements` edge (conformance is
-        // recorded on the `@interface`), so they are untouched. The guarding
+        // parent is an `Impl`-kind node that is a *trait* impl (vs an inherent
+        // `impl Type` block, whose un-called methods are genuine dead code).
+        //
+        // We detect a trait impl two ways, OR'd together:
+        //   1) the impl node's signature contains ` for ` — i.e. the header is
+        //      `impl <Trait> for <Type>`. This is the PRIMARY signal and the
+        //      only one that works for the common case, because…
+        //   2) …the impl node bears an outgoing `implements` edge. This edge
+        //      only materializes when the trait resolves to an indexed node,
+        //      which it does NOT for stdlib/external traits (`Display`, `Drop`,
+        //      `Deref`, `From`, `AsRef`, …) — precisely the traits in the bug
+        //      report. So the edge alone misses almost every real case (mex has
+        //      zero `implements` edges); the signature scan is what carries the
+        //      fix. The edge is kept as a fallback for multi-line impl headers
+        //      where `extract_first_line` truncates before the ` for `.
+        //
+        // Inherent-impl signatures (`impl Type`) and ObjC `@implementation Foo`
+        // blocks contain no ` for `, so they are untouched — inherent dead
+        // methods are still reported. Class-based languages attach `implements`
+        // to the `Class` node (not an `impl`) and store interface methods
+        // `public`, so the visibility filter already covers them. The guarding
         // `parent_id IS NULL OR` is required: `NULL NOT IN (...)` is NULL, not
         // true, which would silently drop every top-level function.
         let trait_impl_filter = if include_trait_impls {
             ""
         } else {
             " AND (parent_id IS NULL OR parent_id NOT IN (
-                 SELECT e.source FROM edges e
-                 JOIN nodes p ON p.id = e.source
-                 WHERE e.kind = 'implements' AND p.kind = 'impl'
+                 SELECT p.id FROM nodes p
+                 WHERE p.kind = 'impl'
+                   AND (p.signature LIKE '% for %'
+                        OR p.id IN (SELECT source FROM edges WHERE kind = 'implements'))
              ))"
         };
 

--- a/tests/graph_test.rs
+++ b/tests/graph_test.rs
@@ -485,39 +485,64 @@ async fn test_find_dead_code_excludes_pub() {
 /// Regression for issue #137: Rust trait-impl methods (e.g. `Display::fmt`)
 /// are reached via implicit compiler dispatch, so they carry no incoming
 /// `calls` edge and — being un-`pub`able — are stored as `private`. They must
-/// NOT be reported as dead by default, but inherent-impl methods (whose impl
-/// block has no `implements` edge) with no callers still must be. Passing
-/// `include_trait_impls: true` opts back into reporting them.
+/// NOT be reported as dead by default, while inherent-impl methods with no
+/// callers still must be. `include_trait_impls: true` opts back into them.
+///
+/// The critical case is a trait impl of a STDLIB/external trait (`Display`,
+/// `Drop`, `Deref`, `From`, `AsRef`): the trait is not an indexed node, so the
+/// extractor never materializes an `implements` edge. Detection therefore
+/// keys off the impl node's signature (`impl <Trait> for <Type>`), with the
+/// `implements` edge as a fallback for multi-line headers. A prior fix that
+/// relied on the edge alone was inert on real codebases (zero such edges).
 #[tokio::test]
 async fn test_find_dead_code_excludes_trait_impl_methods() {
     let (db, _dir) = setup_db().await;
 
-    // `impl Display for MyType` block + the trait it implements.
-    let mut trait_impl = make_node("n-impl-display", "MyType", "src/ty.rs", Visibility::Pub);
-    trait_impl.kind = NodeKind::Impl;
-    let mut display_trait = make_node("n-trait-display", "Display", "src/ty.rs", Visibility::Pub);
-    display_trait.kind = NodeKind::Trait;
-
-    // The trait-impl method `fmt`: private, no incoming call edge.
+    // (1) Stdlib trait impl, signature-only, NO `implements` edge — the case
+    // the edge-only fix missed. `fmt` must be excluded.
+    let mut display_impl = make_node("n-impl-display", "MyType", "src/ty.rs", Visibility::Pub);
+    display_impl.kind = NodeKind::Impl;
+    display_impl.signature = Some("impl std::fmt::Display for MyType".to_string());
     let mut fmt = make_node("n-fmt", "fmt", "src/ty.rs", Visibility::Private);
     fmt.kind = NodeKind::Method;
     fmt.parent_id = Some("n-impl-display".to_string());
 
-    // An inherent `impl MyType` block (no `implements` edge) holding a private
-    // method with no callers — a *genuine* dead-code candidate that must still
-    // be reported, proving the exclusion is scoped to trait impls only.
+    // (2) Inherent `impl MyType` (signature has no ` for `, no edge) holding a
+    // private method with no callers — a genuine dead candidate that must
+    // still be reported, proving the exclusion is scoped to trait impls.
     let mut inherent_impl = make_node("n-impl-inherent", "MyType", "src/ty.rs", Visibility::Pub);
     inherent_impl.kind = NodeKind::Impl;
+    inherent_impl.signature = Some("impl MyType".to_string());
     let mut truly_dead = make_node("n-dead", "truly_dead", "src/ty.rs", Visibility::Private);
     truly_dead.kind = NodeKind::Method;
     truly_dead.parent_id = Some("n-impl-inherent".to_string());
 
-    db.insert_nodes(&[trait_impl, display_trait, fmt, inherent_impl, truly_dead])
-        .await
-        .expect("insert nodes failed");
+    // (3) Trait impl whose first-line signature was truncated before ` for `
+    // (multi-line header), but which DOES carry an `implements` edge — the
+    // fallback path. `via_edge` must be excluded.
+    let mut edge_impl = make_node("n-impl-edge", "MyType", "src/ty.rs", Visibility::Pub);
+    edge_impl.kind = NodeKind::Impl;
+    edge_impl.signature = Some("impl<T> LongTrait<T>".to_string());
+    let mut local_trait = make_node("n-trait-local", "LongTrait", "src/ty.rs", Visibility::Pub);
+    local_trait.kind = NodeKind::Trait;
+    let mut via_edge = make_node("n-via-edge", "via_edge", "src/ty.rs", Visibility::Private);
+    via_edge.kind = NodeKind::Method;
+    via_edge.parent_id = Some("n-impl-edge".to_string());
+
+    db.insert_nodes(&[
+        display_impl,
+        fmt,
+        inherent_impl,
+        truly_dead,
+        edge_impl,
+        local_trait,
+        via_edge,
+    ])
+    .await
+    .expect("insert nodes failed");
     db.insert_edges(&[Edge {
-        source: "n-impl-display".to_string(),
-        target: "n-trait-display".to_string(),
+        source: "n-impl-edge".to_string(),
+        target: "n-trait-local".to_string(),
         kind: EdgeKind::Implements,
         line: Some(1),
     }])
@@ -526,7 +551,7 @@ async fn test_find_dead_code_excludes_trait_impl_methods() {
 
     let qm = GraphQueryManager::new(&db);
 
-    // Default: trait-impl method excluded, inherent dead method still reported.
+    // Default: both trait-impl methods excluded, inherent dead method reported.
     let dead = qm
         .find_dead_code(&[NodeKind::Method], false, false)
         .await
@@ -534,22 +559,26 @@ async fn test_find_dead_code_excludes_trait_impl_methods() {
     let names: Vec<&str> = dead.iter().map(|n| n.name.as_str()).collect();
     assert!(
         !names.contains(&"fmt"),
-        "trait-impl method `fmt` should not be dead by default, got: {names:?}"
+        "stdlib trait-impl method `fmt` (signature-only) should not be dead, got: {names:?}"
+    );
+    assert!(
+        !names.contains(&"via_edge"),
+        "trait-impl method via `implements`-edge fallback should not be dead, got: {names:?}"
     );
     assert!(
         names.contains(&"truly_dead"),
         "inherent-impl method with no callers should still be dead, got: {names:?}"
     );
 
-    // Opt-in: include_trait_impls=true surfaces `fmt` again.
+    // Opt-in: include_trait_impls=true surfaces both trait-impl methods again.
     let dead_all = qm
         .find_dead_code(&[NodeKind::Method], false, true)
         .await
         .expect("find_dead_code failed");
     let names_all: Vec<&str> = dead_all.iter().map(|n| n.name.as_str()).collect();
     assert!(
-        names_all.contains(&"fmt"),
-        "include_trait_impls=true should surface `fmt`, got: {names_all:?}"
+        names_all.contains(&"fmt") && names_all.contains(&"via_edge"),
+        "include_trait_impls=true should surface trait-impl methods, got: {names_all:?}"
     );
 }
 


### PR DESCRIPTION
## Summary

Follow-up to #138 / v6.4.1, which **did not actually work** on real codebases.

The 6.4.1 fix excluded trait-impl methods whose parent `impl` block carries an outgoing `implements` edge. But that edge only materializes when the trait resolves to an *indexed* node — which never happens for stdlib/external traits (`Display`, `Drop`, `Deref`, `From`, `AsRef`), the exact traits in #137. On real codebases there are typically **zero** `implements` edges, so the fix was inert.

## Evidence (verified against the `mex` codebase)

Before this change, `tokensave_dead_code` on mex reported **20** symbols, 13 of which were trait-impl `fmt`/`drop`/`deref`/`from`/`as_ref` false positives (mex has 0 `implements` edges). After: **7**, all genuine inherent/free `pub(crate)` functions with no indexed caller.

## Fix

Detect a trait impl by the impl node's **signature**: a trait impl header is `impl <Trait> for <Type>` and contains ` for `, whereas an inherent `impl Type` block does not. The `implements` edge is kept only as a fallback for multi-line headers that `extract_first_line` truncates before the ` for `.

ObjC `@implementation Foo` blocks (no ` for `) and inherent impls stay untouched.

## Tests

Strengthened `test_find_dead_code_excludes_trait_impl_methods` to cover the signature-only (no-edge) stdlib case the 6.4.1 test missed, plus the edge fallback path, plus an inherent-impl method that must still be reported.

🤖 Generated with [Claude Code](https://claude.com/claude-code)