### PR TITLE
fix(dead_code): resolve calls via receiver bindings, Self::, and cfg/platform variants (#141)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+- **Dead-code analysis resolves calls through receiver bindings, `Self::`, and dotted method calls (#141).** After the trait-impl fix (#137), `tokensave_dead_code` still reported functions/methods as dead when their only call sites used call forms the resolver didn't trace. Three gaps are closed:
+  - **`Self::`/qualified call pre-filter (resolver, all languages).** `resolve_all`'s pre-filter dropped any `Self::method` / `Type::method` ref whose *literal* string wasn't a known name — so it never reached `resolve_one`, which strips the prefix and matches the simple name. It now admits a ref when its trailing simple name is known, and `resolve_one` gained a `.`-separator fallback so Python/TS/Java dotted calls (`obj.method`, emitted as the full callee text with no bare-name ref) resolve via the method name. This alone recovers `Self::` calls in Rust and *all* receiver-method calls in the dotted-callee languages.
+  - **Receiver-type inference (per-extractor: Rust, TypeScript, Java, Python).** A method call through a binding (`r.render_to_png()`) was emitted only as the bare method name, which mis-resolves when several types define a method of that name (e.g. two `render_to_png`s — all call edges piled onto the wrong one). Each extractor now builds a per-function variable→type table (from typed parameters, constructor/`new` initializers or type annotations, and `self`/`this`) and emits a precise `Type::method` ref that the resolver binds by qualified/suffix match to the correct impl/class.
+  - **Build-variant call-edge propagation (#141 Option 2: Rust `#[cfg]`, Go platform files).** Conditionally-compiled definitions (`#[cfg(target_os="macos")] fn f()` vs its `not(...)` twin; `foo_linux.go` vs `foo_windows.go`) are the same logical symbol compiled per-config, but the name-based resolver binds a call to one variant, leaving the others with zero incoming edges and flagged dead. A new post-resolution pass groups build-variant siblings (Rust: same `qualified_name` + `#[cfg]`-gated; Go: same package directory + function name across files) and replicates the call edge to every sibling. Verified against the mex crate: `dead_code_count` dropped from 7 to 0, every removal being a genuine reachable symbol.
+
 
 ## [6.4.2] - 2026-06-17
 

--- a/src/extraction/java_extractor.rs
+++ b/src/extraction/java_extractor.rs
@@ -696,6 +696,7 @@ impl JavaExtractor {
         // Extract call sites from the method body.
         if has_body {
             Self::extract_call_sites(state, node, &id);
+            Self::extract_receiver_typed_calls(state, node, &id);
         }
     }
 
@@ -755,6 +756,7 @@ impl JavaExtractor {
 
         // Extract call sites from the constructor body.
         Self::extract_call_sites(state, node, &id);
+        Self::extract_receiver_typed_calls(state, node, &id);
     }
 
     /// Extract field declarations. Each `variable_declarator` in the field becomes a Field node.
@@ -1390,6 +1392,185 @@ impl JavaExtractor {
 
     /// Recursively find `method_invocation` and `object_creation_expression` nodes inside a
     /// given node and create unresolved Calls references.
+    /// Type name of the nearest enclosing class (for `this` receivers).
+    fn enclosing_class_type(state: &ExtractionState) -> Option<String> {
+        state
+            .node_stack
+            .iter()
+            .rev()
+            .find(|(_, id)| id.starts_with("class:"))
+            .map(|(name, _)| name.clone())
+    }
+
+    /// Normalizes a Java type expression to a bare type name: drops generics,
+    /// array brackets, and any package/qualifier prefix. `List<Foo>` -> `List`,
+    /// `com.x.Service[]` -> `Service`.
+    fn normalize_type_name(raw: &str) -> Option<String> {
+        let mut s = raw.trim();
+        if let Some(p) = s.find(['<', '[', ' ']) {
+            s = &s[..p];
+        }
+        let seg = s.rsplit('.').next().unwrap_or(s).trim();
+        let first = seg.chars().next()?;
+        if !first.is_alphabetic() && first != '_' {
+            return None;
+        }
+        Some(seg.to_string())
+    }
+
+    /// Builds a `var-name -> type-name` table from typed parameters, local
+    /// variable declarations (declared type, or `new T(...)` when `var`), and
+    /// `this`.
+    fn collect_var_types(
+        state: &ExtractionState,
+        fn_node: TsNode<'_>,
+        self_type: Option<&str>,
+    ) -> std::collections::HashMap<String, String> {
+        let mut map = std::collections::HashMap::new();
+        if let Some(t) = self_type {
+            map.insert("this".to_string(), t.to_string());
+        }
+        if let Some(params) = fn_node.child_by_field_name("parameters") {
+            let mut cursor = params.walk();
+            if cursor.goto_first_child() {
+                loop {
+                    let p = cursor.node();
+                    if p.kind() == "formal_parameter" {
+                        if let (Some(ty), Some(name)) =
+                            (p.child_by_field_name("type"), p.child_by_field_name("name"))
+                        {
+                            if let Some(tn) = Self::normalize_type_name(&state.node_text(ty)) {
+                                map.insert(state.node_text(name), tn);
+                            }
+                        }
+                    }
+                    if !cursor.goto_next_sibling() {
+                        break;
+                    }
+                }
+            }
+        }
+        if let Some(body) = fn_node.child_by_field_name("body") {
+            Self::collect_local_types(state, body, &mut map);
+        }
+        map
+    }
+
+    /// Records `local_variable_declaration` types (declared type, or the
+    /// constructed type for `var x = new T()`), skipping nested type bodies.
+    fn collect_local_types(
+        state: &ExtractionState,
+        node: TsNode<'_>,
+        map: &mut std::collections::HashMap<String, String>,
+    ) {
+        let mut cursor = node.walk();
+        if cursor.goto_first_child() {
+            loop {
+                let c = cursor.node();
+                if c.kind() == "local_variable_declaration" {
+                    let declared = c
+                        .child_by_field_name("type")
+                        .map(|t| state.node_text(t))
+                        .filter(|t| t != "var");
+                    let mut dc = c.walk();
+                    if dc.goto_first_child() {
+                        loop {
+                            let d = dc.node();
+                            if d.kind() == "variable_declarator" {
+                                if let Some(name) = d.child_by_field_name("name") {
+                                    let ty = declared
+                                        .as_deref()
+                                        .and_then(Self::normalize_type_name)
+                                        .or_else(|| {
+                                            d.child_by_field_name("value").and_then(|v| {
+                                                (v.kind() == "object_creation_expression")
+                                                    .then(|| v.child_by_field_name("type"))
+                                                    .flatten()
+                                                    .and_then(|t| {
+                                                        Self::normalize_type_name(
+                                                            &state.node_text(t),
+                                                        )
+                                                    })
+                                            })
+                                        });
+                                    if let Some(t) = ty {
+                                        map.insert(state.node_text(name), t);
+                                    }
+                                }
+                            }
+                            if !dc.goto_next_sibling() {
+                                break;
+                            }
+                        }
+                    }
+                }
+                if !matches!(c.kind(), "class_declaration" | "method_declaration") {
+                    Self::collect_local_types(state, c, map);
+                }
+                if !cursor.goto_next_sibling() {
+                    break;
+                }
+            }
+        }
+    }
+
+    /// Emits a `Type::method` Calls ref for `recv.method(...)` whose receiver
+    /// type is known (#141), so the resolver binds to the right class method.
+    fn emit_typed_method_calls(
+        state: &mut ExtractionState,
+        node: TsNode<'_>,
+        fn_node_id: &str,
+        var_types: &std::collections::HashMap<String, String>,
+    ) {
+        let mut cursor = node.walk();
+        if cursor.goto_first_child() {
+            loop {
+                let child = cursor.node();
+                if child.kind() == "method_invocation" {
+                    if let (Some(obj), Some(name)) = (
+                        child.child_by_field_name("object"),
+                        child.child_by_field_name("name"),
+                    ) {
+                        let ty = match obj.kind() {
+                            "this" => var_types.get("this").cloned(),
+                            "identifier" => var_types.get(&state.node_text(obj)).cloned(),
+                            _ => None,
+                        };
+                        if let Some(ty) = ty {
+                            let method = state.node_text(name);
+                            state.unresolved_refs.push(UnresolvedRef {
+                                from_node_id: fn_node_id.to_string(),
+                                reference_name: format!("{ty}::{method}"),
+                                reference_kind: EdgeKind::Calls,
+                                line: child.start_position().row as u32,
+                                column: child.start_position().column as u32,
+                                file_path: state.file_path.clone(),
+                            });
+                        }
+                    }
+                }
+                if !matches!(child.kind(), "class_declaration" | "method_declaration") {
+                    Self::emit_typed_method_calls(state, child, fn_node_id, var_types);
+                }
+                if !cursor.goto_next_sibling() {
+                    break;
+                }
+            }
+        }
+    }
+
+    /// Receiver-type-aware method-call extraction (#141), mirroring the Rust
+    /// pass.
+    fn extract_receiver_typed_calls(
+        state: &mut ExtractionState,
+        fn_node: TsNode<'_>,
+        fn_node_id: &str,
+    ) {
+        let self_type = Self::enclosing_class_type(state);
+        let var_types = Self::collect_var_types(state, fn_node, self_type.as_deref());
+        Self::emit_typed_method_calls(state, fn_node, fn_node_id, &var_types);
+    }
+
     fn extract_call_sites(state: &mut ExtractionState, node: TsNode<'_>, fn_node_id: &str) {
         let mut cursor = node.walk();
         if cursor.goto_first_child() {

--- a/src/extraction/python_extractor.rs
+++ b/src/extraction/python_extractor.rs
@@ -243,6 +243,7 @@ impl PythonExtractor {
         // Extract call sites from the function body.
         if let Some(body) = Self::find_child_by_kind(node, "block") {
             Self::extract_call_sites(state, body, &id);
+            Self::extract_receiver_typed_calls(state, node, body, &id);
         }
     }
 
@@ -789,6 +790,178 @@ impl PythonExtractor {
     }
 
     /// Recursively find call nodes inside a given node and create unresolved Calls references.
+    /// Type name of the nearest enclosing class (for `self` receivers).
+    fn enclosing_class_type(state: &ExtractionState) -> Option<String> {
+        state
+            .node_stack
+            .iter()
+            .rev()
+            .find(|(_, id)| id.starts_with("class:"))
+            .map(|(name, _)| name.clone())
+    }
+
+    /// Normalizes a Python type expression to a bare type name: take the last
+    /// `.`-segment, drop subscripts. `mod.Service` -> `Service`.
+    fn normalize_type_name(raw: &str) -> Option<String> {
+        let mut s = raw.trim();
+        if let Some(p) = s.find(['[', '(', ' ']) {
+            s = &s[..p];
+        }
+        let seg = s.rsplit('.').next().unwrap_or(s).trim();
+        let first = seg.chars().next()?;
+        if !first.is_alphabetic() && first != '_' {
+            return None;
+        }
+        Some(seg.to_string())
+    }
+
+    /// True if `name` looks like a class per PEP8 CapWords — the only cheap
+    /// signal that `Service()` is construction (Python has no `new`).
+    fn looks_like_class(name: &str) -> bool {
+        name.chars().next().is_some_and(char::is_uppercase)
+    }
+
+    /// Builds a `var-name -> type-name` table from typed parameters, annotated
+    /// or `ClassName()`-constructed assignments, and `self`.
+    fn collect_var_types(
+        state: &ExtractionState,
+        fn_node: TsNode<'_>,
+        self_type: Option<&str>,
+    ) -> std::collections::HashMap<String, String> {
+        let mut map = std::collections::HashMap::new();
+        if let Some(t) = self_type {
+            map.insert("self".to_string(), t.to_string());
+        }
+        if let Some(params) = fn_node.child_by_field_name("parameters") {
+            let mut cursor = params.walk();
+            if cursor.goto_first_child() {
+                loop {
+                    let p = cursor.node();
+                    if p.kind() == "typed_parameter" {
+                        // typed_parameter: <identifier> : <type>
+                        let ident = p.named_child(0).filter(|n| n.kind() == "identifier");
+                        if let (Some(ident), Some(ty)) = (ident, p.child_by_field_name("type")) {
+                            if let Some(tn) = Self::normalize_type_name(&state.node_text(ty)) {
+                                map.insert(state.node_text(ident), tn);
+                            }
+                        }
+                    }
+                    if !cursor.goto_next_sibling() {
+                        break;
+                    }
+                }
+            }
+        }
+        if let Some(body) = Self::find_child_by_kind(fn_node, "block") {
+            Self::collect_assignment_types(state, body, &mut map);
+        }
+        map
+    }
+
+    /// Records assignment types: `x: T = ...` (annotation) or `x = T(...)`
+    /// where `T` is CapWords. Skips nested function/class scopes.
+    fn collect_assignment_types(
+        state: &ExtractionState,
+        node: TsNode<'_>,
+        map: &mut std::collections::HashMap<String, String>,
+    ) {
+        let mut cursor = node.walk();
+        if cursor.goto_first_child() {
+            loop {
+                let c = cursor.node();
+                if c.kind() == "assignment" {
+                    if let Some(lhs) = c.child_by_field_name("left") {
+                        if lhs.kind() == "identifier" {
+                            let ty = c
+                                .child_by_field_name("type")
+                                .and_then(|t| Self::normalize_type_name(&state.node_text(t)))
+                                .or_else(|| {
+                                    let rhs = c.child_by_field_name("right")?;
+                                    if rhs.kind() != "call" {
+                                        return None;
+                                    }
+                                    let callee = rhs.child_by_field_name("function")?;
+                                    if callee.kind() != "identifier" {
+                                        return None;
+                                    }
+                                    let name = state.node_text(callee);
+                                    Self::looks_like_class(&name).then_some(name)
+                                });
+                            if let Some(t) = ty {
+                                map.insert(state.node_text(lhs), t);
+                            }
+                        }
+                    }
+                }
+                if !matches!(c.kind(), "function_definition" | "class_definition") {
+                    Self::collect_assignment_types(state, c, map);
+                }
+                if !cursor.goto_next_sibling() {
+                    break;
+                }
+            }
+        }
+    }
+
+    /// Emits a `Type::method` Calls ref for `recv.method(...)` whose receiver
+    /// type is known (#141).
+    fn emit_typed_method_calls(
+        state: &mut ExtractionState,
+        node: TsNode<'_>,
+        fn_node_id: &str,
+        var_types: &std::collections::HashMap<String, String>,
+    ) {
+        let mut cursor = node.walk();
+        if cursor.goto_first_child() {
+            loop {
+                let child = cursor.node();
+                if child.kind() == "call" {
+                    if let Some(func) = child.child_by_field_name("function") {
+                        if func.kind() == "attribute" {
+                            if let (Some(obj), Some(attr)) = (
+                                func.child_by_field_name("object"),
+                                func.child_by_field_name("attribute"),
+                            ) {
+                                if obj.kind() == "identifier" {
+                                    if let Some(ty) = var_types.get(&state.node_text(obj)) {
+                                        let method = state.node_text(attr);
+                                        state.unresolved_refs.push(UnresolvedRef {
+                                            from_node_id: fn_node_id.to_string(),
+                                            reference_name: format!("{ty}::{method}"),
+                                            reference_kind: EdgeKind::Calls,
+                                            line: child.start_position().row as u32,
+                                            column: child.start_position().column as u32,
+                                            file_path: state.file_path.clone(),
+                                        });
+                                    }
+                                }
+                            }
+                        }
+                    }
+                }
+                if !matches!(child.kind(), "function_definition" | "class_definition") {
+                    Self::emit_typed_method_calls(state, child, fn_node_id, var_types);
+                }
+                if !cursor.goto_next_sibling() {
+                    break;
+                }
+            }
+        }
+    }
+
+    /// Receiver-type-aware method-call extraction (#141), mirroring the Rust
+    /// pass.
+    fn extract_receiver_typed_calls(
+        state: &mut ExtractionState,
+        fn_node: TsNode<'_>,
+        body: TsNode<'_>,
+        fn_node_id: &str,
+    ) {
+        let self_type = Self::enclosing_class_type(state);
+        let var_types = Self::collect_var_types(state, fn_node, self_type.as_deref());
+        Self::emit_typed_method_calls(state, body, fn_node_id, &var_types);
+    }
+
     fn extract_call_sites(state: &mut ExtractionState, node: TsNode<'_>, fn_node_id: &str) {
         let mut cursor = node.walk();
         if cursor.goto_first_child() {

--- a/src/extraction/rust_extractor.rs
+++ b/src/extraction/rust_extractor.rs
@@ -242,6 +242,15 @@ impl RustExtractor {
         // Extract call sites from the function body.
         Self::extract_call_sites(state, node, &id);
 
+        // Receiver-type-aware method calls (#141): `recv.method()` is otherwise
+        // emitted only as the bare `method`, which mis-resolves when several
+        // types define a method of that name. Build a local var->type table and
+        // emit a precise `Type::method` ref so the resolver's qualified/suffix
+        // match binds to the right impl.
+        let self_type = Self::enclosing_impl_type(state);
+        let var_types = Self::collect_var_types(state, node, self_type.as_deref());
+        Self::extract_typed_method_calls(state, node, &id, &var_types);
+
         // Extract attribute annotations (e.g. #[test], #[inline]).
         Self::extract_annotations_from_modifiers(state, node, &id);
 
@@ -1173,6 +1182,258 @@ impl RustExtractor {
 
     /// Recursively find `call_expression` nodes inside a given node and create
     /// unresolved Calls references.
+    /// Type-method names that, in `let x = Type::ctor(...)`, let us infer the
+    /// binding's type as `Type` (`new`/`from`/… return `Self`/the named type).
+    const CONSTRUCTOR_NAMES: &'static [&'static str] = &[
+        "new",
+        "default",
+        "with_capacity",
+        "from",
+        "try_from",
+        "build",
+        "create",
+        "open",
+        "init",
+        "builder",
+        "from_str",
+    ];
+
+    /// Returns the type name of the nearest enclosing `impl` block, used to
+    /// resolve `self`/`Self` receivers to a concrete type.
+    fn enclosing_impl_type(state: &ExtractionState) -> Option<String> {
+        state
+            .node_stack
+            .iter()
+            .rev()
+            .find(|(_, id)| id.starts_with("impl:"))
+            .map(|(name, _)| name.clone())
+    }
+
+    /// Normalizes a Rust type-expression text to a bare type name for
+    /// `Type::method` matching: strips leading `&`/`&mut`/`mut`/lifetimes,
+    /// generic arguments, and any path prefix. `&mut MermaidRenderer` ->
+    /// `MermaidRenderer`, `std::vec::Vec<u8>` -> `Vec`. Returns `None` for
+    /// shapes that aren't a plain named type (tuples, slices, `dyn`, etc.).
+    fn normalize_type_name(raw: &str) -> Option<String> {
+        let mut s = raw.trim();
+        loop {
+            if let Some(r) = s.strip_prefix('&') {
+                s = r.trim_start();
+            } else if let Some(r) = s.strip_prefix("mut ") {
+                s = r.trim_start();
+            } else if s.starts_with('\'') {
+                // lifetime token like `'a` — drop up to the next whitespace.
+                match s.find(char::is_whitespace) {
+                    Some(pos) => s = s[pos..].trim_start(),
+                    None => return None,
+                }
+            } else {
+                break;
+            }
+        }
+        // `dyn Trait` / `impl Trait` aren't concrete named types we can match.
+        if let Some(r) = s.strip_prefix("dyn ") {
+            s = r.trim_start();
+        }
+        if s.starts_with("impl ") {
+            return None;
+        }
+        if let Some(pos) = s.find('<') {
+            s = s[..pos].trim_end();
+        }
+        let seg = s.rsplit("::").next().unwrap_or(s).trim();
+        let first = seg.chars().next()?;
+        if !first.is_alphabetic() && first != '_' {
+            return None;
+        }
+        Some(seg.to_string())
+    }
+
+    /// Extracts the bound identifier from a `let` pattern (`x` or `mut x`).
+    fn binding_ident(state: &ExtractionState, pat: TsNode<'_>) -> Option<String> {
+        match pat.kind() {
+            "identifier" => Some(state.node_text(pat)),
+            "mut_pattern" => pat
+                .named_child(0)
+                .filter(|c| c.kind() == "identifier")
+                .map(|c| state.node_text(c)),
+            _ => None,
+        }
+    }
+
+    /// Best-effort type inference for a `let` RHS expression: a constructor
+    /// call `Type::new(...)` or a struct literal `Type { .. }`. `Self::new(...)`
+    /// resolves to `self_type`.
+    fn infer_expr_type(
+        state: &ExtractionState,
+        value: TsNode<'_>,
+        self_type: Option<&str>,
+    ) -> Option<String> {
+        match value.kind() {
+            "call_expression" => {
+                let func = value.child_by_field_name("function")?;
+                if func.kind() != "scoped_identifier" {
+                    return None;
+                }
+                let name = func
+                    .child_by_field_name("name")
+                    .map(|n| state.node_text(n))?;
+                if !Self::CONSTRUCTOR_NAMES.contains(&name.as_str()) {
+                    return None;
+                }
+                let path = func.child_by_field_name("path")?;
+                let ty = Self::normalize_type_name(&state.node_text(path))?;
+                if ty == "Self" {
+                    self_type.map(str::to_string)
+                } else {
+                    Some(ty)
+                }
+            }
+            "struct_expression" => {
+                let name = value.child_by_field_name("name")?;
+                Self::normalize_type_name(&state.node_text(name))
+            }
+            // `let x = &expr` / `let x = expr?` — peel one layer and retry.
+            "reference_expression" | "try_expression" => value
+                .named_child(0)
+                .and_then(|inner| Self::infer_expr_type(state, inner, self_type)),
+            _ => None,
+        }
+    }
+
+    /// Builds a `var-name -> type-name` table for a function body from typed
+    /// parameters and `let` bindings (annotation or constructor RHS). `self`
+    /// maps to the enclosing impl type.
+    fn collect_var_types(
+        state: &ExtractionState,
+        fn_node: TsNode<'_>,
+        self_type: Option<&str>,
+    ) -> std::collections::HashMap<String, String> {
+        let mut map = std::collections::HashMap::new();
+        if let Some(t) = self_type {
+            map.insert("self".to_string(), t.to_string());
+        }
+        if let Some(params) = fn_node.child_by_field_name("parameters") {
+            let mut cursor = params.walk();
+            if cursor.goto_first_child() {
+                loop {
+                    let p = cursor.node();
+                    if p.kind() == "parameter" {
+                        if let (Some(pat), Some(ty)) = (
+                            p.child_by_field_name("pattern"),
+                            p.child_by_field_name("type"),
+                        ) {
+                            if pat.kind() == "identifier" {
+                                if let Some(tn) = Self::normalize_type_name(&state.node_text(ty)) {
+                                    map.insert(state.node_text(pat), tn);
+                                }
+                            }
+                        }
+                    }
+                    if !cursor.goto_next_sibling() {
+                        break;
+                    }
+                }
+            }
+        }
+        if let Some(body) = fn_node.child_by_field_name("body") {
+            Self::collect_let_types(state, body, self_type, &mut map);
+        }
+        map
+    }
+
+    /// Recursively records `let`-binding types into `map`, skipping nested
+    /// function items (they have their own scope).
+    fn collect_let_types(
+        state: &ExtractionState,
+        node: TsNode<'_>,
+        self_type: Option<&str>,
+        map: &mut std::collections::HashMap<String, String>,
+    ) {
+        let mut cursor = node.walk();
+        if cursor.goto_first_child() {
+            loop {
+                let c = cursor.node();
+                if c.kind() == "let_declaration" {
+                    if let Some(var) = c
+                        .child_by_field_name("pattern")
+                        .and_then(|pat| Self::binding_ident(state, pat))
+                    {
+                        let ty = c
+                            .child_by_field_name("type")
+                            .and_then(|t| Self::normalize_type_name(&state.node_text(t)))
+                            .or_else(|| {
+                                c.child_by_field_name("value")
+                                    .and_then(|v| Self::infer_expr_type(state, v, self_type))
+                            });
+                        if let Some(t) = ty {
+                            map.insert(var, t);
+                        }
+                    }
+                }
+                if c.kind() != "function_item" {
+                    Self::collect_let_types(state, c, self_type, map);
+                }
+                if !cursor.goto_next_sibling() {
+                    break;
+                }
+            }
+        }
+    }
+
+    /// Emits a precise `Type::method` Calls ref for every `recv.method(...)`
+    /// whose receiver type is known from `var_types` (or `self`).
+    fn extract_typed_method_calls(
+        state: &mut ExtractionState,
+        node: TsNode<'_>,
+        fn_node_id: &str,
+        var_types: &std::collections::HashMap<String, String>,
+    ) {
+        let mut cursor = node.walk();
+        if cursor.goto_first_child() {
+            loop {
+                let child = cursor.node();
+                if child.kind() == "call_expression" {
+                    if let Some(func) = child.child_by_field_name("function") {
+                        if func.kind() == "field_expression" {
+                            if let (Some(recv), Some(field)) = (
+                                func.child_by_field_name("value"),
+                                func.child_by_field_name("field"),
+                            ) {
+                                if field.kind() == "field_identifier" {
+                                    let ty = match recv.kind() {
+                                        "self" => var_types.get("self").cloned(),
+                                        "identifier" => {
+                                            var_types.get(&state.node_text(recv)).cloned()
+                                        }
+                                        _ => None,
+                                    };
+                                    if let Some(ty) = ty {
+                                        let method = state.node_text(field);
+                                        state.unresolved_refs.push(UnresolvedRef {
+                                            from_node_id: fn_node_id.to_string(),
+                                            reference_name: format!("{ty}::{method}"),
+                                            reference_kind: EdgeKind::Calls,
+                                            line: child.start_position().row as u32,
+                                            column: child.start_position().column as u32,
+                                            file_path: state.file_path.clone(),
+                                        });
+                                    }
+                                }
+                            }
+                        }
+                    }
+                }
+                if child.kind() != "function_item" {
+                    Self::extract_typed_method_calls(state, child, fn_node_id, var_types);
+                }
+                if !cursor.goto_next_sibling() {
+                    break;
+                }
+            }
+        }
+    }
+
     fn extract_call_sites(state: &mut ExtractionState, node: TsNode<'_>, fn_node_id: &str) {
         let mut cursor = node.walk();
         if cursor.goto_first_child() {

--- a/src/extraction/typescript_extractor.rs
+++ b/src/extraction/typescript_extractor.rs
@@ -325,6 +325,7 @@ impl TypeScriptExtractor {
         // Extract call sites from the function body.
         if let Some(body) = Self::find_child_by_kind(node, "statement_block") {
             Self::extract_call_sites(state, body, &id);
+            Self::extract_receiver_typed_calls(state, node, body, &id);
         }
     }
 
@@ -432,6 +433,7 @@ impl TypeScriptExtractor {
         // Extract call sites from the arrow function body.
         if let Some(body) = Self::find_child_by_kind(arrow_node, "statement_block") {
             Self::extract_call_sites(state, body, &id);
+            Self::extract_receiver_typed_calls(state, arrow_node, body, &id);
         }
     }
 
@@ -646,6 +648,7 @@ impl TypeScriptExtractor {
         // Extract call sites from the method body.
         if let Some(body) = Self::find_child_by_kind(node, "statement_block") {
             Self::extract_call_sites(state, body, &id);
+            Self::extract_receiver_typed_calls(state, node, body, &id);
         }
     }
 
@@ -1280,6 +1283,192 @@ impl TypeScriptExtractor {
 
     /// Recursively find `call_expression` nodes inside a node and create
     /// unresolved Calls references.
+    /// Type name of the nearest enclosing class (for `this` receivers).
+    fn enclosing_class_type(state: &ExtractionState) -> Option<String> {
+        state
+            .node_stack
+            .iter()
+            .rev()
+            .find(|(_, id)| id.starts_with("class:"))
+            .map(|(name, _)| name.clone())
+    }
+
+    /// Normalizes a TS type expression to a bare type name: drops a leading
+    /// `:` (annotation), `new`, generics/array/union suffixes, and any
+    /// namespace prefix. `: Service<T>` -> `Service`, `ns.Foo[]` -> `Foo`.
+    fn normalize_type_name(raw: &str) -> Option<String> {
+        let mut s = raw.trim();
+        s = s.trim_start_matches(':').trim();
+        if let Some(r) = s.strip_prefix("new ") {
+            s = r.trim_start();
+        }
+        if let Some(p) = s.find(['<', '[', '(', '|', '&', ' ', '?']) {
+            s = &s[..p];
+        }
+        let seg = s.rsplit('.').next().unwrap_or(s).trim();
+        let first = seg.chars().next()?;
+        if !first.is_alphabetic() && first != '_' {
+            return None;
+        }
+        Some(seg.to_string())
+    }
+
+    /// Infers a variable's type from its initializer: `new Foo()` -> `Foo`.
+    fn infer_value_type(state: &ExtractionState, value: TsNode<'_>) -> Option<String> {
+        if value.kind() == "new_expression" {
+            let ctor = value
+                .child_by_field_name("constructor")
+                .unwrap_or_else(|| value.named_child(0).unwrap_or(value));
+            return Self::normalize_type_name(&state.node_text(ctor));
+        }
+        None
+    }
+
+    /// Builds a `var-name -> type-name` table from typed parameters, typed/
+    /// constructor-initialized `let`/`const` bindings, and `this`.
+    fn collect_var_types(
+        state: &ExtractionState,
+        fn_node: TsNode<'_>,
+        self_type: Option<&str>,
+    ) -> std::collections::HashMap<String, String> {
+        let mut map = std::collections::HashMap::new();
+        if let Some(t) = self_type {
+            map.insert("this".to_string(), t.to_string());
+        }
+        if let Some(params) = Self::find_child_by_kind(fn_node, "formal_parameters") {
+            let mut cursor = params.walk();
+            if cursor.goto_first_child() {
+                loop {
+                    let p = cursor.node();
+                    if matches!(p.kind(), "required_parameter" | "optional_parameter") {
+                        if let (Some(pat), Some(ty)) = (
+                            p.child_by_field_name("pattern"),
+                            p.child_by_field_name("type"),
+                        ) {
+                            if pat.kind() == "identifier" {
+                                if let Some(tn) = Self::normalize_type_name(&state.node_text(ty)) {
+                                    map.insert(state.node_text(pat), tn);
+                                }
+                            }
+                        }
+                    }
+                    if !cursor.goto_next_sibling() {
+                        break;
+                    }
+                }
+            }
+        }
+        if let Some(body) = Self::find_child_by_kind(fn_node, "statement_block") {
+            Self::collect_let_types(state, body, &mut map);
+        }
+        map
+    }
+
+    /// Recursively records `variable_declarator` types, skipping nested
+    /// function scopes.
+    fn collect_let_types(
+        state: &ExtractionState,
+        node: TsNode<'_>,
+        map: &mut std::collections::HashMap<String, String>,
+    ) {
+        let mut cursor = node.walk();
+        if cursor.goto_first_child() {
+            loop {
+                let c = cursor.node();
+                if c.kind() == "variable_declarator" {
+                    if let Some(name) = c.child_by_field_name("name") {
+                        if name.kind() == "identifier" {
+                            let ty = c
+                                .child_by_field_name("type")
+                                .and_then(|t| Self::normalize_type_name(&state.node_text(t)))
+                                .or_else(|| {
+                                    c.child_by_field_name("value")
+                                        .and_then(|v| Self::infer_value_type(state, v))
+                                });
+                            if let Some(t) = ty {
+                                map.insert(state.node_text(name), t);
+                            }
+                        }
+                    }
+                }
+                if !matches!(
+                    c.kind(),
+                    "arrow_function" | "function" | "function_declaration" | "method_definition"
+                ) {
+                    Self::collect_let_types(state, c, map);
+                }
+                if !cursor.goto_next_sibling() {
+                    break;
+                }
+            }
+        }
+    }
+
+    /// Emits a precise `Type::method` Calls ref for `recv.method(...)` whose
+    /// receiver type is known, so the resolver binds to the right class method.
+    fn emit_typed_method_calls(
+        state: &mut ExtractionState,
+        node: TsNode<'_>,
+        fn_node_id: &str,
+        var_types: &std::collections::HashMap<String, String>,
+    ) {
+        let mut cursor = node.walk();
+        if cursor.goto_first_child() {
+            loop {
+                let child = cursor.node();
+                if child.kind() == "call_expression" {
+                    if let Some(func) = child.child_by_field_name("function") {
+                        if func.kind() == "member_expression" {
+                            if let (Some(obj), Some(prop)) = (
+                                func.child_by_field_name("object"),
+                                func.child_by_field_name("property"),
+                            ) {
+                                let ty = match obj.kind() {
+                                    "this" => var_types.get("this").cloned(),
+                                    "identifier" => var_types.get(&state.node_text(obj)).cloned(),
+                                    _ => None,
+                                };
+                                if let Some(ty) = ty {
+                                    let method = state.node_text(prop);
+                                    state.unresolved_refs.push(UnresolvedRef {
+                                        from_node_id: fn_node_id.to_string(),
+                                        reference_name: format!("{ty}::{method}"),
+                                        reference_kind: EdgeKind::Calls,
+                                        line: child.start_position().row as u32,
+                                        column: child.start_position().column as u32,
+                                        file_path: state.file_path.clone(),
+                                    });
+                                }
+                            }
+                        }
+                    }
+                }
+                if !matches!(
+                    child.kind(),
+                    "arrow_function" | "function" | "function_declaration" | "method_definition"
+                ) {
+                    Self::emit_typed_method_calls(state, child, fn_node_id, var_types);
+                }
+                if !cursor.goto_next_sibling() {
+                    break;
+                }
+            }
+        }
+    }
+
+    /// Receiver-type-aware method-call extraction (#141): mirrors the Rust
+    /// pass. Builds the local var->type table and emits `Type::method` refs.
+    fn extract_receiver_typed_calls(
+        state: &mut ExtractionState,
+        fn_node: TsNode<'_>,
+        body: TsNode<'_>,
+        fn_node_id: &str,
+    ) {
+        let self_type = Self::enclosing_class_type(state);
+        let var_types = Self::collect_var_types(state, fn_node, self_type.as_deref());
+        Self::emit_typed_method_calls(state, body, fn_node_id, &var_types);
+    }
+
     fn extract_call_sites(state: &mut ExtractionState, node: TsNode<'_>, fn_node_id: &str) {
         let mut cursor = node.walk();
         if cursor.goto_first_child() {

--- a/src/resolution/mod.rs
+++ b/src/resolution/mod.rs
@@ -3,5 +3,7 @@
 /// Resolves unresolved references (from tree-sitter extraction) into concrete
 /// edges by matching them against known nodes in the database.
 mod resolver;
+mod variants;
 
 pub use resolver::ReferenceResolver;
+pub use variants::propagate_variant_edges;

--- a/src/resolution/resolver.rs
+++ b/src/resolution/resolver.rs
@@ -118,6 +118,15 @@ const CROSS_FILE_BLOCKLIST: &[&str] = &[
     "try_lock",
 ];
 
+/// Returns the trailing "simple" name of a possibly-qualified reference:
+/// the last segment after the final `::` (Rust/C++/PHP path) or `.`
+/// (Python/TS/JS/Java receiver call). `Self::watermark_band` -> `watermark_band`,
+/// `obj.render_to_png` -> `render_to_png`, `plain` -> `plain`.
+fn simple_ref_name(name: &str) -> &str {
+    let after_path = name.rsplit("::").next().unwrap_or(name);
+    after_path.rsplit('.').next().unwrap_or(after_path)
+}
+
 /// Infer a coarse language tag from a file path extension.
 fn lang_from_path(path: &str) -> &'static str {
     match path.rsplit('.').next().unwrap_or("") {
@@ -306,7 +315,8 @@ impl<'a> ReferenceResolver<'a> {
             }
         }
 
-        // Strategy 1: qualified name match
+        // Strategy 1: qualified name match (`::`-separated paths, e.g. Rust's
+        // `Type::method`, `Self::method`, C++ `Class::method`, PHP `A::b`).
         if uref.reference_name.contains("::") {
             if let Some(resolved) = self.try_qualified_match(uref) {
                 return Some(resolved);
@@ -319,6 +329,26 @@ impl<'a> ReferenceResolver<'a> {
                 .unwrap_or(&uref.reference_name);
             if let Some(resolved) = self.try_exact_name_match_simple(uref, simple_name) {
                 return Some(resolved);
+            }
+            return None;
+        }
+
+        // Strategy 1b: dotted receiver call (`recv.method`). The Python / TS /
+        // JS extractors emit the full callee text (`obj.method`) with no
+        // separate bare-name ref, so a method call never resolves without this
+        // fallback to the trailing segment. (Rust/Go already emit a bare-name
+        // ref alongside, so this is harmless there — the duplicate edge is
+        // collapsed by the unique edge index.)
+        if uref.reference_name.contains('.') {
+            let simple_name = uref
+                .reference_name
+                .rsplit('.')
+                .next()
+                .unwrap_or(&uref.reference_name);
+            if simple_name != uref.reference_name {
+                if let Some(resolved) = self.try_exact_name_match_simple(uref, simple_name) {
+                    return Some(resolved);
+                }
             }
             return None;
         }
@@ -341,9 +371,19 @@ impl<'a> ReferenceResolver<'a> {
         let total = refs.len();
 
         // Partition into resolvable (name exists in graph) and hopeless.
-        let (candidates, hopeless): (Vec<_>, Vec<_>) = refs
-            .iter()
-            .partition(|uref| self.is_known_name(&uref.reference_name));
+        //
+        // A qualified/dotted ref (`Self::method`, `Type::method`, `obj.method`)
+        // rarely matches a known name *verbatim* — `Self::watermark_band` is
+        // not a node name, qualified name, or suffix — so the literal-name
+        // check alone dropped every such ref into `hopeless` before
+        // `resolve_one` (which strips the prefix and matches the simple name)
+        // ever ran. That silently lost all `Self::`/`Type::` and Python/TS
+        // dotted-method call edges (#141). Also admit a ref when its trailing
+        // simple name is known.
+        let (candidates, hopeless): (Vec<_>, Vec<_>) = refs.iter().partition(|uref| {
+            self.is_known_name(&uref.reference_name)
+                || self.is_known_name(simple_ref_name(&uref.reference_name))
+        });
 
         let results: Vec<_> = candidates
             .par_iter()

--- a/src/resolution/variants.rs
+++ b/src/resolution/variants.rs
@@ -1,0 +1,142 @@
+// Rust guideline compliant 2026-06-17
+//! Build-variant edge propagation.
+//!
+//! Conditionally-compiled code defines the *same logical symbol* more than
+//! once, one definition per mutually-exclusive build configuration:
+//!
+//! - **Rust** — `#[cfg(target_os = "macos")] fn f()` next to
+//!   `#[cfg(not(target_os = "macos"))] fn f()` in the same module. Both share
+//!   one `qualified_name`.
+//! - **Go** — `f()` declared in `foo_linux.go` and again in `foo_windows.go`
+//!   within one package (filename suffix or `//go:build` constraint). These
+//!   live in *different files*, so their `qualified_name`s differ; the package
+//!   (directory) plus the function name is what they share.
+//!
+//! The name-based resolver binds a call site to exactly one of the variants,
+//! leaving the others with zero incoming edges — so dead-code analysis reports
+//! the inactive-platform definition as dead (#141) even though deleting it
+//! breaks that platform's build.
+//!
+//! This pass groups callable nodes into build-variant sets and, when a call
+//! lands on any member, replicates that `calls` edge to every sibling so the
+//! whole set is seen as reachable. It is a recall-improving over-approximation
+//! deliberately scoped to genuine build variants, not arbitrary name clashes.
+
+use std::collections::{HashMap, HashSet};
+
+use crate::types::{Edge, EdgeKind, Node, NodeKind};
+
+/// Callable node kinds a `Calls` edge can target.
+fn is_callable(kind: &NodeKind) -> bool {
+    matches!(
+        kind,
+        NodeKind::Function
+            | NodeKind::Method
+            | NodeKind::StructMethod
+            | NodeKind::Constructor
+            | NodeKind::AbstractMethod
+    )
+}
+
+/// Directory portion of a path (the Go "package" proxy). `a/b/c.go` -> `a/b`.
+fn parent_dir(path: &str) -> &str {
+    path.rfind('/').map_or("", |i| &path[..i])
+}
+
+/// Returns additional `calls` edges propagating a call that landed on one
+/// build-config variant of a symbol to all its sibling variants. Idempotent:
+/// edges that already exist are skipped, and the caller's unique edge index
+/// collapses any that slip through.
+pub fn propagate_variant_edges(nodes: &[Node], edges: &[Edge]) -> Vec<Edge> {
+    let node_by_id: HashMap<&str, &Node> = nodes.iter().map(|n| (n.id.as_str(), n)).collect();
+
+    // Rust: node ids carrying a `#[cfg]` / `#[cfg_attr]` attribute, i.e. the
+    // target of an `annotates` edge from a `cfg`-named annotation_usage node.
+    // Without this guard, two distinct trait impls that happen to share a
+    // qualified_name (`From<A>`/`From<B>` both named `from`) would be fused.
+    let mut cfg_gated: HashSet<&str> = HashSet::new();
+    for e in edges {
+        if e.kind == EdgeKind::Annotates {
+            if let Some(src) = node_by_id.get(e.source.as_str()) {
+                if src.kind == NodeKind::AnnotationUsage
+                    && (src.name == "cfg" || src.name == "cfg_attr")
+                {
+                    cfg_gated.insert(e.target.as_str());
+                }
+            }
+        }
+    }
+
+    // Group callable nodes into build-variant sets by a language-specific key.
+    let mut groups: HashMap<String, Vec<&str>> = HashMap::new();
+    for n in nodes {
+        if !is_callable(&n.kind) {
+            continue;
+        }
+        if n.file_path.ends_with(".rs") {
+            // Rust variants share a qualified_name and are both cfg-gated.
+            if cfg_gated.contains(n.id.as_str()) {
+                groups
+                    .entry(format!("rs\u{1}{}", n.qualified_name))
+                    .or_default()
+                    .push(n.id.as_str());
+            }
+        } else if n.file_path.ends_with(".go") && n.kind == NodeKind::Function {
+            // Go package-level funcs: same package directory + name. Two such
+            // declarations can only coexist under build constraints (the
+            // compiler forbids redeclaration otherwise), so >=2 members across
+            // the package is itself the build-variant signal.
+            groups
+                .entry(format!(
+                    "go\u{1}{}\u{1}{}",
+                    parent_dir(&n.file_path),
+                    n.name
+                ))
+                .or_default()
+                .push(n.id.as_str());
+        }
+    }
+
+    // Index existing `calls` edges: which targets are called, and the (src,dst)
+    // pairs already present (so we never emit a duplicate).
+    let mut incoming: HashMap<&str, Vec<&Edge>> = HashMap::new();
+    let mut existing: HashSet<(&str, &str)> = HashSet::new();
+    for e in edges {
+        if e.kind == EdgeKind::Calls {
+            incoming.entry(e.target.as_str()).or_default().push(e);
+            existing.insert((e.source.as_str(), e.target.as_str()));
+        }
+    }
+
+    let mut out = Vec::new();
+    let mut emitted: HashSet<(String, String)> = HashSet::new();
+    for members in groups.values() {
+        if members.len() < 2 {
+            continue;
+        }
+        for &m in members {
+            let Some(in_edges) = incoming.get(m) else {
+                continue;
+            };
+            for e in in_edges {
+                for &sibling in members {
+                    if sibling == m || e.source == sibling {
+                        continue; // no self-edge, no re-target onto the source
+                    }
+                    if existing.contains(&(e.source.as_str(), sibling)) {
+                        continue;
+                    }
+                    if emitted.insert((e.source.clone(), sibling.to_string())) {
+                        out.push(Edge {
+                            source: e.source.clone(),
+                            target: sibling.to_string(),
+                            kind: EdgeKind::Calls,
+                            line: e.line,
+                        });
+                    }
+                }
+            }
+        }
+    }
+    out
+}

--- a/src/tokensave.rs
+++ b/src/tokensave.rs
@@ -781,6 +781,11 @@ impl TokenSave {
             let resolver = ReferenceResolver::from_nodes(&self.db, &all_nodes);
             let resolution = resolver.resolve_all(&all_unresolved);
             all_edges.extend(resolver.create_edges(&resolution.resolved));
+            // Propagate call edges across build-config variants (Rust `#[cfg]`
+            // twins, Go platform files) so an inactive-platform definition is
+            // not seen as dead merely because the call bound to its sibling (#141).
+            let variant_edges = crate::resolution::propagate_variant_edges(&all_nodes, &all_edges);
+            all_edges.extend(variant_edges);
         }
         on_verbose(&format!(
             "resolved {} references in {:.1}s",
@@ -1037,6 +1042,14 @@ impl TokenSave {
                 let edges = resolver.create_edges(&resolution.resolved);
                 if !edges.is_empty() {
                     self.db.insert_edges(&edges).await?;
+                    // Re-propagate build-variant call edges over the full graph
+                    // now that new call edges exist (#141).
+                    let all_db_edges = self.db.get_all_edges().await.unwrap_or_default();
+                    let variant_edges =
+                        crate::resolution::propagate_variant_edges(&all_nodes, &all_db_edges);
+                    if !variant_edges.is_empty() {
+                        self.db.insert_edges(&variant_edges).await?;
+                    }
                 }
             }
         }
@@ -1300,6 +1313,13 @@ impl TokenSave {
                 let edges = resolver.create_edges(&resolution.resolved);
                 if !edges.is_empty() {
                     self.db.insert_edges(&edges).await?;
+                    // Propagate call edges across build-config variants (#141).
+                    let all_db_edges = self.db.get_all_edges().await.unwrap_or_default();
+                    let variant_edges =
+                        crate::resolution::propagate_variant_edges(&all_nodes, &all_db_edges);
+                    if !variant_edges.is_empty() {
+                        self.db.insert_edges(&variant_edges).await?;
+                    }
                 }
             }
             on_verbose(&format!(

--- a/tests/java_extraction_test.rs
+++ b/tests/java_extraction_test.rs
@@ -457,3 +457,34 @@ public class App {
     assert!(methods[0].qualified_name.contains("App"));
     assert!(methods[0].qualified_name.contains("run"));
 }
+
+/// #141: receiver-typed method calls emit `Type::method` (declared type or
+/// `new T()`), enabling disambiguation between same-named methods.
+#[test]
+fn test_receiver_typed_method_calls_java() {
+    let source = r#"
+class Alpha { int handle() { return 1; } }
+class Beta { int handle() { return 2; } }
+class Main {
+  int run() {
+    Alpha a = new Alpha();
+    Beta b = new Beta();
+    return a.handle() + b.handle();
+  }
+}
+"#;
+    let result = JavaExtractor.extract("M.java", source);
+    let names: Vec<&str> = result
+        .unresolved_refs
+        .iter()
+        .map(|u| u.reference_name.as_str())
+        .collect();
+    assert!(
+        names.contains(&"Alpha::handle"),
+        "expected Alpha::handle, got {names:?}"
+    );
+    assert!(
+        names.contains(&"Beta::handle"),
+        "expected Beta::handle, got {names:?}"
+    );
+}

--- a/tests/python_extraction_test.rs
+++ b/tests/python_extraction_test.rs
@@ -570,3 +570,24 @@ fn test_py_extensions() {
     assert_eq!(extractor.extensions(), &["py"]);
     assert_eq!(extractor.language_name(), "Python");
 }
+
+/// #141: receiver-typed method calls emit `Type::method`. Type is inferred
+/// from `x = ClassName()` (CapWords) and `self`.
+#[test]
+fn test_receiver_typed_method_calls_python() {
+    let source = "class Alpha:\n    def handle(self):\n        return 1\n    def run(self):\n        return self.handle()\n\nclass Beta:\n    def handle(self):\n        return 2\n\ndef main():\n    a = Alpha()\n    b = Beta()\n    return a.handle() + b.handle()\n";
+    let result = PythonExtractor.extract("m.py", source);
+    let names: Vec<&str> = result
+        .unresolved_refs
+        .iter()
+        .map(|u| u.reference_name.as_str())
+        .collect();
+    assert!(
+        names.contains(&"Alpha::handle"),
+        "expected Alpha::handle, got {names:?}"
+    );
+    assert!(
+        names.contains(&"Beta::handle"),
+        "expected Beta::handle, got {names:?}"
+    );
+}

--- a/tests/resolution_test.rs
+++ b/tests/resolution_test.rs
@@ -372,3 +372,238 @@ async fn test_resolve_all_empty_input() {
     assert!(result.resolved.is_empty());
     assert!(result.unresolved.is_empty());
 }
+
+/// #141 regression: `resolve_all`'s pre-filter must not drop a qualified
+/// `Self::helper` (or `Type::helper`) ref just because the literal string
+/// isn't a known name — its trailing simple name is, and `resolve_one`
+/// strips the prefix and matches it. Previously these were silently lost.
+#[tokio::test]
+async fn test_resolve_all_self_qualified_call_not_dropped() {
+    let (_dir, db) = setup_db_with_nodes().await;
+    let resolver = ReferenceResolver::from_nodes(&db, &db.get_all_nodes().await.unwrap());
+
+    let refs = vec![UnresolvedRef {
+        from_node_id: generate_node_id("src/main.rs", &NodeKind::Function, "main", 1),
+        reference_name: "Self::helper".to_string(),
+        reference_kind: EdgeKind::Calls,
+        line: 3,
+        column: 12,
+        file_path: "src/main.rs".to_string(),
+    }];
+
+    let result = resolver.resolve_all(&refs);
+    assert_eq!(
+        result.resolved_count, 1,
+        "Self::helper should resolve via the simple-name fallback, not be pre-filtered as hopeless"
+    );
+    assert_eq!(
+        result.resolved[0].target_node_id,
+        generate_node_id("src/utils.rs", &NodeKind::Function, "helper", 1),
+    );
+}
+
+/// #141 cross-language: Python/TS extractors emit the full dotted callee
+/// (`obj.helper`) with no bare-name ref. The resolver must fall back to the
+/// trailing method name so the call edge still forms.
+#[tokio::test]
+async fn test_resolve_all_dotted_method_call() {
+    let (_dir, db) = setup_db_with_nodes().await;
+    let resolver = ReferenceResolver::from_nodes(&db, &db.get_all_nodes().await.unwrap());
+
+    let refs = vec![UnresolvedRef {
+        from_node_id: generate_node_id("src/main.rs", &NodeKind::Function, "main", 1),
+        reference_name: "obj.helper".to_string(),
+        reference_kind: EdgeKind::Calls,
+        line: 3,
+        column: 12,
+        file_path: "src/main.rs".to_string(),
+    }];
+
+    let result = resolver.resolve_all(&refs);
+    assert_eq!(
+        result.resolved_count, 1,
+        "obj.helper should resolve to `helper` via the dotted-call fallback"
+    );
+    assert_eq!(
+        result.resolved[0].target_node_id,
+        generate_node_id("src/utils.rs", &NodeKind::Function, "helper", 1),
+    );
+}
+
+// ---------------------------------------------------------------------------
+// #141 Option 2: build-variant call-edge propagation
+// ---------------------------------------------------------------------------
+
+fn variant_node(id: &str, kind: NodeKind, name: &str, qn: &str, file: &str) -> Node {
+    Node {
+        id: id.to_string(),
+        kind,
+        name: name.to_string(),
+        qualified_name: qn.to_string(),
+        file_path: file.to_string(),
+        start_line: 1,
+        attrs_start_line: 1,
+        end_line: 5,
+        start_column: 0,
+        end_column: 1,
+        signature: Some(format!("fn {name}()")),
+        docstring: None,
+        visibility: Visibility::Pub,
+        is_async: false,
+        branches: 0,
+        loops: 0,
+        returns: 0,
+        max_nesting: 0,
+        unsafe_blocks: 0,
+        unchecked_calls: 0,
+        assertions: 0,
+        updated_at: 0,
+        parent_id: None,
+    }
+}
+
+fn calls_edge(from: &str, to: &str) -> Edge {
+    Edge {
+        source: from.to_string(),
+        target: to.to_string(),
+        kind: EdgeKind::Calls,
+        line: Some(1),
+    }
+}
+
+/// Rust `#[cfg]` twins (same qualified_name, both cfg-gated): a call landing on
+/// one variant must propagate to the other so neither looks dead.
+#[test]
+fn test_variant_fanout_rust_cfg() {
+    let nodes = vec![
+        variant_node(
+            "fn:caller",
+            NodeKind::Function,
+            "main",
+            "src/main.rs::main",
+            "src/main.rs",
+        ),
+        variant_node(
+            "fn:macos",
+            NodeKind::Function,
+            "copy",
+            "src/c.rs::copy",
+            "src/c.rs",
+        ),
+        variant_node(
+            "fn:other",
+            NodeKind::Function,
+            "copy",
+            "src/c.rs::copy",
+            "src/c.rs",
+        ),
+        variant_node(
+            "au:1",
+            NodeKind::AnnotationUsage,
+            "cfg",
+            "src/c.rs::cfg",
+            "src/c.rs",
+        ),
+        variant_node(
+            "au:2",
+            NodeKind::AnnotationUsage,
+            "cfg",
+            "src/c.rs::cfg",
+            "src/c.rs",
+        ),
+    ];
+    let edges = vec![
+        Edge {
+            source: "au:1".into(),
+            target: "fn:macos".into(),
+            kind: EdgeKind::Annotates,
+            line: Some(1),
+        },
+        Edge {
+            source: "au:2".into(),
+            target: "fn:other".into(),
+            kind: EdgeKind::Annotates,
+            line: Some(1),
+        },
+        calls_edge("fn:caller", "fn:macos"),
+    ];
+    let extra = tokensave::resolution::propagate_variant_edges(&nodes, &edges);
+    assert!(
+        extra.iter().any(|e| e.source == "fn:caller"
+            && e.target == "fn:other"
+            && e.kind == EdgeKind::Calls),
+        "call should propagate to the cfg sibling, got: {extra:?}"
+    );
+}
+
+/// Go platform files (`foo_linux.go` / `foo_windows.go`): same package
+/// directory + function name across different files = build variants.
+#[test]
+fn test_variant_fanout_go_platform_files() {
+    let nodes = vec![
+        variant_node(
+            "fn:caller",
+            NodeKind::Function,
+            "Main",
+            "pkg/main.go::Main",
+            "pkg/main.go",
+        ),
+        variant_node(
+            "fn:linux",
+            NodeKind::Function,
+            "Do",
+            "pkg/foo_linux.go::Do",
+            "pkg/foo_linux.go",
+        ),
+        variant_node(
+            "fn:win",
+            NodeKind::Function,
+            "Do",
+            "pkg/foo_windows.go::Do",
+            "pkg/foo_windows.go",
+        ),
+    ];
+    let edges = vec![calls_edge("fn:caller", "fn:linux")];
+    let extra = tokensave::resolution::propagate_variant_edges(&nodes, &edges);
+    assert!(
+        extra
+            .iter()
+            .any(|e| e.source == "fn:caller" && e.target == "fn:win"),
+        "call should propagate to the windows platform-file sibling, got: {extra:?}"
+    );
+}
+
+/// Negative: two functions sharing a qualified_name but NOT cfg-gated (e.g.
+/// distinct trait impls) must NOT be fused — that would invent false edges.
+#[test]
+fn test_no_fanout_without_cfg() {
+    let nodes = vec![
+        variant_node(
+            "fn:caller",
+            NodeKind::Function,
+            "main",
+            "src/main.rs::main",
+            "src/main.rs",
+        ),
+        variant_node(
+            "m:a",
+            NodeKind::Method,
+            "from",
+            "src/t.rs::T::from",
+            "src/t.rs",
+        ),
+        variant_node(
+            "m:b",
+            NodeKind::Method,
+            "from",
+            "src/t.rs::T::from",
+            "src/t.rs",
+        ),
+    ];
+    let edges = vec![calls_edge("fn:caller", "m:a")];
+    let extra = tokensave::resolution::propagate_variant_edges(&nodes, &edges);
+    assert!(
+        extra.is_empty(),
+        "non-cfg same-qualified-name nodes must not fan out, got: {extra:?}"
+    );
+}

--- a/tests/rust_extraction_test.rs
+++ b/tests/rust_extraction_test.rs
@@ -846,3 +846,50 @@ fn use_foo() {
         "expected 'bar' method-name ref from f.bar(), got: {ref_names:?}"
     );
 }
+
+/// #141: a method call through a typed binding (`recv.method()`) must emit a
+/// receiver-qualified `Type::method` Calls ref so the resolver can bind it to
+/// the correct impl when several types define a method of the same name.
+/// Covers the three type sources: constructor RHS, typed parameter, and `self`.
+#[test]
+fn test_receiver_typed_method_calls() {
+    let source = r#"
+struct Renderer;
+
+impl Renderer {
+    fn render(&self) {}
+
+    fn run(&self) {
+        // self receiver -> enclosing impl type
+        self.render();
+    }
+}
+
+fn via_ctor() {
+    let mut r = Renderer::new();
+    r.render();
+}
+
+fn via_param(r: &mut Renderer) {
+    r.render();
+}
+"#;
+    let extractor = RustExtractor;
+    let result = extractor.extract("render.rs", source);
+
+    let has_ref = |name: &str| {
+        result.unresolved_refs.iter().any(|u| {
+            u.reference_name == name && u.reference_kind == tokensave::types::EdgeKind::Calls
+        })
+    };
+
+    assert!(
+        has_ref("Renderer::render"),
+        "expected a Renderer::render call ref from the constructor/param/self receivers, got: {:?}",
+        result
+            .unresolved_refs
+            .iter()
+            .map(|u| &u.reference_name)
+            .collect::<Vec<_>>()
+    );
+}

--- a/tests/typescript_extraction_test.rs
+++ b/tests/typescript_extraction_test.rs
@@ -719,3 +719,32 @@ enum Direction {
     assert_eq!(enums.len(), 1);
     assert_eq!(enums[0].visibility, Visibility::Private); // not exported
 }
+
+/// #141: a method call through a typed binding must emit `Type::method` so the
+/// resolver can disambiguate between classes that share a method name.
+#[test]
+fn test_receiver_typed_method_calls_ts() {
+    let source = r#"
+class Alpha { handle(): number { return 1; } }
+class Beta { handle(): number { return 2; } }
+function run(): number {
+  const a = new Alpha();
+  const b: Beta = new Beta();
+  return a.handle() + b.handle();
+}
+"#;
+    let result = TypeScriptExtractor.extract("svc.ts", source);
+    let names: Vec<&str> = result
+        .unresolved_refs
+        .iter()
+        .map(|u| u.reference_name.as_str())
+        .collect();
+    assert!(
+        names.contains(&"Alpha::handle"),
+        "expected Alpha::handle, got {names:?}"
+    );
+    assert!(
+        names.contains(&"Beta::handle"),
+        "expected Beta::handle, got {names:?}"
+    );
+}


### PR DESCRIPTION
Closes #141. After the trait-impl fix (#137), `tokensave_dead_code` still flagged reachable functions/methods as dead when their call sites used forms the resolver didn't trace. Three gaps closed:

### 1. Resolver pre-filter + dotted fallback (all languages)
`resolve_all` dropped `Self::m` / `Type::m` / `obj.m` refs whose literal string wasn't a known name, before `resolve_one` could strip the prefix. It now admits a ref when its trailing simple name is known, and `resolve_one` gained a `.`-separator fallback so Python/TS/Java dotted calls (emitted as full callee text, never a bare name) resolve via the method name.

### 2. Receiver-type inference (Rust, TypeScript, Java, Python extractors)
`r.method()` was emitted only as the bare method name → mis-resolves when several types share a method name. Each extractor now builds a per-function var→type table (typed params, `new T()`/constructor/annotations, `self`/`this`) and emits a precise `Type::method` ref the resolver binds by qualified/suffix match.

### 3. Build-variant fan-out (Rust `#[cfg]`, Go platform files) — Option 2
Conditionally-compiled twins (Rust `#[cfg]` siblings; Go `foo_linux.go`/`foo_windows.go`) are one logical symbol; the resolver binds a call to one, starving the rest. A post-resolution pass (`src/resolution/variants.rs`) groups build-variant siblings and replicates the call edge to every member.

## Verification
Against the `mex` crate: `dead_code_count` **7 → 0**, every removal a genuine reachable symbol. Disambiguation confirmed end-to-end for Rust/TS/Java/Python (two classes with a same-named method each bind to the correct one).

## Tests
Resolver pre-filter, dotted fallback, variant fan-out (Rust cfg + Go platform), and receiver-type emission in all four extractors. Full affected suites green (321 tests).

## Caveats
- The legacy dotted-name fallback fires alongside the precise typed ref, so multi-candidate calls may add a minor wrong `callers`/`callees` edge (harmless for dead-code; consistent with the resolver's existing over-approximation). Suppressing it when a typed ref exists is a follow-up.
- Python uses the CapWords convention to detect `Service()` construction.
- Go retains bare-name emission; its multi-candidate case is not converted.

Unreleased — no version bump.

🤖 Generated with [Claude Code](https://claude.com/claude-code)