### PR TITLE
build: strip release binaries to fix Scoop shim failure (#156)

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -146,3 +146,11 @@ criterion = { version = "0.5", features = ["async_tokio", "html_reports"] }
 name = "large_repos"
 harness = false
 
+
+[profile.release]
+# Strip debug symbols from release binaries. The unstripped binary is ~159 MB,
+# large enough that Windows Defender's post-extract scan can still hold the file
+# when Scoop tries to create its shim, causing "Can't shim 'tokensave.exe':
+# File doesn't exist." even though the exe is present (#156). Stripping cuts the
+# binary to a fraction of that size and avoids the scan/shim race.
+strip = true


### PR DESCRIPTION
## Summary

Fixes #156. Scoop install fails with `Can't shim 'tokensave.exe': File doesn't exist.` even though the exe is present after extraction.

## Root cause

The manifest and release zip are both correct (exe at archive root, `bin: tokensave.exe`), so this is **not** a bucket bug. The Windows release binary ships **unstripped at ~159 MB** — there is no `[profile.release]` in `Cargo.toml` and the release workflow builds with plain `cargo build --release`.

On install, Scoop extracts the zip and then runs `Test-Path "$dir\tokensave.exe"` / `Get-Command` to create the shim (`create_shims` in Scoop's `install.ps1`). Windows Defender's post-extract scan of a binary that large can still hold the file at that moment, so the `Test-Path` checks fail and Scoop aborts the shim — while the file becomes accessible again seconds later.

## Fix

Add `[profile.release] strip = true`, cutting the binary to a fraction of its size and removing the scan/shim race. No behavioral change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)