### PR TITLE
test: add 62 tests across diagnostics, diagnose, derive_table, and SQL extraction

### DIFF
--- a/tests/derive_table_test.rs
+++ b/tests/derive_table_test.rs
@@ -1,0 +1,140 @@
+use tokensave::derive_table::{enrich, lookup};
+
+#[test]
+fn all_well_known_derives_are_found() {
+    let expected = &[
+        "Debug", "Clone", "Copy", "Default", "PartialEq", "Eq", "PartialOrd", "Ord", "Hash",
+        "Serialize", "Deserialize", "Display", "Error",
+    ];
+    for name in expected {
+        assert!(
+            lookup(name).is_some(),
+            "expected {} to be in the well-known table",
+            name
+        );
+    }
+}
+
+#[test]
+fn lookup_is_case_insensitive() {
+    assert!(lookup("debug").is_some(), "lowercase should match");
+    assert!(lookup("DEBUG").is_some(), "uppercase should match");
+    assert!(lookup("DeBuG").is_some(), "mixed case should match");
+    assert!(lookup("clone").is_some(), "lowercase Clone should match");
+    assert!(lookup("COPY").is_some(), "uppercase Copy should match");
+}
+
+#[test]
+fn partial_ord_methods() {
+    let info = lookup("PartialOrd").expect("PartialOrd is well-known");
+    assert_eq!(info.trait_path, "core::cmp::PartialOrd");
+    assert!(info.methods.contains(&"partial_cmp"));
+    assert!(info.methods.contains(&"lt"));
+    assert!(info.methods.contains(&"le"));
+    assert!(info.methods.contains(&"gt"));
+    assert!(info.methods.contains(&"ge"));
+}
+
+#[test]
+fn ord_methods() {
+    let info = lookup("Ord").expect("Ord is well-known");
+    assert_eq!(info.trait_path, "core::cmp::Ord");
+    assert!(info.methods.contains(&"cmp"));
+    assert!(info.methods.contains(&"max"));
+    assert!(info.methods.contains(&"min"));
+    assert!(info.methods.contains(&"clamp"));
+}
+
+#[test]
+fn hash_methods() {
+    let info = lookup("Hash").expect("Hash is well-known");
+    assert_eq!(info.trait_path, "core::hash::Hash");
+    assert_eq!(info.source, "std");
+    assert!(info.methods.contains(&"hash"));
+    assert!(info.methods.contains(&"hash_slice"));
+}
+
+#[test]
+fn serde_derives_correct_source() {
+    let serialize = lookup("Serialize").expect("Serialize is well-known");
+    assert_eq!(serialize.source, "serde");
+    assert_eq!(serialize.trait_path, "serde::ser::Serialize");
+
+    let deserialize = lookup("Deserialize").expect("Deserialize is well-known");
+    assert_eq!(deserialize.source, "serde");
+    assert_eq!(deserialize.trait_path, "serde::de::Deserialize");
+}
+
+#[test]
+fn display_and_error_not_from_std_core() {
+    let display = lookup("Display").expect("Display is well-known");
+    assert_eq!(display.trait_path, "core::fmt::Display");
+    assert_ne!(display.source, "std");
+
+    let error = lookup("Error").expect("Error is well-known");
+    assert_eq!(error.trait_path, "std::error::Error");
+}
+
+#[test]
+fn each_well_known_has_derive_name_matching_lookup() {
+    // Verify consistency: lookup(name).derive_name == name
+    let names = [
+        "Debug", "Clone", "Copy", "Default", "PartialEq", "Eq", "PartialOrd", "Ord",
+        "Hash", "Serialize", "Deserialize", "Display", "Error",
+    ];
+    for name in names {
+        let info = lookup(name).unwrap_or_else(|| panic!("{name} not found"));
+        // Case-insensitive, so info.derive_name preserves canonical casing
+        assert!(
+            info.derive_name.eq_ignore_ascii_case(name),
+            "derive_name {} does not match lookup {}",
+            info.derive_name,
+            name
+        );
+    }
+}
+
+#[test]
+fn enrich_preserves_original_casing() {
+    let l = enrich("debug");
+    assert_eq!(l.derive_name, "debug");
+    assert!(l.known.is_some());
+    // The known info keeps canonical casing
+    assert_eq!(l.known.unwrap().derive_name, "Debug");
+}
+
+#[test]
+fn enrich_unknown_preserves_exact_input() {
+    let l = enrich(" MyWeirdMacro ");
+    assert_eq!(l.derive_name, " MyWeirdMacro ");
+    assert!(l.known.is_none());
+}
+
+#[test]
+fn lookup_empty_string() {
+    assert!(lookup("").is_none());
+}
+
+#[test]
+fn marker_traits_have_no_methods() {
+    for name in &["Copy", "Eq"] {
+        let info = lookup(name).unwrap_or_else(|| panic!("{name} is well-known"));
+        assert!(
+            info.methods.is_empty(),
+            "{} should be a marker trait with no methods",
+            name
+        );
+    }
+}
+
+#[test]
+fn non_marker_traits_have_methods() {
+    for name in &["Debug", "Clone", "Default", "PartialEq", "PartialOrd", "Ord", "Hash", "Serialize", "Deserialize", "Display", "Error"] {
+        let info = lookup(name).unwrap_or_else(|| panic!("{name} is well-known"));
+        assert!(
+            !info.methods.is_empty(),
+            "{} should have methods",
+            name
+        );
+    }
+}

--- a/tests/diagnose_test.rs
+++ b/tests/diagnose_test.rs
@@ -1,0 +1,205 @@
+use tokensave::diagnose::{parse_cargo_output, Severity};
+
+// ---------------------------------------------------------------------------
+// Parse header tests
+// ---------------------------------------------------------------------------
+
+#[test]
+fn parses_error_with_code() {
+    let input = "error[E0308]: mismatched types\n  --> src/lib.rs:42:10\n";
+    let diags = parse_cargo_output(input);
+    assert_eq!(diags.len(), 1);
+    assert_eq!(diags[0].severity, Severity::Error);
+    assert_eq!(diags[0].code.as_deref(), Some("E0308"));
+    assert_eq!(diags[0].message, "mismatched types");
+}
+
+#[test]
+fn parses_warning_without_code() {
+    let input = "warning: unused variable\n  --> src/main.rs:10:5\n";
+    let diags = parse_cargo_output(input);
+    assert_eq!(diags.len(), 1);
+    assert_eq!(diags[0].severity, Severity::Warning);
+    assert!(diags[0].code.is_none());
+    assert_eq!(diags[0].message, "unused variable");
+}
+
+#[test]
+fn parses_note() {
+    let input = "note: variable moved here\n  --> src/a.rs:5:8\n";
+    let diags = parse_cargo_output(input);
+    assert_eq!(diags.len(), 1);
+    assert_eq!(diags[0].severity, Severity::Note);
+}
+
+#[test]
+fn parses_help() {
+    let input = "help: consider borrowing here\n  --> src/a.rs:5:8\n";
+    let diags = parse_cargo_output(input);
+    assert_eq!(diags.len(), 1);
+    assert_eq!(diags[0].severity, Severity::Help);
+}
+
+#[test]
+fn ignores_unknown_severity() {
+    let input = "unknown_severity: something\n  --> src/a.rs:5:8\n";
+    let diags = parse_cargo_output(input);
+    assert!(diags.is_empty());
+}
+
+#[test]
+fn clippy_lint_code() {
+    let input = "error[clippy::redundant_closure]: redundant closure\n  --> src/lib.rs:10:20\n";
+    let diags = parse_cargo_output(input);
+    assert_eq!(diags.len(), 1);
+    assert_eq!(diags[0].code.as_deref(), Some("clippy::redundant_closure"));
+}
+
+// ---------------------------------------------------------------------------
+// Parse span tests
+// ---------------------------------------------------------------------------
+
+#[test]
+fn span_with_drive_letter() {
+    // Windows-style path with drive letter and colons
+    let input = "error[E0308]: type mismatch\n  --> C:\\Users\\dev\\src\\lib.rs:42:10\n";
+    let diags = parse_cargo_output(input);
+    assert_eq!(diags.len(), 1);
+    assert_eq!(diags[0].file, "C:\\Users\\dev\\src\\lib.rs");
+    assert_eq!(diags[0].line, 42);
+    assert_eq!(diags[0].column, 10);
+}
+
+#[test]
+fn span_with_path_containing_colons() {
+    // File path with colons (Windows drive letter or non-standard paths)
+    let input = "warning: deprecated\n  --> D:/projects/rust/src/main.rs:15:3\n";
+    let diags = parse_cargo_output(input);
+    assert_eq!(diags.len(), 1);
+    assert_eq!(diags[0].line, 15);
+    assert_eq!(diags[0].column, 3);
+}
+
+#[test]
+fn span_file_with_single_letter_path() {
+    let input = "error[E0001]: oops\n  --> a:1:1\n";
+    let diags = parse_cargo_output(input);
+    assert_eq!(diags.len(), 1);
+    assert_eq!(diags[0].file, "a");
+    assert_eq!(diags[0].line, 1);
+    assert_eq!(diags[0].column, 1);
+}
+
+// ---------------------------------------------------------------------------
+// Multi-diagnostic tests
+// ---------------------------------------------------------------------------
+
+#[test]
+fn multiple_diagnostics_with_source_context() {
+    let input = "\
+error[E0382]: borrow of moved value: x
+  --> src/a.rs:10:5
+   |
+10 |     let x = String::from(\"hi\");
+   |         - move occurs because x has type String
+11 |     println!(\"{}\", x);
+   |                     ^ value borrowed here after move
+   |
+warning: unused variable: y
+  --> src/b.rs:20:9
+   |
+20 |     let y = 42;
+   |         ^
+   |
+";
+    let diags = parse_cargo_output(input);
+    assert_eq!(diags.len(), 2);
+    assert_eq!(diags[0].severity, Severity::Error);
+    assert_eq!(diags[0].code.as_deref(), Some("E0382"));
+    assert_eq!(diags[0].file, "src/a.rs");
+    assert_eq!(diags[1].severity, Severity::Warning);
+    assert_eq!(diags[1].file, "src/b.rs");
+}
+
+#[test]
+fn diagnostic_without_span_is_dropped() {
+    let input = "\
+error: could not compile `foo` due to 2 previous errors
+note: run with `RUST_BACKTRACE=1` for a backtrace
+";
+    let diags = parse_cargo_output(input);
+    assert!(diags.is_empty());
+}
+
+#[test]
+fn empty_input() {
+    let diags = parse_cargo_output("");
+    assert!(diags.is_empty());
+}
+
+#[test]
+fn only_source_lines_no_header() {
+    let input = "\
+   |
+42 |     let x = 1;
+   |         ^
+";
+    let diags = parse_cargo_output(input);
+    assert!(diags.is_empty());
+}
+
+#[test]
+fn header_far_from_span_is_dropped() {
+    // When a header and its span are more than 12 lines apart, the span
+    // isn't found and the diagnostic is dropped.
+    let mut input = String::from("error[E0001]: far away\n");
+    for _ in 0..15 {
+        input.push_str("   |\n");
+    }
+    input.push_str("  --> src/far.rs:1:1\n");
+    let diags = parse_cargo_output(&input);
+    assert!(diags.is_empty(), "span too far from header should be dropped");
+}
+
+#[test]
+fn intermediate_header_breaks_search() {
+    // When another header line appears before the span, the search stops.
+    let input = "\
+error[E0001]: first
+warning: second
+  --> src/a.rs:1:1
+";
+    let diags = parse_cargo_output(input);
+    // "error[E0001]: first" has no span before the next header, so dropped.
+    // "warning: second" DOES have a span on the next line.
+    assert_eq!(diags.len(), 1);
+    assert_eq!(diags[0].severity, Severity::Warning);
+}
+
+#[test]
+fn ansi_escape_in_header() {
+    // Cargo with --color=always may emit ANSI escape sequences.
+    // The parser strips the leading reset sequence.
+    let input = "\u{1b}[0merror[E0308]: mismatched types\n  --> src/lib.rs:42:10\n";
+    let diags = parse_cargo_output(input);
+    assert_eq!(diags.len(), 1);
+    assert_eq!(diags[0].severity, Severity::Error);
+    assert_eq!(diags[0].code.as_deref(), Some("E0308"));
+}
+
+#[test]
+fn diagnostic_struct_fields() {
+    let input = "\
+error[E0507]: cannot move out of borrowed content
+  --> src/foo.rs:99:15
+";
+    let diags = parse_cargo_output(input);
+    assert_eq!(diags.len(), 1);
+    let d = &diags[0];
+    assert_eq!(d.severity, Severity::Error);
+    assert_eq!(d.code.as_deref(), Some("E0507"));
+    assert_eq!(d.message, "cannot move out of borrowed content");
+    assert_eq!(d.file, "src/foo.rs");
+    assert_eq!(d.line, 99);
+    assert_eq!(d.column, 15);
+}

--- a/tests/diagnostics_test.rs
+++ b/tests/diagnostics_test.rs
@@ -1,0 +1,308 @@
+use tokensave::diagnostics::python::parse_pyright_output;
+use tokensave::diagnostics::typescript::{parse_tsc_line, parse_tsc_output};
+
+// ---------------------------------------------------------------------------
+// Pyright (Python) diagnostics parser tests
+// ---------------------------------------------------------------------------
+
+#[test]
+fn pyright_empty_diagnostics_array() {
+    let stdout = r#"{"generalDiagnostics": []}"#;
+    let diags = parse_pyright_output(stdout, std::path::Path::new("/tmp/proj"));
+    assert!(diags.is_empty());
+}
+
+#[test]
+fn pyright_missing_general_diagnostics_field() {
+    let stdout = r#"{"version": "1.1.350"}"#;
+    let diags = parse_pyright_output(stdout, std::path::Path::new("/tmp/proj"));
+    assert!(diags.is_empty());
+}
+
+#[test]
+fn pyright_multiple_diagnostics_preserved() {
+    let stdout = r#"{
+  "generalDiagnostics": [
+    {
+      "file": "/tmp/proj/src/a.py",
+      "severity": "error",
+      "message": "First",
+      "rule": "reportGeneralTypeIssues",
+      "range": { "start": { "line": 0 }, "end": { "line": 0 } }
+    },
+    {
+      "file": "/tmp/proj/src/b.py",
+      "severity": "warning",
+      "message": "Second",
+      "rule": "reportUnusedVariable",
+      "range": { "start": { "line": 10 }, "end": { "line": 10 } }
+    }
+  ]
+}"#;
+    let diags = parse_pyright_output(stdout, std::path::Path::new("/tmp/proj"));
+    assert_eq!(diags.len(), 2);
+    assert_eq!(diags[0].file, "src/a.py");
+    assert_eq!(diags[1].file, "src/b.py");
+    assert_eq!(diags[0].level, "error");
+    assert_eq!(diags[1].level, "warning");
+    assert_eq!(diags[1].line_start, 11, "0-based line 10 should become 1-based 11");
+}
+
+#[test]
+fn pyright_relative_path_passes_through() {
+    let stdout = r#"{
+  "generalDiagnostics": [
+    {
+      "file": "relative/path/file.py",
+      "severity": "error",
+      "message": "Missing import",
+      "rule": "reportMissingImports",
+      "range": { "start": { "line": 5 }, "end": { "line": 5 } }
+    }
+  ]
+}"#;
+    let diags = parse_pyright_output(stdout, std::path::Path::new("/tmp/proj"));
+    assert_eq!(diags.len(), 1);
+    assert_eq!(diags[0].file, "relative/path/file.py");
+}
+
+#[test]
+fn pyright_path_outside_project_root() {
+    let stdout = r#"{
+  "generalDiagnostics": [
+    {
+      "file": "/other/project/file.py",
+      "severity": "warning",
+      "message": "Unused import",
+      "rule": "reportUnusedImport",
+      "range": { "start": { "line": 3 }, "end": { "line": 3 } }
+    }
+  ]
+}"#;
+    let diags = parse_pyright_output(stdout, std::path::Path::new("/tmp/proj"));
+    assert_eq!(diags.len(), 1);
+    assert_eq!(diags[0].file, "/other/project/file.py");
+}
+
+#[test]
+fn pyright_filters_error_and_warning_only() {
+    let stdout = r#"{
+  "generalDiagnostics": [
+    {
+      "file": "/tmp/proj/x.py",
+      "severity": "error",
+      "message": "Err",
+      "range": { "start": { "line": 1 }, "end": { "line": 1 } }
+    },
+    {
+      "file": "/tmp/proj/x.py",
+      "severity": "warning",
+      "message": "Warn",
+      "range": { "start": { "line": 2 }, "end": { "line": 2 } }
+    },
+    {
+      "file": "/tmp/proj/x.py",
+      "severity": "information",
+      "message": "Info",
+      "range": { "start": { "line": 3 }, "end": { "line": 3 } }
+    },
+    {
+      "file": "/tmp/proj/x.py",
+      "severity": "hint",
+      "message": "Hint",
+      "range": { "start": { "line": 4 }, "end": { "line": 4 } }
+    }
+  ]
+}"#;
+    let diags = parse_pyright_output(stdout, std::path::Path::new("/tmp/proj"));
+    assert_eq!(diags.len(), 2, "only error and warning should be kept");
+    assert_eq!(diags[0].level, "error");
+    assert_eq!(diags[1].level, "warning");
+}
+
+#[test]
+fn pyright_driver_label_is_python() {
+    let stdout = r#"{
+  "generalDiagnostics": [
+    {
+      "file": "/tmp/proj/x.py",
+      "severity": "error",
+      "message": "Boom",
+      "range": { "start": { "line": 0 }, "end": { "line": 0 } }
+    }
+  ]
+}"#;
+    let diags = parse_pyright_output(stdout, std::path::Path::new("/tmp/proj"));
+    assert_eq!(diags[0].driver, "python");
+}
+
+// ---------------------------------------------------------------------------
+// TypeScript (tsc) diagnostics parser tests — line-level
+// ---------------------------------------------------------------------------
+
+#[test]
+fn tsc_line_error_with_code() {
+    let line = "src/lib.ts(4,15): error TS2322: Type 'string' is not assignable to type 'number'.";
+    let d = parse_tsc_line(line).expect("should parse error");
+    assert_eq!(d.file, "src/lib.ts");
+    assert_eq!(d.line_start, 4);
+    assert_eq!(d.level, "error");
+    assert_eq!(d.code, "TS2322");
+    assert!(d.message.contains("not assignable"));
+    assert_eq!(d.driver, "typescript");
+}
+
+#[test]
+fn tsc_line_warning_with_code() {
+    let line = "src/foo.ts(10,1): warning TS6133: 'x' is declared but its value is never read.";
+    let d = parse_tsc_line(line).expect("should parse warning");
+    assert_eq!(d.level, "warning");
+    assert_eq!(d.code, "TS6133");
+    assert_eq!(d.line_start, 10);
+}
+
+#[test]
+fn tsc_line_without_code_number() {
+    // Some tsc output lines may have different code formats
+    let line = "src/app.ts(1,8): error TS18003: No inputs were found in config file 'tsconfig.json'.";
+    let d = parse_tsc_line(line).expect("should parse TS code with 5 digits");
+    assert_eq!(d.code, "TS18003");
+    assert_eq!(d.line_start, 1);
+}
+
+#[test]
+fn tsc_line_message_with_colons() {
+    let line = "src/utils.ts(5,10): error TS2345: Argument of type 'string' is not assignable to parameter of type 'number'.";
+    let d = parse_tsc_line(line).expect("should parse message with colons");
+    assert_eq!(d.code, "TS2345");
+    assert!(d.message.contains("Argument of type"));
+    assert!(d.message.contains("parameter of type"));
+}
+
+#[test]
+fn tsc_line_path_with_parentheses() {
+    // Edge case: file path itself contains parentheses (unusual but possible)
+    // The parser uses the first '(' for the position, so this will misparse.
+    // Documenting the current behavior.
+    let line = "src/lib.ts(4,15): error TS2322: ok";
+    let d = parse_tsc_line(line).expect("normal case should work");
+    assert_eq!(d.file, "src/lib.ts");
+    assert_eq!(d.line_start, 4);
+}
+
+#[test]
+fn tsc_line_blank_returns_none() {
+    assert!(parse_tsc_line("").is_none());
+    assert!(parse_tsc_line("   ").is_none());
+    assert!(parse_tsc_line("\t").is_none());
+}
+
+#[test]
+fn tsc_line_non_diagnostic_returns_none() {
+    assert!(parse_tsc_line("Found 3 errors.").is_none());
+    assert!(parse_tsc_line("src/lib.ts:42:1 - error TS2322: Type 'string'").is_none());
+    assert!(parse_tsc_line("This is just some text").is_none());
+}
+
+#[test]
+fn tsc_line_unexpected_level_returns_none() {
+    // Levels other than "error" or "warning" should be rejected
+    assert!(parse_tsc_line("src/x.ts(1,1): info TS9999: Something happened").is_none());
+    assert!(parse_tsc_line("src/x.ts(1,1): note TS0000: Just a note").is_none());
+}
+
+// ---------------------------------------------------------------------------
+// TypeScript (tsc) diagnostics parser tests — full output
+// ---------------------------------------------------------------------------
+
+#[test]
+fn tsc_output_empty_string() {
+    assert!(parse_tsc_output("").is_empty());
+}
+
+#[test]
+fn tsc_output_single_error() {
+    let stdout = "src/a.ts(1,1): error TS2322: First.\n";
+    let diags = parse_tsc_output(stdout);
+    assert_eq!(diags.len(), 1);
+    assert_eq!(diags[0].file, "src/a.ts");
+    assert_eq!(diags[0].code, "TS2322");
+}
+
+#[test]
+fn tsc_output_multiple_errors_and_warnings() {
+    let stdout = "\
+src/a.ts(1,1): error TS2322: First error.
+src/b.ts(2,2): warning TS6133: First warning.
+src/c.ts(3,3): error TS2345: Second error.
+";
+    let diags = parse_tsc_output(stdout);
+    assert_eq!(diags.len(), 3);
+    assert_eq!(diags[0].file, "src/a.ts");
+    assert_eq!(diags[0].level, "error");
+    assert_eq!(diags[1].file, "src/b.ts");
+    assert_eq!(diags[1].level, "warning");
+    assert_eq!(diags[2].file, "src/c.ts");
+    assert_eq!(diags[2].level, "error");
+}
+
+#[test]
+fn tsc_output_continuation_lines() {
+    let stdout = "\
+src/a.ts(1,5): error TS2322: Type 'string' is not assignable.
+  'string' is the expected type here.
+  The type originates from this expression.
+src/b.ts(2,2): warning TS6133: 'x' is unused.
+";
+    let diags = parse_tsc_output(stdout);
+    assert_eq!(diags.len(), 2);
+    assert!(diags[0].message.contains("Type 'string' is not assignable"));
+    assert!(diags[0].message.contains("the expected type here"));
+    assert!(diags[0].message.contains("this expression"));
+    assert_eq!(diags[1].message, "'x' is unused.");
+}
+
+#[test]
+fn tsc_output_continuation_with_empty_lines() {
+    let stdout = "\
+src/a.ts(1,5): error TS2322: First message.
+
+  Continuation after blank line.
+";
+    let diags = parse_tsc_output(stdout);
+    assert_eq!(diags.len(), 1);
+    // The blank line is not appended (it's empty after trim)
+    assert!(diags[0].message.contains("Continuation after blank line"));
+}
+
+#[test]
+fn tsc_output_all_drivers_labeled_typescript() {
+    let stdout = "\
+src/a.ts(1,1): error TS2322: A.
+src/b.ts(2,2): warning TS6133: B.
+";
+    let diags = parse_tsc_output(stdout);
+    for d in &diags {
+        assert_eq!(d.driver, "typescript");
+    }
+}
+
+#[test]
+fn tsc_output_line_end_equals_line_start() {
+    let stdout = "src/a.ts(42,10): error TS2322: Single-line error.\n";
+    let diags = parse_tsc_output(stdout);
+    assert_eq!(diags[0].line_start, 42);
+    assert_eq!(diags[0].line_end, 42);
+}
+
+#[test]
+fn tsc_output_summary_and_banner_lines_ignored() {
+    let stdout = "\
+Version 5.4.0
+src/a.ts(1,1): error TS2322: The error.
+Found 1 error in src/a.ts:1
+";
+    let diags = parse_tsc_output(stdout);
+    assert_eq!(diags.len(), 1, "only the diagnostic line should be parsed");
+    assert_eq!(diags[0].file, "src/a.ts");
+}

--- a/tests/fixtures/sample.sql
+++ b/tests/fixtures/sample.sql
@@ -1,0 +1,25 @@
+-- Sample SQL file for extraction testing
+CREATE TABLE users (
+    id SERIAL PRIMARY KEY,
+    name TEXT NOT NULL,
+    email TEXT UNIQUE
+);
+
+CREATE TABLE orders (
+    id SERIAL PRIMARY KEY,
+    user_id INT REFERENCES users(id),
+    total DECIMAL(10, 2)
+);
+
+CREATE VIEW active_users AS
+SELECT id, name, email FROM users WHERE active = true;
+
+CREATE FUNCTION calculate_tax(amount DECIMAL) RETURNS DECIMAL
+BEGIN
+    RETURN amount * 0.08;
+END;
+
+CREATE PROCEDURE archive_old_orders()
+BEGIN
+    DELETE FROM orders WHERE created_at < NOW() - INTERVAL '1 year';
+END;

--- a/tests/sql_extraction_test.rs
+++ b/tests/sql_extraction_test.rs
@@ -1,0 +1,113 @@
+#![cfg(feature = "lang-sql")]
+
+use tokensave::extraction::LanguageExtractor;
+use tokensave::extraction::SqlExtractor;
+use tokensave::types::*;
+
+#[test]
+fn test_sql_file_node() {
+    let source = std::fs::read_to_string("tests/fixtures/sample.sql").unwrap();
+    let extractor = SqlExtractor;
+    let result = extractor.extract("sample.sql", &source);
+    assert!(result.errors.is_empty(), "errors: {:?}", result.errors);
+
+    let files: Vec<_> = result
+        .nodes
+        .iter()
+        .filter(|n| n.kind == NodeKind::File)
+        .collect();
+    assert_eq!(files.len(), 1);
+    assert_eq!(files[0].name, "sample.sql");
+}
+
+#[test]
+fn test_sql_extract_table_classes() {
+    let source = std::fs::read_to_string("tests/fixtures/sample.sql").unwrap();
+    let extractor = SqlExtractor;
+    let result = extractor.extract("sample.sql", &source);
+    assert!(result.errors.is_empty(), "errors: {:?}", result.errors);
+
+    let classes: Vec<_> = result
+        .nodes
+        .iter()
+        .filter(|n| n.kind == NodeKind::Class)
+        .collect();
+    assert_eq!(classes.len(), 3, "expected 3 class nodes (2 tables + 1 view), got {}", classes.len());
+    assert!(classes.iter().any(|n| n.name == "users"));
+    assert!(classes.iter().any(|n| n.name == "orders"));
+    assert!(classes.iter().any(|n| n.name == "active_users"), "VIEW should be extracted as Class");
+}
+
+#[test]
+fn test_sql_contains_edges() {
+    let source = std::fs::read_to_string("tests/fixtures/sample.sql").unwrap();
+    let extractor = SqlExtractor;
+    let result = extractor.extract("sample.sql", &source);
+    assert!(result.errors.is_empty(), "errors: {:?}", result.errors);
+
+    let contains: Vec<_> = result
+        .edges
+        .iter()
+        .filter(|e| e.kind == EdgeKind::Contains)
+        .collect();
+    assert_eq!(contains.len(), 3, "expected 3 Contains edges, got {}", contains.len());
+}
+
+#[test]
+fn test_sql_empty_source_produces_file_only() {
+    let extractor = SqlExtractor;
+    let result = extractor.extract("empty.sql", "    ");
+    // Should produce only the File node even for whitespace-only input
+    assert!(result.errors.is_empty(), "errors: {:?}", result.errors);
+    let nodes: Vec<_> = result
+        .nodes
+        .iter()
+        .filter(|n| n.kind == NodeKind::File)
+        .collect();
+    assert_eq!(nodes.len(), 1);
+}
+
+#[test]
+fn test_sql_empty_comment_source() {
+    let extractor = SqlExtractor;
+    let result = extractor.extract("comment.sql", "-- This is just a comment\n");
+    assert!(result.errors.is_empty(), "errors: {:?}", result.errors);
+    let files: Vec<_> = result
+        .nodes
+        .iter()
+        .filter(|n| n.kind == NodeKind::File)
+        .collect();
+    assert_eq!(files.len(), 1);
+}
+
+#[test]
+fn test_sql_extensions() {
+    let extractor = SqlExtractor;
+    assert!(extractor.extensions().contains(&"sql"));
+}
+
+#[test]
+fn test_sql_language_name() {
+    let extractor = SqlExtractor;
+    assert_eq!(extractor.language_name(), "SQL");
+}
+
+#[test]
+fn test_sql_all_edges_are_contains() {
+    let source = std::fs::read_to_string("tests/fixtures/sample.sql").unwrap();
+    let extractor = SqlExtractor;
+    let result = extractor.extract("sample.sql", &source);
+    assert!(result.errors.is_empty(), "errors: {:?}", result.errors);
+
+    for edge in &result.edges {
+        assert_eq!(edge.kind, EdgeKind::Contains, "all SQL edges should be Contains");
+    }
+}
+
+#[test]
+fn test_sql_no_unresolved_refs() {
+    let source = std::fs::read_to_string("tests/fixtures/sample.sql").unwrap();
+    let extractor = SqlExtractor;
+    let result = extractor.extract("sample.sql", &source);
+    assert!(result.unresolved_refs.is_empty());
+}


### PR DESCRIPTION
## Summary

Added 62 new tests to improve test coverage for previously untested or sparsely-tested modules:

### New test files

| File | Tests | Coverage |
|------|-------|----------|
| tests/diagnostics_test.rs | 23 | Pyright (Python) and tsc (TypeScript) diagnostic parsers |
| tests/diagnose_test.rs | 17 | Cargo/rustc output parser: Windows drive letters, ANSI escapes, clippy lints |
| tests/derive_table_test.rs | 13 | Derive macro lookup: case insensitivity, trait methods, marker traits |
| tests/sql_extraction_test.rs | 9 | SQL extractor: table/view class extraction, contains edges |
| tests/fixtures/sample.sql | — | SQL fixture with CREATE TABLE, CREATE VIEW |

### Verification
- All 62 new tests pass
- No clippy warnings from new test files
- No regressions in existing test suite