### PR TITLE
fix(monitor): reconcile the two divergent "Saved" figures

### DIFF
--- a/src/monitor.rs
+++ b/src/monitor.rs
@@ -613,8 +613,14 @@ fn monitor_loop(
         }
 
         // ── Footer ──
+        // Show the same authoritative lifetime "saved" figure as the cost
+        // panel's `Saved:` (both sourced from `global_tokens_saved()` in the
+        // global DB). Previously the footer summed the in-memory ring deltas,
+        // which double-count per-call file-token estimates and only cover the
+        // last RING_CAPACITY events — so the prominent header "Saved" and the
+        // footer "saved tokens" disagreed and looked stale.
         let sep = "\u{2500}".repeat(w);
-        let total_saved: u64 = entries.iter().map(|e| e.delta).sum();
+        let total_saved: u64 = cost_cache.tokens_saved;
         let total_str = format_number(total_saved);
         let label = "TokenSave Monitor";
         let suffix = "saved tokens";


### PR DESCRIPTION
## Summary

The monitor showed two different "saved" numbers: the cost panel's `Saved:` (e.g. 32.8M) and the footer's `N saved tokens` (e.g. 35.3M). They disagreed because they came from different sources:

- **Header `Saved:`** → `global_tokens_saved()` from the global DB (authoritative lifetime total).
- **Footer** → sum of the in-memory ring-buffer deltas, which double-count per-call file-token estimates and only cover the last `RING_CAPACITY` events.

This divergence (the prominent header value lagging the live footer) is the main reason the monitor "looks like it doesn't update."

## Diagnosis note

The refresh loop itself is healthy — verified live: the per-tool breakdown and footer update at the 100 ms tick and the cost panel at its 30 s cadence. Only the *number source* was inconsistent.

## Fix

Source the footer's total from the same `cost_cache.tokens_saved` the header uses, so the two "Saved" figures always agree. The per-tool breakdown + `TOTAL` line remain the live ring view (a distinct, correctly-labeled metric).

🤖 Generated with [Claude Code](https://claude.com/claude-code)