### PR TITLE
feat(analysis): add path filtering to dead_code, hotspots, unused_imports + config defaults

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+- **`path`, `path_include`, `path_exclude` params on `dead_code`, `hotspots`, and `unused_imports`.** These three analysis tools were the only ones missing path-scoping support. Same semantics as `god_class`, `coupling`, `complexity`, and `largest`. `path` filters to a directory prefix; `path_include`/`path_exclude` filter by substring (exclude takes precedence).
+- **`default_path_include` / `default_path_exclude` config fields.** Query-level defaults in `.tokensave/config.json` applied to analysis tools when no explicit `path_include`/`path_exclude` is passed. Useful for permanently excluding test/mock directories from analysis results without repeating args on every call.
+
+### Changed
+- **`git_ignore` now defaults to `true`.** New projects indexed with `tokensave init` will respect `.gitignore` rules out of the box. Existing projects are unaffected (their config is already persisted). Use `tokensave gitignore off` or set `"git_ignore": false` in config to opt out.
+
 ### Fixed
 - **Dead-code analysis resolves calls through receiver bindings, `Self::`, and dotted method calls (#141).** After the trait-impl fix (#137), `tokensave_dead_code` still reported functions/methods as dead when their only call sites used call forms the resolver didn't trace. Three gaps are closed:
   - **`Self::`/qualified call pre-filter (resolver, all languages).** `resolve_all`'s pre-filter dropped any `Self::method` / `Type::method` ref whose *literal* string wasn't a known name — so it never reached `resolve_one`, which strips the prefix and matches the simple name. It now admits a ref when its trailing simple name is known, and `resolve_one` gained a `.`-separator fallback so Python/TS/Java dotted calls (`obj.method`, emitted as the full callee text with no bare-name ref) resolve via the method name. This alone recovers `Self::` calls in Rust and *all* receiver-method calls in the dotted-callee languages.

--- a/src/config.rs
+++ b/src/config.rs
@@ -44,6 +44,14 @@ pub struct TokenSaveConfig {
     /// Whether to respect `.gitignore` rules when scanning files.
     #[serde(default)]
     pub git_ignore: bool,
+    /// Default path-include substrings applied to analysis tool queries when
+    /// no explicit `path_include` is provided by the caller.
+    #[serde(default)]
+    pub default_path_include: Vec<String>,
+    /// Default path-exclude substrings applied to analysis tool queries when
+    /// no explicit `path_exclude` is provided by the caller.
+    #[serde(default)]
+    pub default_path_exclude: Vec<String>,
 }
 
 impl Default for TokenSaveConfig {
@@ -68,6 +76,8 @@ impl Default for TokenSaveConfig {
             extract_docstrings: true,
             track_call_sites: true,
             git_ignore: true,
+            default_path_include: Vec::new(),
+            default_path_exclude: Vec::new(),
         }
     }
 }

--- a/src/config.rs
+++ b/src/config.rs
@@ -67,7 +67,7 @@ impl Default for TokenSaveConfig {
             max_file_size: 1_048_576,
             extract_docstrings: true,
             track_call_sites: true,
-            git_ignore: false,
+            git_ignore: true,
         }
     }
 }

--- a/src/mcp/tools/definitions.rs
+++ b/src/mcp/tools/definitions.rs
@@ -611,6 +611,20 @@ fn def_dead_code() -> ToolDefinition {
                 "include_trait_impls": {
                     "type": "boolean",
                     "description": "When true, do NOT exclude Rust trait-impl methods (implicitly-dispatched methods like fmt/deref/drop). Default false."
+                },
+                "path": {
+                    "type": "string",
+                    "description": "Filter to files under this directory path (e.g. 'src/main/java')"
+                },
+                "path_include": {
+                    "type": "array",
+                    "items": { "type": "string" },
+                    "description": "Only include results whose file path contains one of these substrings (e.g. \"src\", \"app\"). Empty/absent means no path constraint."
+                },
+                "path_exclude": {
+                    "type": "array",
+                    "items": { "type": "string" },
+                    "description": "Exclude results whose file path contains any of these substrings (e.g. \"node_modules\", \"dist\", \"venv\"). Takes precedence over path_include."
                 }
             }
         }),
@@ -686,6 +700,20 @@ fn def_hotspots() -> ToolDefinition {
                 "limit": {
                     "type": "number",
                     "description": "Maximum number of hotspots to return (default: 10)"
+                },
+                "path": {
+                    "type": "string",
+                    "description": "Filter to files under this directory path (e.g. 'src/main/java')"
+                },
+                "path_include": {
+                    "type": "array",
+                    "items": { "type": "string" },
+                    "description": "Only include results whose file path contains one of these substrings (e.g. \"src\", \"app\"). Empty/absent means no path constraint."
+                },
+                "path_exclude": {
+                    "type": "array",
+                    "items": { "type": "string" },
+                    "description": "Exclude results whose file path contains any of these substrings (e.g. \"node_modules\", \"dist\", \"venv\"). Takes precedence over path_include."
                 }
             }
         }),
@@ -739,7 +767,22 @@ fn def_unused_imports() -> ToolDefinition {
         "Find import/use nodes that are never referenced by any other node.",
         json!({
             "type": "object",
-            "properties": {}
+            "properties": {
+                "path": {
+                    "type": "string",
+                    "description": "Filter to files under this directory path (e.g. 'src/main/java')"
+                },
+                "path_include": {
+                    "type": "array",
+                    "items": { "type": "string" },
+                    "description": "Only include results whose file path contains one of these substrings (e.g. \"src\", \"app\"). Empty/absent means no path constraint."
+                },
+                "path_exclude": {
+                    "type": "array",
+                    "items": { "type": "string" },
+                    "description": "Exclude results whose file path contains any of these substrings (e.g. \"node_modules\", \"dist\", \"venv\"). Takes precedence over path_include."
+                }
+            }
         }),
     )
 }

--- a/src/mcp/tools/handlers/analysis.rs
+++ b/src/mcp/tools/handlers/analysis.rs
@@ -11,7 +11,10 @@ use crate::tokensave::TokenSave;
 use crate::types::{NodeKind, Visibility};
 
 use super::super::ToolResult;
-use super::{effective_path, filter_by_scope, truncate_response, unique_file_paths};
+use super::{
+    effective_path, filter_by_path_lists, filter_by_scope, parse_string_array, truncate_response,
+    unique_file_paths,
+};
 
 /// True if `line` contains `identifier` as a whole token (boundaries are
 /// any non-`[A-Za-z0-9_]` char or string ends). Avoids false positives
@@ -172,10 +175,15 @@ pub(super) async fn handle_dead_code(
         .get("include_trait_impls")
         .and_then(serde_json::Value::as_bool)
         .unwrap_or(false);
+    let path_prefix = effective_path(&args, scope_prefix);
+    let path_include = parse_string_array(&args, "path_include");
+    let path_exclude = parse_string_array(&args, "path_exclude");
+
     let dead = cg
         .find_dead_code(&kinds, include_public, include_trait_impls)
         .await?;
-    let dead = filter_by_scope(dead, scope_prefix, |n| &n.file_path);
+    let dead = filter_by_scope(dead, path_prefix, |n| &n.file_path);
+    let dead = filter_by_path_lists(dead, &path_include, &path_exclude, |n| &n.file_path);
 
     let touched_files = unique_file_paths(dead.iter().map(|n| n.file_path.as_str()));
 
@@ -339,7 +347,11 @@ pub(super) async fn handle_hotspots(
         }
     }
 
-    if let Some(prefix) = scope_prefix {
+    let path_prefix = effective_path(&args, scope_prefix);
+    let path_include = parse_string_array(&args, "path_include");
+    let path_exclude = parse_string_array(&args, "path_exclude");
+
+    if let Some(prefix) = path_prefix {
         let with_slash = if prefix.ends_with('/') {
             prefix.to_string()
         } else {
@@ -351,6 +363,13 @@ pub(super) async fn handle_hotspots(
                 .is_some_and(|f| f.starts_with(&with_slash) || f == prefix)
         });
         touched.retain(|f| f.starts_with(&with_slash) || f == prefix);
+    }
+
+    if !path_include.is_empty() || !path_exclude.is_empty() {
+        items = filter_by_path_lists(items, &path_include, &path_exclude, |item| {
+            item["file"].as_str().unwrap_or("")
+        });
+        touched = filter_by_path_lists(touched, &path_include, &path_exclude, |f| f.as_str());
     }
 
     let touched_files = unique_file_paths(touched.iter().map(std::string::String::as_str));
@@ -375,7 +394,10 @@ pub(super) async fn handle_unused_imports(
     args: Value,
     scope_prefix: Option<&str>,
 ) -> Result<ToolResult> {
-    let _ = args; // currently unused beyond scope filtering
+    let path_prefix = effective_path(&args, scope_prefix);
+    let path_include = parse_string_array(&args, "path_include");
+    let path_exclude = parse_string_array(&args, "path_exclude");
+
     let all_nodes = cg.get_all_nodes().await?;
 
     // Find all Use nodes
@@ -383,7 +405,7 @@ pub(super) async fn handle_unused_imports(
         .iter()
         .filter(|n| n.kind == NodeKind::Use)
         .filter(|n| {
-            scope_prefix.is_none_or(|prefix| {
+            path_prefix.is_none_or(|prefix| {
                 let with_slash = if prefix.ends_with('/') {
                     prefix.to_string()
                 } else {
@@ -393,6 +415,9 @@ pub(super) async fn handle_unused_imports(
             })
         })
         .collect();
+    let use_nodes = filter_by_path_lists(use_nodes, &path_include, &path_exclude, |n| {
+        &n.file_path
+    });
 
     let mut unused: Vec<Value> = Vec::new();
     let mut touched: Vec<String> = Vec::new();

--- a/src/mcp/tools/handlers/analysis.rs
+++ b/src/mcp/tools/handlers/analysis.rs
@@ -177,8 +177,14 @@ pub(super) async fn handle_dead_code(
         .unwrap_or(false);
     let cfg = cg.get_config();
     let path_prefix = effective_path(&args, scope_prefix);
-    let path_include = with_defaults(parse_string_array(&args, "path_include"), &cfg.default_path_include);
-    let path_exclude = with_defaults(parse_string_array(&args, "path_exclude"), &cfg.default_path_exclude);
+    let path_include = with_defaults(
+        parse_string_array(&args, "path_include"),
+        &cfg.default_path_include,
+    );
+    let path_exclude = with_defaults(
+        parse_string_array(&args, "path_exclude"),
+        &cfg.default_path_exclude,
+    );
 
     let dead = cg
         .find_dead_code(&kinds, include_public, include_trait_impls)
@@ -350,8 +356,14 @@ pub(super) async fn handle_hotspots(
 
     let cfg = cg.get_config();
     let path_prefix = effective_path(&args, scope_prefix);
-    let path_include = with_defaults(parse_string_array(&args, "path_include"), &cfg.default_path_include);
-    let path_exclude = with_defaults(parse_string_array(&args, "path_exclude"), &cfg.default_path_exclude);
+    let path_include = with_defaults(
+        parse_string_array(&args, "path_include"),
+        &cfg.default_path_include,
+    );
+    let path_exclude = with_defaults(
+        parse_string_array(&args, "path_exclude"),
+        &cfg.default_path_exclude,
+    );
 
     if let Some(prefix) = path_prefix {
         let with_slash = if prefix.ends_with('/') {
@@ -398,8 +410,14 @@ pub(super) async fn handle_unused_imports(
 ) -> Result<ToolResult> {
     let cfg = cg.get_config();
     let path_prefix = effective_path(&args, scope_prefix);
-    let path_include = with_defaults(parse_string_array(&args, "path_include"), &cfg.default_path_include);
-    let path_exclude = with_defaults(parse_string_array(&args, "path_exclude"), &cfg.default_path_exclude);
+    let path_include = with_defaults(
+        parse_string_array(&args, "path_include"),
+        &cfg.default_path_include,
+    );
+    let path_exclude = with_defaults(
+        parse_string_array(&args, "path_exclude"),
+        &cfg.default_path_exclude,
+    );
 
     let all_nodes = cg.get_all_nodes().await?;
 
@@ -418,9 +436,7 @@ pub(super) async fn handle_unused_imports(
             })
         })
         .collect();
-    let use_nodes = filter_by_path_lists(use_nodes, &path_include, &path_exclude, |n| {
-        &n.file_path
-    });
+    let use_nodes = filter_by_path_lists(use_nodes, &path_include, &path_exclude, |n| &n.file_path);
 
     let mut unused: Vec<Value> = Vec::new();
     let mut touched: Vec<String> = Vec::new();

--- a/src/mcp/tools/handlers/analysis.rs
+++ b/src/mcp/tools/handlers/analysis.rs
@@ -13,7 +13,7 @@ use crate::types::{NodeKind, Visibility};
 use super::super::ToolResult;
 use super::{
     effective_path, filter_by_path_lists, filter_by_scope, parse_string_array, truncate_response,
-    unique_file_paths,
+    unique_file_paths, with_defaults,
 };
 
 /// True if `line` contains `identifier` as a whole token (boundaries are
@@ -175,9 +175,10 @@ pub(super) async fn handle_dead_code(
         .get("include_trait_impls")
         .and_then(serde_json::Value::as_bool)
         .unwrap_or(false);
+    let cfg = cg.get_config();
     let path_prefix = effective_path(&args, scope_prefix);
-    let path_include = parse_string_array(&args, "path_include");
-    let path_exclude = parse_string_array(&args, "path_exclude");
+    let path_include = with_defaults(parse_string_array(&args, "path_include"), &cfg.default_path_include);
+    let path_exclude = with_defaults(parse_string_array(&args, "path_exclude"), &cfg.default_path_exclude);
 
     let dead = cg
         .find_dead_code(&kinds, include_public, include_trait_impls)
@@ -347,9 +348,10 @@ pub(super) async fn handle_hotspots(
         }
     }
 
+    let cfg = cg.get_config();
     let path_prefix = effective_path(&args, scope_prefix);
-    let path_include = parse_string_array(&args, "path_include");
-    let path_exclude = parse_string_array(&args, "path_exclude");
+    let path_include = with_defaults(parse_string_array(&args, "path_include"), &cfg.default_path_include);
+    let path_exclude = with_defaults(parse_string_array(&args, "path_exclude"), &cfg.default_path_exclude);
 
     if let Some(prefix) = path_prefix {
         let with_slash = if prefix.ends_with('/') {
@@ -394,9 +396,10 @@ pub(super) async fn handle_unused_imports(
     args: Value,
     scope_prefix: Option<&str>,
 ) -> Result<ToolResult> {
+    let cfg = cg.get_config();
     let path_prefix = effective_path(&args, scope_prefix);
-    let path_include = parse_string_array(&args, "path_include");
-    let path_exclude = parse_string_array(&args, "path_exclude");
+    let path_include = with_defaults(parse_string_array(&args, "path_include"), &cfg.default_path_include);
+    let path_exclude = with_defaults(parse_string_array(&args, "path_exclude"), &cfg.default_path_exclude);
 
     let all_nodes = cg.get_all_nodes().await?;
 

--- a/src/mcp/tools/handlers/mod.rs
+++ b/src/mcp/tools/handlers/mod.rs
@@ -129,6 +129,16 @@ pub(crate) fn parse_string_array(args: &Value, key: &str) -> Vec<String> {
         .unwrap_or_default()
 }
 
+/// Returns `caller` if non-empty, otherwise falls back to `defaults`.
+/// Used to merge explicit tool-call args with config-level defaults.
+pub(crate) fn with_defaults(caller: Vec<String>, defaults: &[String]) -> Vec<String> {
+    if caller.is_empty() {
+        defaults.to_vec()
+    } else {
+        caller
+    }
+}
+
 /// Deduplicates an iterator of file path strings into a `Vec<String>`.
 pub(crate) fn unique_file_paths<'a>(paths: impl Iterator<Item = &'a str>) -> Vec<String> {
     let mut seen = HashSet::new();


### PR DESCRIPTION
## Summary

- Add `path`, `path_include`, `path_exclude` params to `dead_code`, `hotspots`, and `unused_imports` — the three analysis tools that were missing path-scoping support.
- Add `default_path_include` / `default_path_exclude` config fields in `.tokensave/config.json` for query-level defaults applied when no explicit args are passed.
- Flip `git_ignore` default to `true` so new projects respect `.gitignore` out of the box.

## Motivation

On monorepos with vendored dependencies (e.g. Swift SPM prebuilts, Go vendor/, JS bundles), analysis tools return thousands of results from code the team doesn't own. `dead_code` on a ~57K-node Swift monorepo returned 9,219 results — 93% noise from vendored code, test mocks, and cross-platform duplicates.

`god_class`, `coupling`, `complexity`, and `largest` already have `path` — but `dead_code`, `hotspots`, and `unused_imports` do not, and no tool has `path_exclude`. This forced users to run direct SQLite queries against `.tokensave/tokensave.db` to scope results.

With these changes, the same query goes from 9,219 → 652 results (with explicit filters) or → 31 results (with config defaults).

## Changes

- `src/mcp/tools/definitions.rs` — Added `path`, `path_include`, `path_exclude` to the three tool schemas
- `src/mcp/tools/handlers/analysis.rs` — Wired `effective_path`, `filter_by_path_lists`, `parse_string_array`, and new `with_defaults` helper into `handle_dead_code`, `handle_hotspots`, `handle_unused_imports`
- `src/mcp/tools/handlers/mod.rs` — Added `with_defaults()` helper (returns caller args if non-empty, else config defaults)
- `src/config.rs` — Added `default_path_include` / `default_path_exclude` fields; flipped `git_ignore` default to `true`
- `CHANGELOG.md` — Updated `[Unreleased]` section

## Test plan

- [x] `cargo test --lib` passes (422 tests)
- [x] `cargo test --test tokensave_test` passes (40 tests)
- [x] `cargo clippy` has no new warnings (all warnings are pre-existing)
- [x] Tested manually on a 57K-node Swift monorepo:
  - `dead_code` with `--path Record-App/Sources`: 431 → 2 results
  - `dead_code` with `path_exclude: ["Tests", "Mocks", "Prebuilts"]`: 9,219 → 652
  - `dead_code` with zero args + config defaults: 431 → 31
  - `hotspots` with `path_exclude`: 10 → 1
  - `unused_imports` with `path_exclude`: 568 → 31
  - Re-index after adding `Prebuilts/**` to indexer exclude: 3,299 → 1,687 files

## Checklist

- [x] `CHANGELOG.md` updated (under `[Unreleased]`)
- [x] No secrets, credentials, or `.env` files included
- [x] Breaking changes documented — `git_ignore` default change only affects new `tokensave init`; existing projects keep their persisted config